### PR TITLE
Skip tracing when CI mode disabled and manual API is used

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -29,7 +29,8 @@ module Datadog
       # @param [String] service_name the service name for this session
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Datadog::CI::TestSession] returns the active, running {Datadog::CI::TestSession}.
-      # @return [nil] if test suite level visibility is disabled (old Datadog agent detected)
+      # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled or if old Datadog agent is
+      #         detected and test suite level visibility cannot be supported.
       #
       # @public_api
       def start_test_session(service_name: nil, tags: {})
@@ -104,8 +105,10 @@ module Datadog
       # @return [Object] If a block is provided, returns the result of the block execution.
       # @return [Datadog::CI::Test] If no block is provided, returns the active,
       #         unfinished {Datadog::CI::Test}.
+      # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       # @yield Optional block where new newly created {Datadog::CI::Test} captures the execution.
       # @yieldparam [Datadog::CI::Test] ci_test the newly created and active [Datadog::CI::Test]
+      # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
       def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
@@ -133,6 +136,7 @@ module Datadog
       # @param [String] service_name the service name for this span.
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Datadog::CI::Test] Returns the active, unfinished {Datadog::CI::Test}.
+      # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
       def start_test(test_name, service_name: nil, operation_name: "test", tags: {})
@@ -174,8 +178,10 @@ module Datadog
       # @return [Object] If a block is provided, returns the result of the block execution.
       # @return [Datadog::CI::Span] If no block is provided, returns the active,
       #         unfinished {Datadog::CI::Span}.
+      # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       # @yield Optional block where new newly created {Datadog::CI::Span} captures the execution.
       # @yieldparam [Datadog::CI::Span] ci_span the newly created and active [Datadog::CI::Span]
+      # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
       def trace(span_type, span_name, tags: {}, &block)

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -148,7 +148,7 @@ module Datadog
       # - database query
       # - any custom operation you want to see in your trace view
       #
-      # You can use thi method with a <tt>do-block</tt> like:
+      # You can use this method with a <tt>do-block</tt> like:
       #
       # ```
       # Datadog::CI.trace(

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -22,6 +22,11 @@ module Datadog
           # Activate CI mode if enabled
           activate_ci!(settings) if settings.ci.enabled
 
+          @ci_recorder = Recorder.new(
+            enabled: settings.ci.enabled,
+            test_suite_level_visibility_enabled: settings.ci.experimental_test_suite_level_visibility_enabled
+          )
+
           # Initialize normally
           super
         end
@@ -61,10 +66,6 @@ module Datadog
           end
 
           settings.tracing.test_mode.writer_options = writer_options
-
-          @ci_recorder = Recorder.new(
-            test_suite_level_visibility_enabled: settings.ci.experimental_test_suite_level_visibility_enabled
-          )
         end
 
         def can_use_evp_proxy?(settings, agent_settings)

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -39,6 +39,8 @@ module Datadog
             test_visibility_transport = build_agentless_transport(settings)
           elsif can_use_evp_proxy?(settings, agent_settings)
             test_visibility_transport = build_evp_proxy_transport(settings, agent_settings)
+          else
+            settings.ci.experimental_test_suite_level_visibility_enabled = false
           end
 
           # Deactivate telemetry

--- a/lib/datadog/ci/null_span.rb
+++ b/lib/datadog/ci/null_span.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "datadog/tracing/span_operation"
+
+module Datadog
+  module CI
+    # Represents an ignored span when CI visibility is disabled.
+    # Replaces all methods with no-op.
+    #
+    # @public_api
+    class NullSpan < Span
+      def initialize
+        super(Datadog::Tracing::SpanOperation.new("null.span"))
+      end
+
+      def id
+      end
+
+      def name
+      end
+
+      def service
+      end
+
+      def span_type
+      end
+
+      def passed!
+      end
+
+      def failed!(exception: nil)
+      end
+
+      def skipped!(exception: nil, reason: nil)
+      end
+
+      def get_tag(key)
+      end
+
+      def set_tag(key, value)
+      end
+
+      def set_metric(key, value)
+      end
+
+      def finish
+      end
+
+      def set_tags(tags)
+      end
+
+      def set_environment_runtime_tags
+      end
+
+      def set_default_tags
+      end
+
+      def to_s
+        self.class.to_s
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -20,9 +20,10 @@ module Datadog
   module CI
     # Common behavior for CI tests
     class Recorder
-      attr_reader :environment_tags, :test_suite_level_visibility_enabled
+      attr_reader :environment_tags, :test_suite_level_visibility_enabled, :enabled
 
-      def initialize(test_suite_level_visibility_enabled: false)
+      def initialize(enabled: true, test_suite_level_visibility_enabled: false)
+        @enabled = enabled
         @test_suite_level_visibility_enabled = test_suite_level_visibility_enabled
 
         @environment_tags = Ext::Environment.tags(ENV).freeze
@@ -31,7 +32,7 @@ module Datadog
       end
 
       def start_test_session(service_name: nil, tags: {})
-        return nil unless @test_suite_level_visibility_enabled
+        return nil unless test_suite_level_visibility_enabled
 
         span_options = {
           service: service_name,
@@ -53,6 +54,8 @@ module Datadog
 
       # Creates a new span for a CI test
       def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
+        return nil unless enabled
+
         test_session = active_test_session
         if test_session
           service_name ||= test_session.service
@@ -94,6 +97,8 @@ module Datadog
       end
 
       def trace(span_type, span_name, tags: {}, &block)
+        return nil unless enabled
+
         span_options = {
           resource: span_name,
           span_type: span_type

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -13,6 +13,7 @@ require_relative "context/global"
 require_relative "context/local"
 
 require_relative "span"
+require_relative "null_span"
 require_relative "test"
 require_relative "test_session"
 
@@ -32,7 +33,7 @@ module Datadog
       end
 
       def start_test_session(service_name: nil, tags: {})
-        return nil unless test_suite_level_visibility_enabled
+        return skip_tracing unless test_suite_level_visibility_enabled
 
         span_options = {
           service: service_name,
@@ -54,7 +55,7 @@ module Datadog
 
       # Creates a new span for a CI test
       def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
-        return nil unless enabled
+        return skip_tracing(block) unless enabled
 
         test_session = active_test_session
         if test_session
@@ -97,7 +98,7 @@ module Datadog
       end
 
       def trace(span_type, span_name, tags: {}, &block)
-        return nil unless enabled
+        return skip_tracing(block) unless enabled
 
         span_options = {
           resource: span_name,
@@ -139,6 +140,14 @@ module Datadog
 
       private
 
+      def skip_tracing(block = nil)
+        if block
+          block.call(null_span)
+        else
+          null_span
+        end
+      end
+
       # Sets trace's origin to ciapp-test
       def set_trace_origin(trace)
         trace.origin = Ext::Test::CONTEXT_ORIGIN if trace
@@ -168,6 +177,10 @@ module Datadog
 
         ci_span.set_tags(tags)
         ci_span.set_tags(environment_tags)
+      end
+
+      def null_span
+        @null_span ||= NullSpan.new
       end
     end
   end

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -1,10 +1,10 @@
 module Datadog
   module CI
-    def self.trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test test) -> untyped } -> untyped
+    def self.trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
 
-    def self.start_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Test
+    def self.start_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-    def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::TestSession?
+    def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
     def self.trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 

--- a/sig/datadog/ci/null_span.rbs
+++ b/sig/datadog/ci/null_span.rbs
@@ -1,0 +1,37 @@
+module Datadog
+  module CI
+    class NullSpan < Span
+      def initialize: () -> void
+
+      def id: () -> nil
+
+      def name: () -> nil
+
+      def service: () -> nil
+
+      def span_type: () -> nil
+
+      def passed!: () -> nil
+
+      def failed!: (?exception: untyped?) -> nil
+
+      def skipped!: (?exception: untyped?, ?reason: untyped?) -> nil
+
+      def get_tag: (untyped key) -> nil
+
+      def set_tag: (untyped key, untyped value) -> nil
+
+      def set_metric: (untyped key, untyped value) -> nil
+
+      def finish: () -> nil
+
+      def set_tags: (untyped tags) -> nil
+
+      def set_environment_runtime_tags: () -> nil
+
+      def set_default_tags: () -> nil
+
+      def to_s: () -> untyped
+    end
+  end
+end

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -2,13 +2,17 @@ module Datadog
   module CI
     class Recorder
       @test_suite_level_visibility_enabled: bool
+      @enabled: bool
+
       @environment_tags: Hash[String, String]
       @local_context: Datadog::CI::Context::Local
       @global_context: Datadog::CI::Context::Global
 
       attr_reader environment_tags: Hash[String, String]
+      attr_reader test_suite_level_visibility_enabled: bool
+      attr_reader enabled: bool
 
-      def initialize: (?test_suite_level_visibility_enabled: bool) -> void
+      def initialize: (?enabled: bool, ?test_suite_level_visibility_enabled: bool) -> void
 
       def trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -14,11 +14,11 @@ module Datadog
 
       def initialize: (?enabled: bool, ?test_suite_level_visibility_enabled: bool) -> void
 
-      def trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
+      def trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
       def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
-      def start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::TestSession?
+      def start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
       def active_test_session: () -> Datadog::CI::TestSession?
 
@@ -43,6 +43,10 @@ module Datadog
       def build_span: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Span
 
       def set_initial_tags: (Datadog::CI::Span ci_span, Hash[untyped, untyped] tags) -> void
+
+      def null_span: () -> Datadog::CI::Span
+
+      def skip_tracing: (?untyped block) -> untyped
     end
   end
 end

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -84,6 +84,9 @@ RSpec.describe Datadog::CI::Configuration::Components do
           allow(settings.ci)
             .to receive(:enabled=)
 
+          allow(settings.ci)
+            .to receive(:experimental_test_suite_level_visibility_enabled=)
+
           allow(Datadog.logger)
             .to receive(:error)
 
@@ -141,7 +144,7 @@ RSpec.describe Datadog::CI::Configuration::Components do
               context "and when agent does not support EVP proxy" do
                 let(:evp_proxy_supported) { false }
 
-                it "falls back to default transport" do
+                it "falls back to default transport and disables test suite level visibility" do
                   expect(settings.tracing.test_mode)
                     .to have_received(:enabled=)
                     .with(true)
@@ -149,6 +152,10 @@ RSpec.describe Datadog::CI::Configuration::Components do
                   expect(settings.tracing.test_mode)
                     .to have_received(:trace_flush=)
                     .with(settings.ci.trace_flush || kind_of(Datadog::CI::TestVisibility::Flush::Partial))
+
+                  expect(settings.ci)
+                    .to have_received(:experimental_test_suite_level_visibility_enabled=)
+                    .with(false)
 
                   expect(settings.tracing.test_mode).to have_received(:writer_options=) do |options|
                     expect(options[:transport]).to be_nil

--- a/spec/datadog/ci/null_span_spec.rb
+++ b/spec/datadog/ci/null_span_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe Datadog::CI::NullSpan do
+  subject(:span) { described_class.new }
+
+  describe "#name" do
+    it "returns nil" do
+      expect(span.name).to be_nil
+    end
+  end
+
+  describe "#passed!" do
+    it "returns nil" do
+      expect(span.passed!).to be_nil
+    end
+  end
+
+  describe "#failed!" do
+    it "returns nil" do
+      expect(span.failed!).to be_nil
+    end
+  end
+
+  describe "#skipped!" do
+    it "returns nil" do
+      expect(span.skipped!).to be_nil
+    end
+  end
+
+  describe "#set_tag" do
+    it "returns nil" do
+      expect(span.set_tag("foo", "bar")).to be_nil
+    end
+  end
+
+  describe "#set_tags" do
+    it "returns nil" do
+      expect(span.set_tags("foo" => "bar", "baz" => "qux")).to be_nil
+    end
+  end
+
+  describe "#set_metric" do
+    it "returns nil" do
+      expect(span.set_metric("foo", "bar")).to be_nil
+    end
+  end
+
+  describe "#set_default_tags" do
+    it "returns nil" do
+      expect(span.set_default_tags).to be_nil
+    end
+  end
+
+  describe "#set_environment_runtime_tags" do
+    it "returns nil" do
+      expect(span.set_environment_runtime_tags).to be_nil
+    end
+  end
+
+  describe "#finish" do
+    it "returns nil" do
+      expect(span.finish).to be_nil
+    end
+  end
+
+  describe "#span_type" do
+    it "returns nil" do
+      expect(span.span_type).to be_nil
+    end
+  end
+end

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -44,6 +44,33 @@ RSpec.describe Datadog::CI::Recorder do
     end
   end
 
+  context "when CI mode is disabled" do
+    include_context "CI mode activated" do
+      let(:experimental_test_suite_level_visibility_enabled) { false }
+      let(:ci_enabled) { false }
+    end
+
+    describe "#trace_test" do
+      context "when given a block" do
+        before do
+          recorder.trace_test("my test") do |test_span|
+            sleep(0.1)
+          end
+        end
+
+        it "does not create spans" do
+          expect(spans.count).to eq(0)
+        end
+      end
+
+      context "without a block" do
+        subject { recorder.trace_test("my test") }
+
+        it { is_expected.to be_nil }
+      end
+    end
+  end
+
   context "when test suite level visibility is disabled" do
     include_context "CI mode activated" do
       let(:experimental_test_suite_level_visibility_enabled) { false }

--- a/spec/support/ci_mode_helpers.rb
+++ b/spec/support/ci_mode_helpers.rb
@@ -2,7 +2,10 @@ RSpec.shared_context "CI mode activated" do
   let(:test_command) { "command" }
   let(:integration_name) { :no_instrument }
   let(:integration_options) { {} }
+
+  let(:ci_enabled) { true }
   let(:experimental_test_suite_level_visibility_enabled) { true }
+
   let(:recorder) { Datadog.send(:components).ci_recorder }
 
   before do
@@ -13,7 +16,7 @@ RSpec.shared_context "CI mode activated" do
     allow(Datadog::CI::Utils::TestRun).to receive(:command).and_return(test_command)
 
     Datadog.configure do |c|
-      c.ci.enabled = true
+      c.ci.enabled = ci_enabled
       c.ci.experimental_test_suite_level_visibility_enabled = experimental_test_suite_level_visibility_enabled
       unless integration_name == :no_instrument
         c.ci.instrument integration_name, integration_options


### PR DESCRIPTION
**What does this PR do?**
Couple of small but important fixes regarding CI mode configuration:
- currently when using manual API and setting `settings.ci.enabled` to `false` (when running tests locally) leads to a complete failure because `@ci_recorder` is nil. Now we are creating the recorder in disabled state in this case to stop tracing but preserving the behaviour. 
  - In order to make it more bearable without adding null checks everywhere a new span type is provided - `NullSpan` which is an implementation of NullObject pattern.
- we will disable test suite level visibility always when we detect old agent version that does not support event protocol

**How to test the change?**
Unit tests are provided