### PR TITLE
reduce permissions for milestone github actions

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   add_milestone_to_merged:
+    permissions:
+      pull-requests: write
     if: github.event.pull_request.merged && github.event.pull_request.milestone == null
     name: Add milestone to merged pull requests
     runs-on: ubuntu-latest

--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   add_milestone_to_merged:
     permissions:
+      issues: write
       pull-requests: write
     if: github.event.pull_request.merged && github.event.pull_request.milestone == null
     name: Add milestone to merged pull requests
@@ -15,11 +16,11 @@ jobs:
     steps:
       - name: Get project milestones
         id: milestones
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const list = await github.issues.listMilestonesForRepo({
+            const list = await github.rest.issues.listMilestones({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'
@@ -31,12 +32,12 @@ jobs:
             return milestones.length == 0 ? null : milestones[0].number
       - name: Update Pull Request
         if: steps.milestones.outputs.result != null
-        uses: actions/github-script@0.9.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Confusingly, the issues api is used because pull requests are issues
-            await github.issues.update({
+            await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ github.event.pull_request.number }},

--- a/.github/workflows/create-next-milestone.yml
+++ b/.github/workflows/create-next-milestone.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   create_next_milestone:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - name: Get next minor version


### PR DESCRIPTION
Closes #50

**What does this PR do?**
This PR reduces the permission of the add-milestone-to-pull-requests and create-next-milestone GitHub Actions to the minimum possible.

**Motivation**
See pull requests for dd-trace-rb repository explaining the motivation:

https://github.com/DataDog/dd-trace-rb/pull/3193
https://github.com/DataDog/dd-trace-rb/pull/3194

