### PR TITLE
Test module support

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -61,6 +61,14 @@ module Datadog
         recorder.active_test_session
       end
 
+      def start_test_module(test_module_name, service_name: nil, tags: {})
+        recorder.start_test_module(test_module_name, service_name: service_name, tags: tags)
+      end
+
+      def active_test_module
+        recorder.active_test_module
+      end
+
       # Return a {Datadog::CI::Test ci_test} that will trace a test called `test_name`.
       # Raises an error if a test is already active.
       # If there is an active test session, the new test will be connected to the session.
@@ -251,6 +259,11 @@ module Datadog
       # Internal only, to finish a test session use Datadog::CI::TestSession#finish
       def deactivate_test_session
         recorder.deactivate_test_session
+      end
+
+      # Internal only, to finish a test module use Datadog::CI::TestModule#finish
+      def deactivate_test_module
+        recorder.deactivate_test_module
       end
 
       private

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -11,6 +11,8 @@ module Datadog
   module CI
     class << self
       # Return a {Datadog::CI::TestSesstion ci_test_session} that represents the whole test session run.
+      # Read Datadog documentation on test sessions
+      # [here](https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#sessions).
       # Raises an error if a session is already active.
       #
       # The {#start_test_session} method is used to mark the start of the test session:

--- a/lib/datadog/ci/context/global.rb
+++ b/lib/datadog/ci/context/global.rb
@@ -19,6 +19,25 @@ module Datadog
           @test_session
         end
 
+        def service
+          @mutex.synchronize do
+            # thank you RBS for this weirdness
+            test_session = @test_session
+            test_session.service if test_session
+          end
+        end
+
+        def inheritable_session_tags
+          @mutex.synchronize do
+            test_session = @test_session
+            if test_session
+              test_session.inheritable_tags
+            else
+              {}
+            end
+          end
+        end
+
         def activate_test_session!(test_session)
           @mutex.synchronize do
             raise "Nested test sessions are not supported. Currently active test session: #{@test_session}" unless @test_session.nil?

--- a/lib/datadog/ci/ext/app_types.rb
+++ b/lib/datadog/ci/ext/app_types.rb
@@ -6,8 +6,9 @@ module Datadog
       module AppTypes
         TYPE_TEST = "test"
         TYPE_TEST_SESSION = "test_session_end"
+        TYPE_TEST_MODULE = "test_module_end"
 
-        CI_SPAN_TYPES = [TYPE_TEST, TYPE_TEST_SESSION].freeze
+        CI_SPAN_TYPES = [TYPE_TEST, TYPE_TEST_SESSION, TYPE_TEST_MODULE].freeze
       end
     end
   end

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -14,13 +14,15 @@ module Datadog
         TAG_SKIP_REASON = "test.skip_reason" # DEV: Not populated yet
         TAG_STATUS = "test.status"
         TAG_SUITE = "test.suite"
+        TAG_MODULE = "test.module"
         TAG_TRAITS = "test.traits"
         TAG_TYPE = "test.type"
         TAG_COMMAND = "test.command"
 
-        # those tags are special and they are used to conrrelate tests with the test sessions, suites, and modules
+        # those tags are special and they are used to correlate tests with the test sessions, suites, and modules
         TAG_TEST_SESSION_ID = "_test.session_id"
-        SPECIAL_TAGS = [TAG_TEST_SESSION_ID].freeze
+        TAG_TEST_MODULE_ID = "_test.module_id"
+        SPECIAL_TAGS = [TAG_TEST_SESSION_ID, TAG_TEST_MODULE_ID].freeze
 
         # tags that can be inherited from the test session
         INHERITABLE_TAGS = [TAG_FRAMEWORK, TAG_FRAMEWORK_VERSION, TAG_TYPE].freeze

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -65,7 +65,6 @@ module Datadog
         test_module
       end
 
-      # Creates a new span for a CI test
       def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
         return skip_tracing(block) unless enabled
 
@@ -78,6 +77,8 @@ module Datadog
         span_options = build_span_options(
           service_name,
           Ext::AppTypes::TYPE_TEST,
+          # :resource is needed for the agent APM protocol to work correctly (for older agent versions)
+          # :continue_from is required to start a new trace for each test
           {resource: test_name, continue_from: Datadog::Tracing::TraceDigest.new}
         )
 

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -62,6 +62,8 @@ module Datadog
           service_name ||= test_session.service
 
           tags = test_session.inheritable_tags.merge(tags)
+
+          tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id
         end
 
         span_options = {
@@ -74,9 +76,8 @@ module Datadog
 
         set_trace_origin(trace)
 
-        tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id if test_session
         tags[Ext::Test::TAG_TEST_MODULE_ID] = tracer_span.id
-        tags[Ext::Test::TAG_MODULE] = test_module_name
+        tags[Ext::Test::TAG_MODULE] = tracer_span.name
 
         test_module = build_test_module(tracer_span, tags)
         @global_context.activate_test_module!(test_module)

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -51,10 +51,10 @@ module Datadog
       def start_test_module(test_module_name, service_name: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
+        tags = tags_with_inherited_globals(tags)
+
         test_session = active_test_session
         if test_session
-          tags = test_session.inheritable_tags.merge(tags)
-
           tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id
         end
 
@@ -75,10 +75,10 @@ module Datadog
       def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
         return skip_tracing(block) unless enabled
 
+        tags = tags_with_inherited_globals(tags)
+
         test_session = active_test_session
         if test_session
-          tags = test_session.inheritable_tags.merge(tags)
-
           tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id
         end
 
@@ -207,6 +207,10 @@ module Datadog
         other_options[:span_type] = span_type
 
         other_options
+      end
+
+      def tags_with_inherited_globals(tags)
+        @global_context.inheritable_session_tags.merge(tags)
       end
 
       def set_initial_tags(ci_span, tags)

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -93,7 +93,17 @@ module Datadog
           service_name ||= test_session.service
 
           tags = test_session.inheritable_tags.merge(tags)
+
+          tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id
         end
+
+        test_module = active_test_module
+        if test_module
+          tags[Ext::Test::TAG_TEST_MODULE_ID] = test_module.id
+          tags[Ext::Test::TAG_MODULE] = test_module.name
+        end
+
+        tags[Ext::Test::TAG_NAME] = test_name
 
         span_options = {
           resource: test_name,
@@ -102,9 +112,6 @@ module Datadog
           # this option is needed to force a new trace to be created
           continue_from: Datadog::Tracing::TraceDigest.new
         }
-
-        tags[Ext::Test::TAG_NAME] = test_name
-        tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id if test_session
 
         if block
           Datadog::Tracing.trace(operation_name, **span_options) do |tracer_span, trace|

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -26,7 +26,7 @@ module Datadog
 
       def initialize(enabled: true, test_suite_level_visibility_enabled: false)
         @enabled = enabled
-        @test_suite_level_visibility_enabled = test_suite_level_visibility_enabled
+        @test_suite_level_visibility_enabled = enabled && test_suite_level_visibility_enabled
 
         @environment_tags = Ext::Environment.tags(ENV).freeze
         @local_context = Context::Local.new

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -16,6 +16,7 @@ require_relative "span"
 require_relative "null_span"
 require_relative "test"
 require_relative "test_session"
+require_relative "test_module"
 
 module Datadog
   module CI

--- a/lib/datadog/ci/test_module.rb
+++ b/lib/datadog/ci/test_module.rb
@@ -16,7 +16,7 @@ module Datadog
       def finish
         super
 
-        # CI.deactivate_test_module(self)
+        # CI.deactivate_test_module
       end
     end
   end

--- a/lib/datadog/ci/test_module.rb
+++ b/lib/datadog/ci/test_module.rb
@@ -16,7 +16,7 @@ module Datadog
       def finish
         super
 
-        # CI.deactivate_test_module
+        CI.deactivate_test_module
       end
     end
   end

--- a/lib/datadog/ci/test_module.rb
+++ b/lib/datadog/ci/test_module.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "concurrent_span"
+
+module Datadog
+  module CI
+    # Represents a single test module.
+    # Read here on what test module could mean:
+    # https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#module
+    # This object can be shared between multiple threads.
+    #
+    # @public_api
+    class TestModule < ConcurrentSpan
+      # Finishes this test module.
+      # @return [void]
+      def finish
+        super
+
+        # CI.deactivate_test_module(self)
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -6,6 +6,8 @@ require_relative "ext/test"
 module Datadog
   module CI
     # Represents the whole test session process.
+    # Documentation on test sessions is here:
+    # https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#sessions
     # This object can be shared between multiple threads.
     #
     # @public_api

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -75,6 +75,10 @@ module Datadog
             @span.get_tag(Ext::Test::TAG_TEST_SESSION_ID)
           end
 
+          def test_module_id
+            @span.get_tag(Ext::Test::TAG_TEST_MODULE_ID)
+          end
+
           def type
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
@@ -2,6 +2,7 @@
 
 require_relative "../test_v2"
 require_relative "../test_session"
+require_relative "../test_module"
 require_relative "../span"
 
 module Datadog
@@ -19,6 +20,8 @@ module Datadog
                 Serializers::TestV2.new(trace, span)
               when Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION
                 Serializers::TestSession.new(trace, span)
+              when Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE
+                Serializers::TestModule.new(trace, span)
               else
                 Serializers::Span.new(trace, span)
               end

--- a/lib/datadog/ci/test_visibility/serializers/test_module.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_module.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../../ext/test"
+
+module Datadog
+  module CI
+    module TestVisibility
+      module Serializers
+        class TestModule < Base
+          CONTENT_FIELDS = [
+            "test_session_id",
+            "test_module_id",
+            "name", "resource", "service",
+            "error", "start", "duration",
+            "meta", "metrics",
+            "type" => "span_type"
+          ].freeze
+
+          CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
+
+          REQUIRED_FIELDS = [
+            "test_session_id",
+            "test_module_id",
+            "error",
+            "name",
+            "resource",
+            "start",
+            "duration"
+          ].freeze
+
+          def content_fields
+            CONTENT_FIELDS
+          end
+
+          def content_map_size
+            CONTENT_MAP_SIZE
+          end
+
+          def type
+            Ext::AppTypes::TYPE_TEST_MODULE
+          end
+
+          def name
+            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_module"
+          end
+
+          def resource
+            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_module.#{@span.get_tag(Ext::Test::TAG_MODULE)}"
+          end
+
+          private
+
+          def required_fields
+            REQUIRED_FIELDS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_visibility/serializers/test_v2.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_v2.rb
@@ -8,11 +8,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class TestV2 < TestV1
-          CONTENT_FIELDS = (["test_session_id"] + TestV1::CONTENT_FIELDS).freeze
+          CONTENT_FIELDS = (["test_session_id", "test_module_id"] + TestV1::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = (["test_session_id"] + TestV1::REQUIRED_FIELDS).freeze
+          REQUIRED_FIELDS = (["test_session_id", "test_module_id"] + TestV1::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -6,9 +6,13 @@ module Datadog
 
     def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
+    def self.start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+
     def self.trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
     def self.active_test_session: () -> Datadog::CI::TestSession?
+
+    def self.active_test_module: () -> Datadog::CI::TestModule?
 
     def self.active_test: () -> Datadog::CI::Test?
 
@@ -17,6 +21,8 @@ module Datadog
     def self.deactivate_test: (Datadog::CI::Test test) -> void
 
     def self.deactivate_test_session: () -> void
+
+    def self.deactivate_test_module: () -> void
 
     def self.components: () -> Datadog::CI::Configuration::Components
 

--- a/sig/datadog/ci/context/global.rbs
+++ b/sig/datadog/ci/context/global.rbs
@@ -5,14 +5,21 @@ module Datadog
         @mutex: Thread::Mutex
 
         @test_session: Datadog::CI::TestSession?
+        @test_module: Datadog::CI::TestModule?
 
         def initialize: () -> void
 
         def active_test_session: () -> Datadog::CI::TestSession?
 
+        def active_test_module: () -> Datadog::CI::TestModule?
+
         def activate_test_session!: (Datadog::CI::TestSession test_session) -> void
 
+        def activate_test_module!: (Datadog::CI::TestModule test_module) -> void
+
         def deactivate_test_session!: () -> void
+
+        def deactivate_test_module!: () -> void
       end
     end
   end

--- a/sig/datadog/ci/context/global.rbs
+++ b/sig/datadog/ci/context/global.rbs
@@ -11,6 +11,10 @@ module Datadog
 
         def active_test_session: () -> Datadog::CI::TestSession?
 
+        def service: () -> String?
+
+        def inheritable_session_tags: () -> Hash[untyped, untyped]
+
         def active_test_module: () -> Datadog::CI::TestModule?
 
         def activate_test_session!: (Datadog::CI::TestSession test_session) -> void

--- a/sig/datadog/ci/ext/app_types.rbs
+++ b/sig/datadog/ci/ext/app_types.rbs
@@ -4,6 +4,7 @@ module Datadog
       module AppTypes
         TYPE_TEST: "test"
         TYPE_TEST_SESSION: "test_session_end"
+        TYPE_TEST_MODULE: "test_module_end"
 
         CI_SPAN_TYPES: Array[String]
       end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -18,6 +18,8 @@ module Datadog
 
         TAG_SUITE: String
 
+        TAG_MODULE: String
+
         TAG_TRAITS: String
 
         TAG_TYPE: String
@@ -25,6 +27,8 @@ module Datadog
         TAG_COMMAND: String
 
         TAG_TEST_SESSION_ID: String
+
+        TAG_TEST_MODULE_ID: String
 
         SPECIAL_TAGS: Array[String]
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -56,6 +56,11 @@ module Datadog
 
       def set_initial_tags: (Datadog::CI::Span ci_span, Hash[untyped, untyped] tags) -> void
 
+      # the type (Datadog::CI::TestSession | Datadog::Tracing::SpanOperation) screams of wrong/mising abstraction
+      def set_session_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestSession | Datadog::Tracing::SpanOperation? test_session) -> void
+
+      def set_module_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestModule | Datadog::Tracing::SpanOperation? test_module) -> void
+
       def null_span: () -> Datadog::CI::Span
 
       def skip_tracing: (?untyped block) -> untyped

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -52,6 +52,8 @@ module Datadog
 
       def build_span: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Span
 
+      def build_span_options: (String? service_name, String span_type, ?Hash[Symbol, untyped] other_options) -> Hash[Symbol, untyped]
+
       def set_initial_tags: (Datadog::CI::Span ci_span, Hash[untyped, untyped] tags) -> void
 
       def null_span: () -> Datadog::CI::Span

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -61,6 +61,8 @@ module Datadog
       def skip_tracing: (?untyped block) -> untyped
 
       def start_datadog_tracer_span: (String span_name, Hash[untyped, untyped] span_options) ?{ (untyped) -> untyped } -> untyped
+
+      def tags_with_inherited_globals: (Hash[untyped, untyped] tags) -> Hash[untyped, untyped]
     end
   end
 end

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -20,7 +20,11 @@ module Datadog
 
       def start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
+      def start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+
       def active_test_session: () -> Datadog::CI::TestSession?
+
+      def active_test_module: () -> Datadog::CI::TestModule?
 
       def active_test: () -> Datadog::CI::Test?
 
@@ -29,6 +33,8 @@ module Datadog
       def deactivate_test: (Datadog::CI::Test test) -> void
 
       def deactivate_test_session: () -> void
+
+      def deactivate_test_module: () -> void
 
       def create_datadog_span: (String span_name, ?span_options: Hash[untyped, untyped], ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
@@ -39,6 +45,8 @@ module Datadog
       def build_test: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Test
 
       def build_test_session: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::TestSession
+
+      def build_test_module: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::TestModule
 
       def build_span: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Span
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -8,6 +8,8 @@ module Datadog
       @local_context: Datadog::CI::Context::Local
       @global_context: Datadog::CI::Context::Global
 
+      @null_span: Datadog::CI::NullSpan
+
       attr_reader environment_tags: Hash[String, String]
       attr_reader test_suite_level_visibility_enabled: bool
       attr_reader enabled: bool

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -57,6 +57,8 @@ module Datadog
       def null_span: () -> Datadog::CI::Span
 
       def skip_tracing: (?untyped block) -> untyped
+
+      def start_datadog_tracer_span: (String span_name, Hash[untyped, untyped] span_options) ?{ (untyped) -> untyped } -> untyped
     end
   end
 end

--- a/sig/datadog/ci/test_module.rbs
+++ b/sig/datadog/ci/test_module.rbs
@@ -1,0 +1,6 @@
+module Datadog
+  module CI
+    class TestModule < ConcurrentSpan
+    end
+  end
+end

--- a/sig/datadog/ci/test_visibility/serializers/test_module.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/test_module.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module CI
+    module TestVisibility
+      module Serializers
+        class TestModule < Base
+          CONTENT_FIELDS: Array[String | Hash[String, String]]
+          CONTENT_MAP_SIZE: Integer
+          REQUIRED_FIELDS: Array[String]
+
+          def content_fields: () -> Array[String | Hash[String, String]]
+          def content_map_size: () -> Integer
+
+          def type: () -> ::String
+
+          def name: () -> ::String
+
+          def resource: () -> ::String
+
+          private
+
+          def required_fields: () -> Array[String]
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/test_module_spec.rb
+++ b/spec/datadog/ci/test_module_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Datadog::CI::TestModule do
+  let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, finish: true) }
+
+  describe "#finish" do
+    subject(:ci_test_module) { described_class.new(tracer_span) }
+
+    before { allow(Datadog::CI).to receive(:deactivate_test_module) }
+
+    it "deactivates the test module" do
+      ci_test_module.finish
+
+      expect(Datadog::CI).to have_received(:deactivate_test_module)
+    end
+  end
+end

--- a/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
+RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
   include_context "CI mode activated" do
     let(:integration_name) { :rspec }
   end
 
   include_context "Test visibility event serialized" do
-    subject { described_class.new(trace_for_span(test_session_span), test_session_span) }
+    subject { described_class.new(trace_for_span(test_module_span), test_module_span) }
   end
 
   describe "#to_msgpack" do
@@ -14,30 +14,33 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
       end
 
       it "serializes test event to messagepack" do
-        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
+        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
 
         expect(content).to include(
           {
             "test_session_id" => test_session_span.id.to_s,
-            "name" => "rspec.test_session",
+            "test_module_id" => test_module_span.id.to_s,
+            "name" => "rspec.test_module",
             "service" => "rspec-test-suite",
-            "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION,
-            "resource" => "rspec.test_session.#{test_command}"
+            "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE,
+            "resource" => "rspec.test_module.arithmetic"
           }
         )
 
         expect(meta).to include(
           {
             "test.command" => test_command,
+            "test.module" => "arithmetic",
             "test.framework" => "rspec",
             "test.framework_version" => "1.0.0",
-            "test.status" => "pass",
             "test.type" => "test",
+            "test.status" => "pass",
             "_dd.origin" => "ciapp-test"
           }
         )
 
         expect(meta["_test.session_id"]).to be_nil
+        expect(meta["_test.module_id"]).to be_nil
       end
     end
 
@@ -47,7 +50,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
       end
 
       it "has error" do
-        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
+        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
 
         expect(content).to include({"error" => 1})
         expect(meta).to include({"test.status" => "fail"})
@@ -69,7 +72,29 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
 
       context "when test_session_id is nil" do
         before do
-          test_session_span.clear_tag("_test.session_id")
+          test_module_span.clear_tag("_test.session_id")
+        end
+
+        it "returns false" do
+          expect(subject.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "test_module_id" do
+      before do
+        produce_test_session_trace
+      end
+
+      context "when test_module_id is not nil" do
+        it "returns true" do
+          expect(subject.valid?).to eq(true)
+        end
+      end
+
+      context "when test_module_id is nil" do
+        before do
+          test_module_span.clear_tag("_test.module_id")
         end
 
         it "returns false" do

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -132,4 +132,40 @@ RSpec.describe Datadog::CI do
 
     it { is_expected.to be_nil }
   end
+
+  describe "::start_test_module" do
+    subject(:start_test_module) { described_class.start_test_module("my-module") }
+
+    let(:ci_test_module) { instance_double(Datadog::CI::TestModule) }
+
+    before do
+      allow(recorder).to(
+        receive(:start_test_module).with("my-module", service_name: nil, tags: {}).and_return(ci_test_module)
+      )
+    end
+
+    it { is_expected.to be(ci_test_module) }
+  end
+
+  describe "::active_test_module" do
+    subject(:active_test_module) { described_class.active_test_module }
+
+    let(:ci_test_module) { instance_double(Datadog::CI::TestModule) }
+
+    before do
+      allow(recorder).to receive(:active_test_module).and_return(ci_test_module)
+    end
+
+    it { is_expected.to be(ci_test_module) }
+  end
+
+  describe "::deactivate_test_module" do
+    subject(:deactivate_test_module) { described_class.deactivate_test_module }
+
+    before do
+      allow(recorder).to receive(:deactivate_test_module)
+    end
+
+    it { is_expected.to be_nil }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds test modules support as described by Datadog docs [here](https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#module).

For Ruby test frameworks module will be synonymous with session (just like in JS), so only one module per process can be active at any given time.

**How to test the change?**
Unit tests are provided