### PR TITLE
add note to readme.md that right now this gem is part of ddtrace and not to be used on its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Datadog CI Visibility for Ruby
 
 Datadog's Ruby Library for instrumenting your test and continuous integration pipeline.
-Learn more on our [official website](https://docs.datadoghq.com/continuous_integration/tests/ruby/?tab=azurepipelines).
+Learn more on our [official website](https://docs.datadoghq.com/continuous_integration/tests/ruby/).
 
 > [!IMPORTANT]
 > The `datadog-ci` gem is currently a component of [`ddtrace`](https://github.com/datadog/dd-trace-rb) and should not be used without it.


### PR DESCRIPTION
**What does this PR do?**
Add a note to readme.md that right now this gem is part of ddtrace and not to be used on its own.

**Motivation**
When this gem becomes open-source it may cause confusion about which gem to use for Test Visibility in Ruby. I want to make it clear that right now `ddtrace` gem is to be used (but this will change in the next major release).

**How to test the change?**
Read the copy and tell me if it is clear.