### PR TITLE
disable 128-bit trace id generation in CI mode

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -40,6 +40,10 @@ module Datadog
           # Deactivate remote configuration
           settings.remote.enabled = false
 
+          # do not use 128-bit trace ids for CI visibility
+          # they are used for OTEL compatibility in Datadog tracer
+          settings.tracing.trace_id_128_bit_generation_enabled = false
+
           # Activate underlying tracing test mode
           settings.tracing.test_mode.enabled = true
 


### PR DESCRIPTION
**What does this PR do?**
Disables 128-bit trace_id generation for CI mode. Tracing enabled it by default in https://github.com/DataDog/dd-trace-rb/pull/3266

**Motivation**
128-bit trace ids cause message pack to fail with "Cause: bignum too big to convert into `unsigned long long'" causing agentless mode to fail completely

**How to test the change?**
```bash
git clone https://github.com/DataDog/test-environment

cd test-environment

yarn

cd dd-trace-rb/jekyll
bundle add ddtrace --git "https://github.com/DataDog/dd-trace-rb.git" --branch "master" --skip-install
bundle install --path .bundle
cd ../..

yarn test dd-trace-rb/jekyll.test.js

cd dd-trace-rb/devdocs
bundle add ddtrace --git "https://github.com/DataDog/dd-trace-rb.git" --branch "master" --skip-install
bundle install --path .bundle
cd ../..

yarn test dd-trace-rb/devdocs.test.js
```