### PR TITLE
Remove _dd.measured tag from spans

### DIFF
--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "datadog/tracing"
-require "datadog/tracing/contrib/analytics"
 
 require "rbconfig"
 
@@ -48,13 +47,13 @@ module Datadog
 
       def create_datadog_span(span_name, span_options: {}, tags: {}, &block)
         if block
-          ::Datadog::Tracing.trace(span_name, **span_options) do |tracer_span, trace|
+          Datadog::Tracing.trace(span_name, **span_options) do |tracer_span, trace|
             set_internal_tracing_context!(trace, tracer_span)
             block.call(Span.new(tracer_span, tags))
           end
         else
           tracer_span = Datadog::Tracing.trace(span_name, **span_options)
-          trace = ::Datadog::Tracing.active_trace
+          trace = Datadog::Tracing.active_trace
 
           set_internal_tracing_context!(trace, tracer_span)
           Span.new(tracer_span, tags)
@@ -62,9 +61,8 @@ module Datadog
       end
 
       def set_internal_tracing_context!(trace, span)
-        # Set default tags
+        # Sets trace's origin to ciapp-test
         trace.origin = Ext::Test::CONTEXT_ORIGIN if trace
-        ::Datadog::Tracing::Contrib::Analytics.set_measured(span)
       end
     end
   end

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -12,12 +12,6 @@ RSpec.describe Datadog::CI::Recorder do
 
   shared_examples_for "internal tracing context" do
     it do
-      expect(Datadog::Tracing::Contrib::Analytics)
-        .to have_received(:set_measured)
-        .with(span_op)
-    end
-
-    it do
       expect(trace_op)
         .to have_received(:origin=)
         .with(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
@@ -67,7 +61,6 @@ RSpec.describe Datadog::CI::Recorder do
             trace_block.call(span_op, trace_op)
           end
 
-        allow(Datadog::Tracing::Contrib::Analytics).to receive(:set_measured)
         allow(Datadog::CI::Span).to receive(:new).with(span_op, expected_tags).and_return(ci_test)
 
         trace
@@ -103,7 +96,6 @@ RSpec.describe Datadog::CI::Recorder do
           )
           .and_return(span_op)
 
-        allow(Datadog::Tracing::Contrib::Analytics).to receive(:set_measured)
         allow(Datadog::CI::Span).to receive(:new).with(span_op, expected_tags).and_return(ci_test)
 
         trace
@@ -152,7 +144,6 @@ RSpec.describe Datadog::CI::Recorder do
             trace_block.call(span_op, trace_op)
           end
 
-        allow(Datadog::Tracing::Contrib::Analytics).to receive(:set_measured)
         allow(Datadog::CI::Span).to receive(:new).with(span_op, expected_tags).and_return(ci_span)
 
         trace
@@ -187,7 +178,6 @@ RSpec.describe Datadog::CI::Recorder do
           )
           .and_return(span_op)
 
-        allow(Datadog::Tracing::Contrib::Analytics).to receive(:set_measured)
         allow(Datadog::CI::Span).to receive(:new).with(span_op, expected_tags).and_return(ci_span)
 
         trace

--- a/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
           }
         )
         expect(metrics).to eq(
-          {"_dd.measured" => 1.0, "_dd.top_level" => 1.0, "memory_allocations" => 16}
+          {"_dd.top_level" => 1.0, "memory_allocations" => 16}
         )
       end
     end

--- a/spec/support/span_helpers.rb
+++ b/spec/support/span_helpers.rb
@@ -65,18 +65,6 @@ module SpanHelpers
     end
   end
 
-  # Span with the metric '_dd.measured' set to 1.0.
-  RSpec::Matchers.define :be_measured do
-    match do |span|
-      value = span.get_metric("_dd.measured")
-      values_match? 1.0, value
-    end
-
-    def description_of(actual)
-      "#{actual} with metrics #{actual.instance_variable_get(:@metrics)}"
-    end
-  end
-
   # Does this span have no parent span?
   RSpec::Matchers.define :be_root_span do
     match do |span|


### PR DESCRIPTION
**What does this PR do?**
Removes "_dd.measured" tags from spans in CI visibility tracer.

**Motivation**
_dd.measured tag is used for automatically generating metrics out of non-root traces. This feature is not used for CI visbility, other test tracers do not send this tag so it can be removed

**How to test the change?**
No visible change in behaviour