### PR TITLE
refactor env providers to support custom logic to determine which env they handle

### DIFF
--- a/lib/datadog/ci/ext/environment/providers.rb
+++ b/lib/datadog/ci/ext/environment/providers.rb
@@ -24,23 +24,23 @@ module Datadog
       module Environment
         module Providers
           PROVIDERS = [
-            ["APPVEYOR", Providers::Appveyor],
-            ["TF_BUILD", Providers::Azure],
-            ["BITBUCKET_COMMIT", Providers::Bitbucket],
-            ["BITRISE_BUILD_SLUG", Providers::Bitrise],
-            ["BUDDY", Providers::Buddy],
-            ["BUILDKITE", Providers::Buildkite],
-            ["CIRCLECI", Providers::Circleci],
-            ["CF_BUILD_ID", Providers::Codefresh],
-            ["GITHUB_SHA", Providers::GithubActions],
-            ["GITLAB_CI", Providers::Gitlab],
-            ["JENKINS_URL", Providers::Jenkins],
-            ["TEAMCITY_VERSION", Providers::Teamcity],
-            ["TRAVIS", Providers::Travis]
+            Providers::Appveyor,
+            Providers::Azure,
+            Providers::Bitbucket,
+            Providers::Bitrise,
+            Providers::Buddy,
+            Providers::Buildkite,
+            Providers::Circleci,
+            Providers::Codefresh,
+            Providers::GithubActions,
+            Providers::Gitlab,
+            Providers::Jenkins,
+            Providers::Teamcity,
+            Providers::Travis
           ]
 
           def self.for_environment(env)
-            _, provider_klass = PROVIDERS.find { |provider_env_var, _| env.key?(provider_env_var) }
+            provider_klass = PROVIDERS.find { |klass| klass.handles?(env) }
             provider_klass = Providers::Base if provider_klass.nil?
 
             provider_klass.new(env)

--- a/lib/datadog/ci/ext/environment/providers/appveyor.rb
+++ b/lib/datadog/ci/ext/environment/providers/appveyor.rb
@@ -10,6 +10,10 @@ module Datadog
           # Appveyor: https://www.appveyor.com/
           # Environment variables docs: https://www.appveyor.com/docs/environment-variables/
           class Appveyor < Base
+            def self.handles?(env)
+              env.key?("APPVEYOR")
+            end
+
             def provider_name
               "appveyor"
             end

--- a/lib/datadog/ci/ext/environment/providers/azure.rb
+++ b/lib/datadog/ci/ext/environment/providers/azure.rb
@@ -12,6 +12,10 @@ module Datadog
           # Azure Pipelines: https://azure.microsoft.com/en-us/products/devops/pipelines
           # Environment variables docs: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
           class Azure < Base
+            def self.handles?(env)
+              env.key?("TF_BUILD")
+            end
+
             def provider_name
               "azurepipelines"
             end

--- a/lib/datadog/ci/ext/environment/providers/base.rb
+++ b/lib/datadog/ci/ext/environment/providers/base.rb
@@ -8,6 +8,10 @@ module Datadog
           class Base
             attr_reader :env
 
+            def self.handles?(_env)
+              false
+            end
+
             def initialize(env)
               @env = env
             end

--- a/lib/datadog/ci/ext/environment/providers/bitbucket.rb
+++ b/lib/datadog/ci/ext/environment/providers/bitbucket.rb
@@ -10,6 +10,10 @@ module Datadog
           # Bitbucket Pipelines: https://bitbucket.org/product/features/pipelines
           # Environment variables docs: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
           class Bitbucket < Base
+            def self.handles?(env)
+              env.key?("BITBUCKET_COMMIT")
+            end
+
             # overridden methods
             def provider_name
               "bitbucket"

--- a/lib/datadog/ci/ext/environment/providers/bitrise.rb
+++ b/lib/datadog/ci/ext/environment/providers/bitrise.rb
@@ -10,6 +10,10 @@ module Datadog
           # Bitrise: https://bitrise.io/
           # Environment variables docs: https://devcenter.bitrise.io/en/references/available-environment-variables.html
           class Bitrise < Base
+            def self.handles?(env)
+              env.key?("BITRISE_BUILD_SLUG")
+            end
+
             def provider_name
               "bitrise"
             end

--- a/lib/datadog/ci/ext/environment/providers/buddy.rb
+++ b/lib/datadog/ci/ext/environment/providers/buddy.rb
@@ -10,6 +10,10 @@ module Datadog
           # Buddy: https://buddy.works/
           # Environment variables docs: https://buddy.works/docs/pipelines/environment-variables
           class Buddy < Base
+            def self.handles?(env)
+              env.key?("BUDDY")
+            end
+
             def provider_name
               "buddy"
             end

--- a/lib/datadog/ci/ext/environment/providers/buildkite.rb
+++ b/lib/datadog/ci/ext/environment/providers/buildkite.rb
@@ -12,6 +12,10 @@ module Datadog
           # Buildkite: https://buildkite.com/
           # Environment variables docs: https://buildkite.com/docs/pipelines/environment-variables
           class Buildkite < Base
+            def self.handles?(env)
+              env.key?("BUILDKITE")
+            end
+
             def provider_name
               "buildkite"
             end

--- a/lib/datadog/ci/ext/environment/providers/circleci.rb
+++ b/lib/datadog/ci/ext/environment/providers/circleci.rb
@@ -12,6 +12,10 @@ module Datadog
           # Circle CI: https://circleci.com/
           # Environment variables docs: https://circleci.com/docs/variables/#built-in-environment-variables
           class Circleci < Base
+            def self.handles?(env)
+              env.key?("CIRCLECI")
+            end
+
             def provider_name
               "circleci"
             end

--- a/lib/datadog/ci/ext/environment/providers/codefresh.rb
+++ b/lib/datadog/ci/ext/environment/providers/codefresh.rb
@@ -12,6 +12,10 @@ module Datadog
           # Codefresh: https://codefresh.io/
           # Environment variables docs: https://codefresh.io/docs/docs/pipelines/variables/#export-variables-to-all-steps-with-cf_export
           class Codefresh < Base
+            def self.handles?(env)
+              env.key?("CF_BUILD_ID")
+            end
+
             def provider_name
               "codefresh"
             end

--- a/lib/datadog/ci/ext/environment/providers/github_actions.rb
+++ b/lib/datadog/ci/ext/environment/providers/github_actions.rb
@@ -12,6 +12,10 @@ module Datadog
           # Github Actions: https://github.com/features/actions
           # Environment variables docs: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
           class GithubActions < Base
+            def self.handles?(env)
+              env.key?("GITHUB_SHA")
+            end
+
             def provider_name
               "github"
             end

--- a/lib/datadog/ci/ext/environment/providers/gitlab.rb
+++ b/lib/datadog/ci/ext/environment/providers/gitlab.rb
@@ -10,6 +10,10 @@ module Datadog
           # Gitlab CI: https://docs.gitlab.com/ee/ci/
           # Environment variables docs: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html
           class Gitlab < Base
+            def self.handles?(env)
+              env.key?("GITLAB_CI")
+            end
+
             def provider_name
               "gitlab"
             end

--- a/lib/datadog/ci/ext/environment/providers/jenkins.rb
+++ b/lib/datadog/ci/ext/environment/providers/jenkins.rb
@@ -13,6 +13,10 @@ module Datadog
           # Jenkins: https://www.jenkins.io/
           # Environment variables docs: https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables
           class Jenkins < Base
+            def self.handles?(env)
+              env.key?("JENKINS_URL")
+            end
+
             def provider_name
               "jenkins"
             end

--- a/lib/datadog/ci/ext/environment/providers/teamcity.rb
+++ b/lib/datadog/ci/ext/environment/providers/teamcity.rb
@@ -10,6 +10,10 @@ module Datadog
           # Teamcity: https://www.jetbrains.com/teamcity/
           # Environment variables docs: https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html
           class Teamcity < Base
+            def self.handles?(env)
+              env.key?("TEAMCITY_VERSION")
+            end
+
             def provider_name
               "teamcity"
             end

--- a/lib/datadog/ci/ext/environment/providers/travis.rb
+++ b/lib/datadog/ci/ext/environment/providers/travis.rb
@@ -10,6 +10,10 @@ module Datadog
           # Travis CI: https://www.travis-ci.com/
           # Environment variables docs: https://docs.travis-ci.com/user/environment-variables#default-environment-variables
           class Travis < Base
+            def self.handles?(env)
+              env.key?("TRAVIS")
+            end
+
             def provider_name
               "travisci"
             end

--- a/sig/datadog/ci/ext/environment/providers.rbs
+++ b/sig/datadog/ci/ext/environment/providers.rbs
@@ -3,7 +3,7 @@ module Datadog
     module Ext
       module Environment
         module Providers
-          PROVIDERS: ::Array[[String, untyped]]
+          PROVIDERS: ::Array[untyped]
 
           def self.for_environment: (Hash[String, String?] env) -> Providers::Base
         end

--- a/sig/datadog/ci/ext/environment/providers/base.rbs
+++ b/sig/datadog/ci/ext/environment/providers/base.rbs
@@ -8,6 +8,8 @@ module Datadog
             @branch: String?
             @tag: String?
 
+            def self.handles?: (Hash[String, String?] env) -> bool
+
             def initialize: (Hash[String, String?] env) -> void
 
             def job_name: () -> nil


### PR DESCRIPTION
**What does this PR do?**
Changes the env provider selection logic and pushes it down to specific provider classes in order to support custom logic for selection (like when the ENV value must start with specific prefix).

**Motivation**
Preparation for AWS CodePipeline support

**How to test the change?**
Unit tests