### PR TITLE
Fix circular dependencies warnings

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "ddtrace"
 require_relative "ci/version"
 
 require "datadog/core"

--- a/lib/datadog/ci/contrib/cucumber/integration.rb
+++ b/lib/datadog/ci/contrib/cucumber/integration.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "datadog/tracing/contrib"
+require "datadog/tracing/contrib/integration"
+
 require_relative "configuration/settings"
 require_relative "patcher"
 

--- a/lib/datadog/ci/contrib/minitest/integration.rb
+++ b/lib/datadog/ci/contrib/minitest/integration.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "datadog/tracing/contrib"
+require "datadog/tracing/contrib/integration"
+
 require_relative "configuration/settings"
 require_relative "patcher"
 

--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "datadog/tracing/contrib"
 require "datadog/tracing/contrib/integration"
 
 require_relative "configuration/settings"

--- a/lib/datadog/ci/ext/environment/extractor.rb
+++ b/lib/datadog/ci/ext/environment/extractor.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../environment"
 require_relative "../git"
 require_relative "../../utils/git"
 require_relative "providers"


### PR DESCRIPTION
**What does this PR do?**
Solving circular references warnings discovered during integration testing

**Motivation**
To be able to run ddtrace in CI with datadog-ci dependency without warnings

**Additional Notes**
I will publish 0.1.1 release after merging this PR to continue with phase 1 of the CI migration

**How to test the change?**
Unit tests