### PR TITLE
Add integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   build_and_run_integration_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_image:
+          - ruby:3.0
+          - ruby:3.1
+          - ruby:3.2
     steps:
       - name: Checkout datadog-ci
         uses: actions/checkout@v3
@@ -16,4 +22,4 @@ jobs:
       - name: Run test
         working-directory: integration/app
         run: |
-          docker compose run --rm --no-deps app "bundle install && bundle exec rake test"
+          BASE_IMAGE=${{matrix.ruby_image}} docker compose run --rm --no-deps app "bundle install && bundle exec rake test"

--- a/integration/app/.envrc.sample
+++ b/integration/app/.envrc.sample
@@ -1,2 +1,3 @@
 export DD_API_KEY==<Your Datadog API key here>
 export DD_HOSTNAME=$(hostname)
+export BASE_IMAGE=ruby:3.1

--- a/integration/app/Dockerfile
+++ b/integration/app/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:3.1.2-bullseye
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/integration/app/docker-compose.yml
+++ b/integration/app/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   app:
     build:
       context: .
+      args:
+        BASE_IMAGE: ${BASE_IMAGE}
     depends_on:
       - ddagent
     environment:


### PR DESCRIPTION
Currently, run integration test for ruby 3.0, 3.1, 3.2 with Github actions.
