### PR TITLE
edge builds for integrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,12 +103,12 @@ step_appraisal_install: &step_appraisal_install
         bundle exec appraisal generate # Generate the appraisal files to match the lockfiles in the tree
         echo "All required gems were found in cache."
       fi
-# TODO: this is something to use for edge tests (against newest versions of rspec, minitest, etc.)
-# step_appraisal_update: &step_appraisal_update
-#   run:
-#     name: Update Appraisal gems
-#     command: | # Remove all generated gemfiles and lockfiles, resolve, and install dependencies again
-#       bundle exec appraisal update
+step_appraisal_update: &step_appraisal_update
+  run:
+    name: Update Appraisal gems
+    command:
+      | # Remove all generated gemfiles and lockfiles, resolve, and install dependencies again
+      bundle exec appraisal update
 step_compute_bundle_checksum: &step_compute_bundle_checksum
   run:
     name: Compute bundle checksum
@@ -165,7 +165,17 @@ orbs:
                 - bundle-{{ .Environment.CIRCLE_CACHE_VERSION }}-{{ checksum ".circleci/images/primary/binary_version" }}-<<parameters.ruby_version>>-{{ checksum "lib/datadog/ci/version.rb" }}
           - *check_exact_bundle_cache_hit
           - *step_bundle_install
-          - *step_appraisal_install
+          - when:
+              condition:
+                equal: [<< parameters.edge >>, true]
+              steps:
+                - *step_appraisal_update # Run on latest version of all gems we integrate with
+          - when:
+              condition:
+                not:
+                  equal: [<< parameters.edge >>, true]
+              steps:
+                - *step_appraisal_install # Run on a stable set of gems we integrate with
           - *save_bundle_checksum
           - save_cache:
               key: '{{ .Environment.CIRCLE_CACHE_VERSION }}-bundled-repo-<<parameters.ruby_version>>-{{ .Environment.CIRCLE_SHA1 }}'
@@ -384,6 +394,71 @@ workflows:
       - orb/build:
           <<: *config-jruby-9_4
           name: build-jruby-9.4
+      - orb/test:
+          <<: *config-jruby-9_4
+          name: test-jruby-9.4
+          requires:
+            - build-jruby-9.4
+  # This workflow runs the same `build` and `test` jobs as above on a schedule.
+  edge:
+    triggers:
+      - schedule:
+          cron: '0 0 * * 1-5' # Every weekday
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - orb/build:
+          <<: *config-2_7
+          name: build-2.7
+          edge: true
+      - orb/test:
+          <<: *config-2_7
+          name: test-2.7
+          requires:
+            - build-2.7
+      - orb/build:
+          <<: *config-3_0
+          name: build-3.0
+          edge: true
+      - orb/test:
+          <<: *config-3_0
+          name: test-3.0
+          requires:
+            - build-3.0
+      - orb/build:
+          <<: *config-3_1
+          name: build-3.1
+          edge: true
+      - orb/test:
+          <<: *config-3_1
+          name: test-3.1
+          requires:
+            - build-3.1
+      - orb/build:
+          <<: *config-3_2
+          name: build-3.2
+          edge: true
+      - orb/test:
+          <<: *config-3_2
+          name: test-3.2
+          requires:
+            - build-3.2
+      - orb/build:
+          <<: *config-3_3
+          name: build-3.3
+          edge: true
+      - orb/test:
+          <<: *config-3_3
+          name: test-3.3
+          requires:
+            - build-3.3
+      # ADD NEW RUBIES HERE
+      - orb/build:
+          <<: *config-jruby-9_4
+          name: build-jruby-9.4
+          edge: true
       - orb/test:
           <<: *config-jruby-9_4
           name: test-jruby-9.4


### PR DESCRIPTION
**What does this PR do?**
Closes #34

This PR adds "edge builds" that run `bundle update` for all appraisal gemfiles in order to test against latest versions of integrations. These builds are executed every weekday, they'll be used to find out any issues with dependencies updates.

**Motivation**
Bringing build infrastructure on par with main ddtrace library.

**How to test the change?**
Tested by running the workflow on circle ci.