### PR TITLE
enable ruby-2.1 mode for linting until we separate from dd-trace-rb

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,5 +1,7 @@
-ruby_version: 2.7
+ruby_version: 2.1
 format: progress
 
 ignore:
   - 'gemfiles/**/*'
+  - 'tasks/**/*'
+  - 'yard/**/*'

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -557,7 +557,7 @@ module Datadog
 
         def branch_or_tag(branch_or_tag)
           branch = tag = nil
-          if branch_or_tag&.include?("tags/")
+          if branch_or_tag && branch_or_tag.include?("tags/")
             tag = branch_or_tag
           else
             branch = branch_or_tag


### PR DESCRIPTION
**What does this PR do?**
Enable Ruby 2.1 mode for standardrb for now until we separate it from dd-trace-rb

**Motivation**
Ensure that dd-trace-rb will not break when including this gem as a dependency

**How to test the change?**
Tested in CI pipeline