### PR TITLE
[CIVIS-175] Add AWS CodePipeline support

### DIFF
--- a/lib/datadog/ci/ext/environment/providers.rb
+++ b/lib/datadog/ci/ext/environment/providers.rb
@@ -2,6 +2,7 @@
 
 require_relative "providers/base"
 require_relative "providers/appveyor"
+require_relative "providers/aws_code_pipeline"
 require_relative "providers/azure"
 require_relative "providers/bitbucket"
 require_relative "providers/bitrise"
@@ -25,6 +26,7 @@ module Datadog
         module Providers
           PROVIDERS = [
             Providers::Appveyor,
+            Providers::AwsCodePipeline,
             Providers::Azure,
             Providers::Bitbucket,
             Providers::Bitrise,

--- a/lib/datadog/ci/ext/environment/providers/aws_code_pipeline.rb
+++ b/lib/datadog/ci/ext/environment/providers/aws_code_pipeline.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module Datadog
+  module CI
+    module Ext
+      module Environment
+        module Providers
+          # AWS CodePipeline: https://aws.amazon.com/codepipeline/
+          # Environment variables docs: https://docs.aws.amazon.com/codepipeline/latest/userguide/actions-variables.html
+          # AWS CodeBuild: https://aws.amazon.com/codebuild/
+          # Environment variable docs: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+          class AwsCodePipeline < Base
+            def self.handles?(env)
+              !env["CODEBUILD_INITIATOR"].nil? && env["CODEBUILD_INITIATOR"].start_with?("codepipeline")
+            end
+
+            def provider_name
+              "awscodepipeline"
+            end
+
+            def pipeline_id
+              env["DD_PIPELINE_EXECUTION_ID"]
+            end
+
+            def ci_env_vars
+              {
+                "CODEBUILD_BUILD_ARN" => env["CODEBUILD_BUILD_ARN"],
+                "DD_PIPELINE_EXECUTION_ID" => env["DD_PIPELINE_EXECUTION_ID"],
+                "DD_ACTION_EXECUTION_ID" => env["DD_ACTION_EXECUTION_ID"]
+              }.to_json
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "delegate"
-require "net/http"
 require "datadog/core/transport/http/adapters/net"
 require "datadog/core/transport/http/env"
 require "datadog/core/transport/request"

--- a/sig/datadog/ci/ext/environment/providers/aws_code_pipeline.rbs
+++ b/sig/datadog/ci/ext/environment/providers/aws_code_pipeline.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module CI
+    module Ext
+      module Environment
+        module Providers
+          class AwsCodePipeline < Base
+            def self.handles?: (Hash[String, String?] env) -> bool
+
+            def provider_name: () -> "awscodepipeline"
+
+            def pipeline_id: () -> String?
+
+            def ci_env_vars: () -> String?
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/ci/awscodepipeline.json
+++ b/spec/support/fixtures/ci/awscodepipeline.json
@@ -1,0 +1,62 @@
+[
+  [
+    {
+      "CODEBUILD_BUILD_ARN": "arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19",
+      "CODEBUILD_INITIATOR": "codepipeline/test-pipeline",
+      "DD_ACTION_EXECUTION_ID": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git",
+      "DD_PIPELINE_EXECUTION_ID": "bb1f15ed-fde2-494d-8e13-88785bca9cc0"
+    },
+    {
+      "_dd.ci.env_vars": "{\"CODEBUILD_BUILD_ARN\":\"arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19\",\"DD_PIPELINE_EXECUTION_ID\":\"bb1f15ed-fde2-494d-8e13-88785bca9cc0\",\"DD_ACTION_EXECUTION_ID\":\"35519dc3-7c45-493c-9ba6-cd78ea11f69d\"}",
+      "ci.pipeline.id": "bb1f15ed-fde2-494d-8e13-88785bca9cc0",
+      "ci.provider.name": "awscodepipeline",
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ],
+  [
+    {
+      "CODEBUILD_INITIATOR": "lambdafunction/test-lambda",
+      "DD_GIT_BRANCH": "user-supplied-branch",
+      "DD_GIT_COMMIT_AUTHOR_DATE": "usersupplied-authordate",
+      "DD_GIT_COMMIT_AUTHOR_EMAIL": "usersupplied-authoremail",
+      "DD_GIT_COMMIT_AUTHOR_NAME": "usersupplied-authorname",
+      "DD_GIT_COMMIT_COMMITTER_DATE": "usersupplied-comitterdate",
+      "DD_GIT_COMMIT_COMMITTER_EMAIL": "usersupplied-comitteremail",
+      "DD_GIT_COMMIT_COMMITTER_NAME": "usersupplied-comittername",
+      "DD_GIT_COMMIT_MESSAGE": "usersupplied-message",
+      "DD_GIT_COMMIT_SHA": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "DD_GIT_REPOSITORY_URL": "git@github.com:DataDog/userrepo.git"
+    },
+    {
+      "git.branch": "user-supplied-branch",
+      "git.commit.author.date": "usersupplied-authordate",
+      "git.commit.author.email": "usersupplied-authoremail",
+      "git.commit.author.name": "usersupplied-authorname",
+      "git.commit.committer.date": "usersupplied-comitterdate",
+      "git.commit.committer.email": "usersupplied-comitteremail",
+      "git.commit.committer.name": "usersupplied-comittername",
+      "git.commit.message": "usersupplied-message",
+      "git.commit.sha": "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
+      "git.repository_url": "git@github.com:DataDog/userrepo.git"
+    }
+  ]
+]


### PR DESCRIPTION
**What does this PR do?**
Adds AWS CodePipeline support for automatic environment tags extraction

**Motivation**
Datadog CI visibility backend supports AWS CodePipeline integration now, so we add it to the library

**How to test the change?**
Tested by updating fixtures from Datadog CI specs