### PR TITLE
issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: File a bug report
+title: ''
+labels: community, bug
+assignees: ''
+
+---
+
+**Current behaviour**
+<!-- What is be happening. -->
+
+**Expected behaviour**
+<!-- What should be happening. -->
+
+**Steps to reproduce**
+<!--
+  How can we reproduce this issue in order to diagnose it?
+  Code snippets, log messages, screenshots and sample apps are encouraged!
+-->
+
+**How does `datadog-ci` help you?**
+<!-- Optionally, tell us why and how you're using datadog-ci, and what your overall experience with it is! -->
+
+**Environment**
+
+* **datadog-ci-rb version:**
+* **Configuration block (`Datadog.configure ...`):**
+* **Test framework version:**
+* **CI Provider:**
+* **Ruby version:**
+* **Operating system:**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: community, feature-request
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the goal of the feature**
+<!-- A clear and concise description of what you want to happen, and how it may used or behave. -->
+
+**Describe alternatives you've considered**
+<!-- Optionally, provide description of any alternative solutions or features you've considered. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->
+
+**How does `datadog-ci` help you?**
+<!-- Optionally, tell us why and how you're using datadog-ci, and what your overall experience with it is! -->


### PR DESCRIPTION
**What does this PR do?**
Creates issues templates (adapted from dd-trace-rb gem)

**Motivation**
Following checklist to opensource this repository

**How to test the change?**
read it