### PR TITLE
[CIVIS-2844] Test suites support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile-*.lock
 .envrc
 .ruby-version
 .DS_Store
+/test.rb

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -214,6 +214,7 @@ module Datadog
       # Remember that in this case, calling {Datadog::CI::Test#finish} is mandatory.
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
+      # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
       # @param [String] operation_name defines label for a test span in trace view ("test" if it's missing)
       # @param [String] service_name the service name for this test
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
@@ -226,8 +227,8 @@ module Datadog
       # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
-        recorder.trace_test(test_name, service_name: service_name, operation_name: operation_name, tags: tags, &block)
+      def trace_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {}, &block)
+        recorder.trace_test(test_name, test_suite_name, service_name: service_name, operation_name: operation_name, tags: tags, &block)
       end
 
       # Same as {#trace_test} but it does not accept a block.
@@ -247,6 +248,7 @@ module Datadog
       # ```
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
+      # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
       # @param [String] operation_name the resource this span refers, or `test` if it's missing
       # @param [String] service_name the service name for this span.
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
@@ -254,8 +256,8 @@ module Datadog
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def start_test(test_name, service_name: nil, operation_name: "test", tags: {})
-        recorder.trace_test(test_name, service_name: service_name, operation_name: operation_name, tags: tags)
+      def start_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {})
+        recorder.trace_test(test_name, test_suite_name, service_name: service_name, operation_name: operation_name, tags: tags)
       end
 
       # Trace any custom span inside a test. For example, you could trace:

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -11,8 +11,10 @@ module Datadog
   module CI
     class << self
       # Starts a {Datadog::CI::TestSesstion ci_test_session} that represents the whole test session run.
+      #
       # Read Datadog documentation on test sessions
       # [here](https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#sessions).
+      #
       # Raises an error if a session is already active.
       #
       # The {#start_test_session} method is used to mark the start of the test session:

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -28,7 +28,7 @@ module Datadog
       #
       # Remember that calling {Datadog::CI::TestSession#finish} is mandatory.
       #
-      # @param [String] service_name the service name for this session
+      # @param [String] service_name the service name for this session (optional, defaults to DD_SERVICE)
       # @param [Hash<String,String>] tags extra tags which should be added to the test session.
       # @return [Datadog::CI::TestSession] returns the active, running {Datadog::CI::TestSession}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled or if old Datadog agent is
@@ -36,6 +36,7 @@ module Datadog
       #
       # @public_api
       def start_test_session(service_name: nil, tags: {})
+        service_name ||= Datadog.configuration.service
         recorder.start_test_session(service_name: service_name, tags: tags)
       end
 

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -15,12 +15,12 @@ module Datadog
       # Read Datadog documentation on test sessions
       # [here](https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#sessions).
       #
-      # Raises an error if a session is already active.
+      # Returns the existing test session if one is already active. There is at most a single test session per process.
       #
       # The {#start_test_session} method is used to mark the start of the test session:
       # ```
       # Datadog::CI.start_test_session(
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -49,7 +49,7 @@ module Datadog
       # ```
       # # start a test session
       # Datadog::CI.start_test_session(
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -70,14 +70,14 @@ module Datadog
       # Read Datadog documentation on test modules:
       # [here](https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#module).
       #
-      # Raises an error if a module is already active. There is at most a single test module per process
+      # Returns the existing test session if one is already active. There is at most a single test module per process
       # active at any given time.
       #
       # The {#start_test_module} method is used to mark the start of the test session:
       # ```
       # Datadog::CI.start_test_module(
       #   "my-module",
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -107,7 +107,7 @@ module Datadog
       # # start a test module
       # Datadog::CI.start_test_module(
       #   "my-module",
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -132,7 +132,7 @@ module Datadog
       # ```
       # Datadog::CI.start_test_suite(
       #   "calculator_tests",
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -162,7 +162,7 @@ module Datadog
       # # start a test suite
       # Datadog::CI.start_test_suite(
       #   "calculator_tests",
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -206,7 +206,7 @@ module Datadog
       # ```
       # ci_test = Datadog::CI.trace_test(
       #   "test_add_two_numbers',
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
@@ -242,7 +242,7 @@ module Datadog
       # ```
       # ci_test = Datadog::CI.start_test(
       #   "test_add_two_numbers',
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
@@ -344,7 +344,7 @@ module Datadog
       # # start a test
       # Datadog::CI.start_test(
       #   "test_add_two_numbers',
-      #   service: "my-web-site-tests",
+      #   service_name: "my-web-site-tests",
       #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -62,9 +62,6 @@ module Datadog
                 fetch_integration(integration_name).configuration
               end
 
-              # TODO: Deprecate in the next major version, as `instrument` better describes this method's purpose
-              alias_method :use, :instrument
-
               option :trace_flush
 
               option :writer_options do |o|

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -62,6 +62,9 @@ module Datadog
                 fetch_integration(integration_name).configuration
               end
 
+              # @deprecated Will be removed on datadog-ci-rb 1.0.
+              alias_method :use, :instrument
+
               option :trace_flush
 
               option :writer_options do |o|

--- a/lib/datadog/ci/context/global.rb
+++ b/lib/datadog/ci/context/global.rb
@@ -9,6 +9,13 @@ module Datadog
           @mutex = Mutex.new
           @test_session = nil
           @test_module = nil
+          @test_suites = {}
+        end
+
+        def fetch_or_activate_test_suite(test_suite_name, &block)
+          @mutex.synchronize do
+            @test_suites[test_suite_name] ||= block.call
+          end
         end
 
         def active_test_module
@@ -17,6 +24,10 @@ module Datadog
 
         def active_test_session
           @test_session
+        end
+
+        def active_test_suite(test_suite_name)
+          @mutex.synchronize { @test_suites[test_suite_name] }
         end
 
         def service
@@ -60,6 +71,10 @@ module Datadog
 
         def deactivate_test_module!
           @mutex.synchronize { @test_module = nil }
+        end
+
+        def deactivate_test_suite!(test_suite_name)
+          @mutex.synchronize { @test_suites.delete(test_suite_name) }
         end
       end
     end

--- a/lib/datadog/ci/context/global.rb
+++ b/lib/datadog/ci/context/global.rb
@@ -20,6 +20,18 @@ module Datadog
           end
         end
 
+        def fetch_or_activate_test_module(&block)
+          @mutex.synchronize do
+            @test_module ||= block.call
+          end
+        end
+
+        def fetch_or_activate_test_session(&block)
+          @mutex.synchronize do
+            @test_session ||= block.call
+          end
+        end
+
         def active_test_module
           @test_module
         end

--- a/lib/datadog/ci/context/global.rb
+++ b/lib/datadog/ci/context/global.rb
@@ -6,7 +6,9 @@ module Datadog
       # This context is shared between threads and represents the current test session and test module.
       class Global
         def initialize
-          @mutex = Mutex.new
+          # we are using Monitor instead of Mutex because it is reentrant
+          @mutex = Monitor.new
+
           @test_session = nil
           @test_module = nil
           @test_suites = {}

--- a/lib/datadog/ci/context/global.rb
+++ b/lib/datadog/ci/context/global.rb
@@ -63,22 +63,6 @@ module Datadog
           end
         end
 
-        def activate_test_session!(test_session)
-          @mutex.synchronize do
-            raise "Nested test sessions are not supported. Currently active test session: #{@test_session}" unless @test_session.nil?
-
-            @test_session = test_session
-          end
-        end
-
-        def activate_test_module!(test_module)
-          @mutex.synchronize do
-            raise "Nested test modules are not supported. Currently active test module: #{@test_module}" unless @test_module.nil?
-
-            @test_module = test_module
-          end
-        end
-
         def deactivate_test_session!
           @mutex.synchronize { @test_session = nil }
         end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -29,11 +29,11 @@ module Datadog
           def on_test_case_started(event)
             CI.start_test(
               event.test_case.name,
+              event.test_case.location.file,
               tags: {
                 CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Cucumber::Integration.version.to_s,
-                CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE,
-                CI::Ext::Test::TAG_SUITE => event.test_case.location.file
+                CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
               service_name: configuration[:service_name],
               operation_name: configuration[:operation_name]

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -20,11 +20,11 @@ module Datadog
 
             CI.start_test(
               test_name,
+              test_suite,
               tags: {
                 CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s,
-                CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE,
-                CI::Ext::Test::TAG_SUITE => test_suite
+                CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
               service_name: configuration[:service_name],
               operation_name: configuration[:operation_name]

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -26,11 +26,11 @@ module Datadog
 
               CI.trace_test(
                 test_name,
+                metadata[:example_group][:file_path],
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
-                  CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE,
-                  CI::Ext::Test::TAG_SUITE => metadata[:example_group][:file_path]
+                  CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
                 },
                 service_name: configuration[:service_name],
                 operation_name: configuration[:operation_name]

--- a/lib/datadog/ci/ext/app_types.rb
+++ b/lib/datadog/ci/ext/app_types.rb
@@ -7,8 +7,9 @@ module Datadog
         TYPE_TEST = "test"
         TYPE_TEST_SESSION = "test_session_end"
         TYPE_TEST_MODULE = "test_module_end"
+        TYPE_TEST_SUITE = "test_suite_end"
 
-        CI_SPAN_TYPES = [TYPE_TEST, TYPE_TEST_SESSION, TYPE_TEST_MODULE].freeze
+        CI_SPAN_TYPES = [TYPE_TEST, TYPE_TEST_SESSION, TYPE_TEST_MODULE, TYPE_TEST_SUITE].freeze
       end
     end
   end

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -22,7 +22,8 @@ module Datadog
         # those tags are special and they are used to correlate tests with the test sessions, suites, and modules
         TAG_TEST_SESSION_ID = "_test.session_id"
         TAG_TEST_MODULE_ID = "_test.module_id"
-        SPECIAL_TAGS = [TAG_TEST_SESSION_ID, TAG_TEST_MODULE_ID].freeze
+        TAG_TEST_SUITE_ID = "_test.suite_id"
+        SPECIAL_TAGS = [TAG_TEST_SESSION_ID, TAG_TEST_MODULE_ID, TAG_TEST_SUITE_ID].freeze
 
         # tags that can be inherited from the test session
         INHERITABLE_TAGS = [TAG_FRAMEWORK, TAG_FRAMEWORK_VERSION, TAG_TYPE].freeze

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -34,7 +34,6 @@ module Datadog
         TAG_RUNTIME_NAME = "runtime.name"
         TAG_RUNTIME_VERSION = "runtime.version"
 
-        # TODO: is there a better place for SPAN_KIND?
         TAG_SPAN_KIND = "span.kind"
 
         module Status

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -157,7 +157,6 @@ module Datadog
         @global_context.active_test_suite(test_suite_name)
       end
 
-      # TODO: does it make sense to have a parameter here?
       def deactivate_test(test)
         @local_context.deactivate_test!(test)
       end

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -242,13 +242,13 @@ module Datadog
 
       def set_session_context(tags, test_session = nil)
         test_session ||= active_test_session
-        tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id if test_session
+        tags[Ext::Test::TAG_TEST_SESSION_ID] = test_session.id.to_s if test_session
       end
 
       def set_module_context(tags, test_module = nil)
         test_module ||= active_test_module
         if test_module
-          tags[Ext::Test::TAG_TEST_MODULE_ID] = test_module.id
+          tags[Ext::Test::TAG_TEST_MODULE_ID] = test_module.id.to_s
           tags[Ext::Test::TAG_MODULE] = test_module.name
         end
       end
@@ -259,7 +259,7 @@ module Datadog
         test_suite = span || active_test_suite(name)
 
         if test_suite
-          tags[Ext::Test::TAG_TEST_SUITE_ID] = test_suite.id
+          tags[Ext::Test::TAG_TEST_SUITE_ID] = test_suite.id.to_s
           tags[Ext::Test::TAG_SUITE] = test_suite.name
         else
           tags[Ext::Test::TAG_SUITE] = name

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -17,6 +17,7 @@ require_relative "null_span"
 require_relative "test"
 require_relative "test_session"
 require_relative "test_module"
+require_relative "test_suite"
 
 module Datadog
   module CI

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -173,7 +173,7 @@ module Datadog
       end
 
       def deactivate_test_suite(test_suite_name)
-        @global_context.deactivate_test_module!
+        @global_context.deactivate_test_suite!(test_suite_name)
       end
 
       private

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -38,32 +38,30 @@ module Datadog
       def start_test_session(service_name: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
-        tracer_span = start_datadog_tracer_span(
-          "test.session", build_span_options(service_name, Ext::AppTypes::TYPE_TEST_SESSION)
-        )
-        set_session_context(tags, tracer_span)
+        @global_context.fetch_or_activate_test_session do
+          tracer_span = start_datadog_tracer_span(
+            "test.session", build_span_options(service_name, Ext::AppTypes::TYPE_TEST_SESSION)
+          )
+          set_session_context(tags, tracer_span)
 
-        test_session = build_test_session(tracer_span, tags)
-        @global_context.activate_test_session!(test_session)
-
-        test_session
+          build_test_session(tracer_span, tags)
+        end
       end
 
       def start_test_module(test_module_name, service_name: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
-        tags = tags_with_inherited_globals(tags)
-        set_session_context(tags)
+        @global_context.fetch_or_activate_test_module do
+          tags = tags_with_inherited_globals(tags)
+          set_session_context(tags)
 
-        tracer_span = start_datadog_tracer_span(
-          test_module_name, build_span_options(service_name, Ext::AppTypes::TYPE_TEST_MODULE)
-        )
-        set_module_context(tags, tracer_span)
+          tracer_span = start_datadog_tracer_span(
+            test_module_name, build_span_options(service_name, Ext::AppTypes::TYPE_TEST_MODULE)
+          )
+          set_module_context(tags, tracer_span)
 
-        test_module = build_test_module(tracer_span, tags)
-        @global_context.activate_test_module!(test_module)
-
-        test_module
+          build_test_module(tracer_span, tags)
+        end
       end
 
       def start_test_suite(test_suite_name, service_name: nil, tags: {})

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -83,12 +83,13 @@ module Datadog
         end
       end
 
-      def trace_test(test_name, service_name: nil, operation_name: "test", tags: {}, &block)
+      def trace_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {}, &block)
         return skip_tracing(block) unless enabled
 
         tags = tags_with_inherited_globals(tags)
         set_session_context(tags)
         set_module_context(tags)
+        set_suite_context(tags, name: test_suite_name)
 
         tags[Ext::Test::TAG_NAME] = test_name
 

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -23,13 +23,13 @@ module Datadog
       def inheritable_tags
         return @inheritable_tags if defined?(@inheritable_tags)
 
-        # this method is not synchronized because it does not iterate over the tags, but rather
+        # this method is not synchronized because it does not iterate over the tags collection, but rather
         # uses synchronized method to get each tag value
         res = {}
         Ext::Test::INHERITABLE_TAGS.each do |tag|
           res[tag] = get_tag(tag)
         end
-        @inheritable_tags = res
+        @inheritable_tags = res.freeze
       end
     end
   end

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -13,6 +13,13 @@ module Datadog
     #
     # @public_api
     class TestSuite < ConcurrentSpan
+      # Finishes this test suite.
+      # @return [void]
+      def finish
+        super
+
+        CI.deactivate_test_suite(name)
+      end
     end
   end
 end

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative "concurrent_span"
+
+module Datadog
+  module CI
+    # Represents a single test suite.
+    #
+    # Read here on what test suite means:
+    # https://docs.datadoghq.com/continuous_integration/explorer/?tab=testruns#suite
+    #
+    # This object can be shared between multiple threads.
+    #
+    # @public_api
+    class TestSuite < ConcurrentSpan
+    end
+  end
+end

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -94,6 +94,10 @@ module Datadog
             @span.get_tag(Ext::Test::TAG_TEST_MODULE_ID)
           end
 
+          def test_suite_id
+            @span.get_tag(Ext::Test::TAG_TEST_SUITE_ID)
+          end
+
           def type
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -87,15 +87,15 @@ module Datadog
           end
 
           def test_session_id
-            @span.get_tag(Ext::Test::TAG_TEST_SESSION_ID)
+            to_integer(@span.get_tag(Ext::Test::TAG_TEST_SESSION_ID))
           end
 
           def test_module_id
-            @span.get_tag(Ext::Test::TAG_TEST_MODULE_ID)
+            to_integer(@span.get_tag(Ext::Test::TAG_TEST_MODULE_ID))
           end
 
           def test_suite_id
-            @span.get_tag(Ext::Test::TAG_TEST_SUITE_ID)
+            to_integer(@span.get_tag(Ext::Test::TAG_TEST_SUITE_ID))
           end
 
           def type
@@ -180,6 +180,10 @@ module Datadog
           # in nanoseconds
           def duration_nano(duration)
             (duration * 1e9).to_i
+          end
+
+          def to_integer(value)
+            value.to_i if value
           end
         end
       end

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -11,6 +11,21 @@ module Datadog
           MINIMUM_DURATION_NANO = 0
           MAXIMUM_DURATION_NANO = 9223372036854775807
 
+          CONTENT_FIELDS = [
+            "name", "resource", "service",
+            "error", "start", "duration",
+            "meta", "metrics",
+            "type" => "span_type"
+          ].freeze
+
+          REQUIRED_FIELDS = [
+            "error",
+            "name",
+            "resource",
+            "start",
+            "duration"
+          ].freeze
+
           attr_reader :trace, :span, :meta
 
           def initialize(trace, span)

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
@@ -3,6 +3,7 @@
 require_relative "../test_v2"
 require_relative "../test_session"
 require_relative "../test_module"
+require_relative "../test_suite"
 require_relative "../span"
 
 module Datadog
@@ -22,6 +23,8 @@ module Datadog
                 Serializers::TestSession.new(trace, span)
               when Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE
                 Serializers::TestModule.new(trace, span)
+              when Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE
+                Serializers::TestSuite.new(trace, span)
               else
                 Serializers::Span.new(trace, span)
               end

--- a/lib/datadog/ci/test_visibility/serializers/span.rb
+++ b/lib/datadog/ci/test_visibility/serializers/span.rb
@@ -7,25 +7,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class Span < Base
-          CONTENT_FIELDS = [
-            "trace_id", "span_id", "parent_id",
-            "name", "resource", "service",
-            "error", "start", "duration",
-            "meta", "metrics",
-            "type" => "span_type"
-          ].freeze
+          CONTENT_FIELDS = (["trace_id", "span_id", "parent_id"] + Base::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = [
-            "trace_id",
-            "span_id",
-            "error",
-            "name",
-            "resource",
-            "start",
-            "duration"
-          ].freeze
+          REQUIRED_FIELDS = (["trace_id", "span_id"] + Base::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/lib/datadog/ci/test_visibility/serializers/test_module.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_module.rb
@@ -8,26 +8,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class TestModule < Base
-          CONTENT_FIELDS = [
-            "test_session_id",
-            "test_module_id",
-            "name", "resource", "service",
-            "error", "start", "duration",
-            "meta", "metrics",
-            "type" => "span_type"
-          ].freeze
+          CONTENT_FIELDS = (["test_session_id", "test_module_id"] + Base::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = [
-            "test_session_id",
-            "test_module_id",
-            "error",
-            "name",
-            "resource",
-            "start",
-            "duration"
-          ].freeze
+          REQUIRED_FIELDS = (["test_session_id", "test_module_id"] + Base::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/lib/datadog/ci/test_visibility/serializers/test_session.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_session.rb
@@ -8,24 +8,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class TestSession < Base
-          CONTENT_FIELDS = [
-            "test_session_id",
-            "name", "resource", "service",
-            "error", "start", "duration",
-            "meta", "metrics",
-            "type" => "span_type"
-          ].freeze
+          CONTENT_FIELDS = (["test_session_id"] + Base::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = [
-            "test_session_id",
-            "error",
-            "name",
-            "resource",
-            "start",
-            "duration"
-          ].freeze
+          REQUIRED_FIELDS = (["test_session_id"] + Base::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/lib/datadog/ci/test_visibility/serializers/test_suite.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_suite.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require_relative "../../ext/test"
+
+module Datadog
+  module CI
+    module TestVisibility
+      module Serializers
+        class TestSuite < Base
+          CONTENT_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + Base::CONTENT_FIELDS).freeze
+
+          CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
+
+          REQUIRED_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + Base::REQUIRED_FIELDS).freeze
+
+          def content_fields
+            CONTENT_FIELDS
+          end
+
+          def content_map_size
+            CONTENT_MAP_SIZE
+          end
+
+          def type
+            Ext::AppTypes::TYPE_TEST_SUITE
+          end
+
+          def name
+            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_suite"
+          end
+
+          def resource
+            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_suite.#{@span.get_tag(Ext::Test::TAG_SUITE)}"
+          end
+
+          private
+
+          def required_fields
+            REQUIRED_FIELDS
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_visibility/serializers/test_v1.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_v1.rb
@@ -8,25 +8,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class TestV1 < Base
-          CONTENT_FIELDS = [
-            "trace_id", "span_id",
-            "name", "resource", "service",
-            "error", "start", "duration",
-            "meta", "metrics",
-            "type" => "span_type"
-          ].freeze
+          CONTENT_FIELDS = (["trace_id", "span_id"] + Base::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = [
-            "trace_id",
-            "span_id",
-            "error",
-            "name",
-            "resource",
-            "start",
-            "duration"
-          ].freeze
+          REQUIRED_FIELDS = (["trace_id", "span_id"] + Base::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/lib/datadog/ci/test_visibility/serializers/test_v2.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_v2.rb
@@ -8,11 +8,11 @@ module Datadog
     module TestVisibility
       module Serializers
         class TestV2 < TestV1
-          CONTENT_FIELDS = (["test_session_id", "test_module_id"] + TestV1::CONTENT_FIELDS).freeze
+          CONTENT_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + TestV1::CONTENT_FIELDS).freeze
 
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
 
-          REQUIRED_FIELDS = (["test_session_id", "test_module_id"] + TestV1::REQUIRED_FIELDS).freeze
+          REQUIRED_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + TestV1::REQUIRED_FIELDS).freeze
 
           def content_fields
             CONTENT_FIELDS

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -8,6 +8,8 @@ module Datadog
 
     def self.start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
+    def self.start_test_suite: (String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+
     def self.trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
     def self.active_test_session: () -> Datadog::CI::TestSession?
@@ -23,6 +25,8 @@ module Datadog
     def self.deactivate_test_session: () -> void
 
     def self.deactivate_test_module: () -> void
+
+    def self.deactivate_test_suite: (String test_suite_name) -> void
 
     def self.components: () -> Datadog::CI::Configuration::Components
 

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -1,8 +1,8 @@
 module Datadog
   module CI
-    def self.trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
+    def self.trace_test: (String test_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
 
-    def self.start_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test: (String test_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
     def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 

--- a/sig/datadog/ci/context/global.rbs
+++ b/sig/datadog/ci/context/global.rbs
@@ -6,10 +6,15 @@ module Datadog
 
         @test_session: Datadog::CI::TestSession?
         @test_module: Datadog::CI::TestModule?
+        @test_suites: Hash[String, Datadog::CI::TestSuite]
 
         def initialize: () -> void
 
+        def fetch_or_activate_test_suite: (String test_suite_name) {() -> Datadog::CI::TestSuite} -> Datadog::CI::TestSuite
+
         def active_test_session: () -> Datadog::CI::TestSession?
+
+        def active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
 
         def service: () -> String?
 
@@ -24,6 +29,8 @@ module Datadog
         def deactivate_test_session!: () -> void
 
         def deactivate_test_module!: () -> void
+
+        def deactivate_test_suite!: (String test_suite_name) -> void
       end
     end
   end

--- a/sig/datadog/ci/context/global.rbs
+++ b/sig/datadog/ci/context/global.rbs
@@ -26,10 +26,6 @@ module Datadog
 
         def active_test_module: () -> Datadog::CI::TestModule?
 
-        def activate_test_session!: (Datadog::CI::TestSession test_session) -> void
-
-        def activate_test_module!: (Datadog::CI::TestModule test_module) -> void
-
         def deactivate_test_session!: () -> void
 
         def deactivate_test_module!: () -> void

--- a/sig/datadog/ci/context/global.rbs
+++ b/sig/datadog/ci/context/global.rbs
@@ -12,6 +12,10 @@ module Datadog
 
         def fetch_or_activate_test_suite: (String test_suite_name) {() -> Datadog::CI::TestSuite} -> Datadog::CI::TestSuite
 
+        def fetch_or_activate_test_module: () {() -> Datadog::CI::TestModule} -> Datadog::CI::TestModule
+
+        def fetch_or_activate_test_session: () {() -> Datadog::CI::TestSession} -> Datadog::CI::TestSession
+
         def active_test_session: () -> Datadog::CI::TestSession?
 
         def active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?

--- a/sig/datadog/ci/ext/app_types.rbs
+++ b/sig/datadog/ci/ext/app_types.rbs
@@ -5,6 +5,7 @@ module Datadog
         TYPE_TEST: "test"
         TYPE_TEST_SESSION: "test_session_end"
         TYPE_TEST_MODULE: "test_module_end"
+        TYPE_TEST_SUITE: "test_suite_end"
 
         CI_SPAN_TYPES: Array[String]
       end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -30,6 +30,8 @@ module Datadog
 
         TAG_TEST_MODULE_ID: String
 
+        TAG_TEST_SUITE_ID: String
+
         SPECIAL_TAGS: Array[String]
 
         INHERITABLE_TAGS: Array[String]

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -16,7 +16,7 @@ module Datadog
 
       def initialize: (?enabled: bool, ?test_suite_level_visibility_enabled: bool) -> void
 
-      def trace_test: (String span_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+      def trace_test: (String span_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
       def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -24,9 +24,13 @@ module Datadog
 
       def start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
+      def start_test_suite: (String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+
       def active_test_session: () -> Datadog::CI::TestSession?
 
       def active_test_module: () -> Datadog::CI::TestModule?
+
+      def active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
 
       def active_test: () -> Datadog::CI::Test?
 
@@ -37,6 +41,8 @@ module Datadog
       def deactivate_test_session: () -> void
 
       def deactivate_test_module: () -> void
+
+      def deactivate_test_suite: (String test_suite_name) -> void
 
       def create_datadog_span: (String span_name, ?span_options: Hash[untyped, untyped], ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
@@ -50,6 +56,8 @@ module Datadog
 
       def build_test_module: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::TestModule
 
+      def build_test_suite: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::TestSuite
+
       def build_span: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Span
 
       def build_span_options: (String? service_name, String span_type, ?Hash[Symbol, untyped] other_options) -> Hash[Symbol, untyped]
@@ -58,6 +66,8 @@ module Datadog
 
       # the type (Datadog::CI::TestSession | Datadog::Tracing::SpanOperation) screams of wrong/mising abstraction
       def set_session_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestSession | Datadog::Tracing::SpanOperation? test_session) -> void
+
+      def set_suite_context: (Hash[untyped, untyped] tags, ?span: Datadog::Tracing::SpanOperation, ?name: String) -> void
 
       def set_module_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestModule | Datadog::Tracing::SpanOperation? test_module) -> void
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -77,7 +77,7 @@ module Datadog
 
       def start_datadog_tracer_span: (String span_name, Hash[untyped, untyped] span_options) ?{ (untyped) -> untyped } -> untyped
 
-      def tags_with_inherited_globals: (Hash[untyped, untyped] tags) -> Hash[untyped, untyped]
+      def set_inherited_globals: (Hash[untyped, untyped] tags) -> void
     end
   end
 end

--- a/sig/datadog/ci/test_suite.rbs
+++ b/sig/datadog/ci/test_suite.rbs
@@ -1,0 +1,6 @@
+module Datadog
+  module CI
+    class TestSuite < ConcurrentSpan
+    end
+  end
+end

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -34,6 +34,12 @@ module Datadog
 
           def parent_id: () -> String
 
+          def test_session_id: () -> String?
+
+          def test_module_id: () -> String?
+
+          def test_suite_id: () -> String?
+
           def type: () -> nil
 
           def version: () -> 1

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -7,6 +7,9 @@ module Datadog
           MINIMUM_DURATION_NANO: 0
           MAXIMUM_DURATION_NANO: 9223372036854775807
 
+          CONTENT_FIELDS: Array[String | Hash[String, String]]
+          REQUIRED_FIELDS: Array[String]
+
           @content_fields_count: Integer
           @start: Integer
           @duration: Integer

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -34,11 +34,11 @@ module Datadog
 
           def parent_id: () -> String
 
-          def test_session_id: () -> String?
+          def test_session_id: () -> Integer?
 
-          def test_module_id: () -> String?
+          def test_module_id: () -> Integer?
 
-          def test_suite_id: () -> String?
+          def test_suite_id: () -> Integer?
 
           def type: () -> nil
 
@@ -74,6 +74,8 @@ module Datadog
           def write_field: (untyped packer, String field_name, ?String? method) -> untyped
           def time_nano: (Time time) -> Integer
           def duration_nano: (Float duration) -> Integer
+
+          def to_integer: (String? value) -> Integer?
 
           def content_fields_count: () -> Integer
         end

--- a/sig/datadog/ci/test_visibility/serializers/test_suite.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/test_suite.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module CI
+    module TestVisibility
+      module Serializers
+        class TestSuite < Base
+          CONTENT_FIELDS: Array[String | Hash[String, String]]
+          CONTENT_MAP_SIZE: Integer
+          REQUIRED_FIELDS: Array[String]
+
+          def content_fields: () -> Array[String | Hash[String, String]]
+          def content_map_size: () -> Integer
+
+          def type: () -> ::String
+
+          def name: () -> ::String
+
+          def resource: () -> ::String
+
+          private
+
+          def required_fields: () -> Array[String]
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/concurrent_span_spec.rb
+++ b/spec/datadog/ci/concurrent_span_spec.rb
@@ -1,20 +1,17 @@
-THREADS_COUNT = 10
-REPEAT_COUNT = 20
-
 RSpec.describe Datadog::CI::ConcurrentSpan do
   describe "#finish" do
+    include_context "Concurrency test"
+
     it "calls SpanOperation#stop once" do
-      REPEAT_COUNT.times do
+      repeat do
         tracer_span = Datadog::Tracing::SpanOperation.new("operation")
         ci_span = described_class.new(tracer_span)
 
         expect(tracer_span).to receive(:stop).once
 
-        (1..THREADS_COUNT).map do
-          Thread.new do
-            ci_span.finish
-          end
-        end.map(&:join)
+        run_concurrently do
+          ci_span.finish
+        end
       end
     end
   end

--- a/spec/datadog/ci/context/global_spec.rb
+++ b/spec/datadog/ci/context/global_spec.rb
@@ -5,35 +5,10 @@ RSpec.describe Datadog::CI::Context::Global do
   let(:session) { Datadog::CI::TestSession.new(tracer_span) }
   let(:test_module) { Datadog::CI::TestModule.new(tracer_span) }
 
-  describe "#activate_test_session!" do
-    context "when a test session is already active" do
-      before do
-        subject.activate_test_session!(Datadog::CI::TestSession.new(tracer_span))
-      end
-
-      it "raises an error" do
-        expect { subject.activate_test_session!(session) }.to(
-          raise_error(
-            RuntimeError,
-            "Nested test sessions are not supported. Currently active test session: " \
-            "#{session}"
-          )
-        )
-      end
-    end
-
-    context "when no test session is active" do
-      it "activates the test session" do
-        subject.activate_test_session!(session)
-        expect(subject.active_test_session).to be(session)
-      end
-    end
-  end
-
   describe "#service" do
     context "when a test session is active" do
       before do
-        subject.activate_test_session!(session)
+        subject.fetch_or_activate_test_session { session }
       end
 
       it "returns the service name" do
@@ -54,7 +29,7 @@ RSpec.describe Datadog::CI::Context::Global do
       before do
         expect(session).to receive(:inheritable_tags).and_return(inheritable_tags)
 
-        subject.activate_test_session!(session)
+        subject.fetch_or_activate_test_session { session }
       end
 
       it "returns the inheritable session tags" do
@@ -72,7 +47,7 @@ RSpec.describe Datadog::CI::Context::Global do
   describe "active_test_session" do
     context "when a test session is active" do
       before do
-        subject.activate_test_session!(session)
+        subject.fetch_or_activate_test_session { session }
       end
 
       it "returns the active test session" do
@@ -90,7 +65,7 @@ RSpec.describe Datadog::CI::Context::Global do
   describe "#deactivate_test_session!" do
     context "when a test session is active" do
       before do
-        subject.activate_test_session!(session)
+        subject.fetch_or_activate_test_session { session }
       end
 
       it "deactivates the test session" do
@@ -107,35 +82,10 @@ RSpec.describe Datadog::CI::Context::Global do
     end
   end
 
-  describe "#activate_test_module!" do
-    context "when a test module is already active" do
-      before do
-        subject.activate_test_module!(Datadog::CI::TestModule.new(tracer_span))
-      end
-
-      it "raises an error" do
-        expect { subject.activate_test_module!(test_module) }.to(
-          raise_error(
-            RuntimeError,
-            "Nested test modules are not supported. Currently active test module: " \
-            "#{test_module}"
-          )
-        )
-      end
-    end
-
-    context "when no test module is active" do
-      it "activates the test module" do
-        subject.activate_test_module!(test_module)
-        expect(subject.active_test_module).to be(test_module)
-      end
-    end
-  end
-
   describe "active_test_module" do
     context "when a test module is active" do
       before do
-        subject.activate_test_module!(test_module)
+        subject.fetch_or_activate_test_module { test_module }
       end
 
       it "returns the active test module" do
@@ -153,7 +103,7 @@ RSpec.describe Datadog::CI::Context::Global do
   describe "#deactivate_test_module!" do
     context "when a test module is active" do
       before do
-        subject.activate_test_module!(test_module)
+        subject.fetch_or_activate_test_module { test_module }
       end
 
       it "deactivates the test module" do

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -309,7 +309,7 @@ RSpec.describe Datadog::CI::Recorder do
             end
 
             it "connects the test span to the test session" do
-              expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(test_session.id.to_s)
+              expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID).to_s).to eq(test_session.id.to_s)
             end
 
             it "starts a new trace" do
@@ -352,7 +352,7 @@ RSpec.describe Datadog::CI::Recorder do
             end
 
             it "connects the test span to the test module" do
-              expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID)).to eq(test_module.id.to_s)
+              expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID).to_s).to eq(test_module.id.to_s)
               expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_MODULE)).to eq(module_name)
             end
 
@@ -366,7 +366,7 @@ RSpec.describe Datadog::CI::Recorder do
               end
 
               it "connects the test span to the test suite" do
-                expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(test_suite.id.to_s)
+                expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID).to_s).to eq(test_suite.id.to_s)
                 expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(test_suite_name)
               end
             end
@@ -429,7 +429,7 @@ RSpec.describe Datadog::CI::Recorder do
       end
 
       it "sets the test session id" do
-        expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(subject.id.to_s)
+        expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID).to_s).to eq(subject.id.to_s)
       end
 
       it "sets the provided tags correctly" do
@@ -465,7 +465,7 @@ RSpec.describe Datadog::CI::Recorder do
         end
 
         it "sets the test module id" do
-          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID)).to eq(subject.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID).to_s).to eq(subject.id.to_s)
         end
 
         it "sets the test module tag" do
@@ -517,7 +517,7 @@ RSpec.describe Datadog::CI::Recorder do
         end
 
         it "connects the test module span to the test session" do
-          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(test_session.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID).to_s).to eq(test_session.id.to_s)
         end
 
         it "does not start a new trace" do
@@ -559,13 +559,13 @@ RSpec.describe Datadog::CI::Recorder do
         end
 
         it "sets the test suite context" do
-          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(subject.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID).to_s).to eq(subject.id.to_s)
           expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(suite_name)
         end
 
         it "sets test session and test module contexts" do
-          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(test_session.id.to_s)
-          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID)).to eq(test_module.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID).to_s).to eq(test_session.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID).to_s).to eq(test_module.id.to_s)
           expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_MODULE)).to eq(module_name)
         end
 

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -136,6 +136,38 @@ RSpec.describe Datadog::CI::Recorder do
         expect(recorder.active_test_module).to be_nil
       end
     end
+
+    describe "#trace_test_suite" do
+      let(:suite_name) { "my-module" }
+
+      subject { recorder.start_test_suite(suite_name, service_name: service_name, tags: tags) }
+
+      it { is_expected.to be_kind_of(Datadog::CI::NullSpan) }
+
+      it "does not activate test suite" do
+        expect(recorder.active_test_suite(suite_name)).to be_nil
+      end
+    end
+
+    describe "#trace" do
+      let(:span_type) { "step" }
+      let(:span_name) { "my test step" }
+      let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
+
+      context "when given a block" do
+        before do
+          recorder.trace(span_type, span_name, tags: tags) do |span|
+            span.set_metric("my.metric", 42)
+          end
+        end
+        subject { span }
+
+        it "traces the block" do
+          expect(subject.resource).to eq(span_name)
+          expect(subject.span_type).to eq(span_type)
+        end
+      end
+    end
   end
 
   context "when test suite level visibility is enabled" do
@@ -458,6 +490,72 @@ RSpec.describe Datadog::CI::Recorder do
 
         it "does not start a new trace" do
           expect(subject.tracer_span.trace_id).to eq(test_session.tracer_span.trace_id)
+        end
+      end
+    end
+
+    describe "start_test_suite" do
+      let(:module_name) { "my-module" }
+      let(:session_service_name) { "session_service_name" }
+      let(:session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
+
+      let(:test_session) { recorder.start_test_session(service_name: session_service_name, tags: session_tags) }
+      let(:test_module) { recorder.start_test_module(module_name) }
+
+      before do
+        test_session
+        test_module
+      end
+
+      context "when test suite with given name is not started yet" do
+        let(:suite_name) { "my-suite" }
+        let(:tags) { {"my.tag" => "my_value"} }
+
+        subject { recorder.start_test_suite(suite_name, tags: tags) }
+
+        it "returns a new CI test_suite span" do
+          expect(subject).to be_kind_of(Datadog::CI::TestSuite)
+          expect(subject.name).to eq(suite_name)
+          expect(subject.service).to eq(session_service_name)
+          expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
+        end
+
+        it "sets the provided tags correctly while inheriting some tags from the session" do
+          expect(subject.get_tag("test.framework_version")).to eq("1.0")
+          expect(subject.get_tag("my.tag")).to eq("my_value")
+          expect(subject.get_tag("my.session.tag")).to be_nil
+        end
+
+        it "sets the test suite context" do
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(subject.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(suite_name)
+        end
+
+        it "sets test session and test module contexts" do
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(test_session.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID)).to eq(test_module.id.to_s)
+          expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_MODULE)).to eq(module_name)
+        end
+
+        it_behaves_like "span with environment tags"
+        it_behaves_like "span with default tags"
+        it_behaves_like "span with runtime tags"
+      end
+
+      context "when test suite with given name is already started" do
+        let(:suite_name) { "my-suite" }
+        let(:tags) { {"my.tag" => "my_value"} }
+        let(:already_running_test_suite) { recorder.start_test_suite(suite_name, tags: tags) }
+
+        before do
+          already_running_test_suite
+        end
+
+        subject { recorder.start_test_suite(suite_name) }
+
+        it "returns the already running test suite" do
+          expect(subject.id).to eq(already_running_test_suite.id)
+          expect(subject.get_tag("my.tag")).to eq("my_value")
         end
       end
     end

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -741,5 +741,25 @@ RSpec.describe Datadog::CI::Recorder do
         end
       end
     end
+
+    describe "#deactivate_test_suite" do
+      subject { recorder.deactivate_test_suite("my suite") }
+
+      context "when there is no active test suite" do
+        it { is_expected.to be_nil }
+      end
+
+      context "when deactivating the currently active test suite" do
+        before do
+          recorder.start_test_suite("my suite")
+        end
+
+        it "deactivates the test suite" do
+          subject
+
+          expect(recorder.active_test_suite("my suite")).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/datadog/ci/test_suite_spec.rb
+++ b/spec/datadog/ci/test_suite_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe Datadog::CI::TestSuite do
+  let(:test_suite_name) { "my.suite" }
+  let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, finish: true, name: test_suite_name) }
+
+  describe "#finish" do
+    subject(:ci_test_suite) { described_class.new(tracer_span) }
+
+    before { allow(Datadog::CI).to receive(:deactivate_test_suite) }
+
+    it "deactivates the test suite" do
+      ci_test_suite.finish
+
+      expect(Datadog::CI).to have_received(:deactivate_test_suite).with(test_suite_name)
+    end
+  end
+end

--- a/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLev
       it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSession) }
     end
 
+    context "with a module span" do
+      let(:ci_span) { test_module_span }
+      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestModule) }
+    end
+
+    context "with a suite span" do
+      let(:ci_span) { test_suite_span }
+      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSuite) }
+    end
+
     context "with a test span" do
       let(:ci_span) { first_test_span }
       it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestV2) }

--- a/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
         expect(content).to include(
           {
-            "test_session_id" => test_session_span.id.to_s,
-            "test_module_id" => test_module_span.id.to_s,
+            "test_session_id" => test_session_span.id,
+            "test_module_id" => test_module_span.id,
             "name" => "rspec.test_module",
             "service" => "rspec-test-suite",
             "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE,

--- a/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
 
         expect(content).to include(
           {
-            "test_session_id" => test_session_span.id.to_s,
+            "test_session_id" => test_session_span.id,
             "name" => "rspec.test_session",
             "service" => "rspec-test-suite",
             "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION,

--- a/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
@@ -1,10 +1,10 @@
-RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
+RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSuite do
   include_context "CI mode activated" do
     let(:integration_name) { :rspec }
   end
 
   include_context "Test visibility event serialized" do
-    subject { described_class.new(trace_for_span(test_module_span), test_module_span) }
+    subject { described_class.new(trace_for_span(test_suite_span), test_suite_span) }
   end
 
   describe "#to_msgpack" do
@@ -13,17 +13,19 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
         produce_test_session_trace
       end
 
-      it "serializes test module event to messagepack" do
-        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
+      it "serializes test suite event to messagepack" do
+        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
 
         expect(content).to include(
           {
             "test_session_id" => test_session_span.id.to_s,
             "test_module_id" => test_module_span.id.to_s,
-            "name" => "rspec.test_module",
+            "test_suite_id" => test_suite_span.id.to_s,
+            "name" => "rspec.test_suite",
+            "error" => 0,
             "service" => "rspec-test-suite",
-            "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE,
-            "resource" => "rspec.test_module.arithmetic"
+            "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE,
+            "resource" => "rspec.test_suite.calculator_tests"
           }
         )
 
@@ -31,6 +33,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
           {
             "test.command" => test_command,
             "test.module" => "arithmetic",
+            "test.suite" => "calculator_tests",
             "test.framework" => "rspec",
             "test.framework_version" => "1.0.0",
             "test.type" => "test",
@@ -41,6 +44,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
         expect(meta["_test.session_id"]).to be_nil
         expect(meta["_test.module_id"]).to be_nil
+        expect(meta["_test.suite_id"]).to be_nil
       end
     end
 
@@ -50,7 +54,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
       end
 
       it "has error" do
-        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
+        expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
 
         expect(content).to include({"error" => 1})
         expect(meta).to include({"test.status" => "fail"})
@@ -72,7 +76,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
       context "when test_session_id is nil" do
         before do
-          test_module_span.clear_tag("_test.session_id")
+          test_suite_span.clear_tag("_test.session_id")
         end
 
         it "returns false" do
@@ -94,7 +98,29 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
       context "when test_module_id is nil" do
         before do
-          test_module_span.clear_tag("_test.module_id")
+          test_suite_span.clear_tag("_test.module_id")
+        end
+
+        it "returns false" do
+          expect(subject.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "test_suite_id" do
+      before do
+        produce_test_session_trace
+      end
+
+      context "when test_suite_id is not nil" do
+        it "returns true" do
+          expect(subject.valid?).to eq(true)
+        end
+      end
+
+      context "when test_suite_id is nil" do
+        before do
+          test_suite_span.clear_tag("_test.suite_id")
         end
 
         it "returns false" do

--- a/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSuite do
 
         expect(content).to include(
           {
-            "test_session_id" => test_session_span.id.to_s,
-            "test_module_id" => test_module_span.id.to_s,
-            "test_suite_id" => test_suite_span.id.to_s,
+            "test_session_id" => test_session_span.id,
+            "test_module_id" => test_module_span.id,
+            "test_suite_id" => test_suite_span.id,
             "name" => "rspec.test_suite",
             "error" => 0,
             "service" => "rspec-test-suite",

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -27,9 +27,9 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
             "service" => "rspec-test-suite",
             "type" => "test",
             "resource" => "calculator_tests.test_add.run.0",
-            "test_session_id" => test_session_span.id.to_s,
-            "test_module_id" => test_module_span.id.to_s,
-            "test_suite_id" => test_suite_span.id.to_s
+            "test_session_id" => test_session_span.id,
+            "test_module_id" => test_module_span.id,
+            "test_suite_id" => test_suite_span.id
           }
         )
 
@@ -70,7 +70,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
               "service" => "rspec-test-suite",
               "type" => "test",
               "resource" => "calculator_tests.test_add.run.#{index}",
-              "test_session_id" => test_session_span.id.to_s
+              "test_session_id" => test_session_span.id
             }
           )
         end

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
             "type" => "test",
             "resource" => "calculator_tests.test_add.run.0",
             "test_session_id" => test_session_span.id.to_s,
-            "test_module_id" => test_module_span.id.to_s
+            "test_module_id" => test_module_span.id.to_s,
+            "test_suite_id" => test_suite_span.id.to_s
           }
         )
 
@@ -148,6 +149,28 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
       context "when test_module_id is nil" do
         before do
           first_test_span.clear_tag("_test.module_id")
+        end
+
+        it "returns false" do
+          expect(subject.valid?).to eq(false)
+        end
+      end
+    end
+
+    context "test_suite_id" do
+      before do
+        produce_test_session_trace
+      end
+
+      context "when test_suite_id is not nil" do
+        it "returns true" do
+          expect(subject.valid?).to eq(true)
+        end
+      end
+
+      context "when test_suite_id is nil" do
+        before do
+          first_test_span.clear_tag("_test.suite_id")
         end
 
         it "returns false" do

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -168,4 +168,42 @@ RSpec.describe Datadog::CI do
 
     it { is_expected.to be_nil }
   end
+
+  describe "::start_test_suite" do
+    subject(:start_test_suite) { described_class.start_test_suite("my-suite") }
+
+    let(:ci_test_suite) { instance_double(Datadog::CI::TestSuite) }
+
+    before do
+      allow(recorder).to(
+        receive(:start_test_suite).with("my-suite", service_name: nil, tags: {}).and_return(ci_test_suite)
+      )
+    end
+
+    it { is_expected.to be(ci_test_suite) }
+  end
+
+  describe "::active_test_suite" do
+    let(:test_suite_name) { "my-suite" }
+    subject(:active_test_suite) { described_class.active_test_suite(test_suite_name) }
+
+    let(:ci_test_suite) { instance_double(Datadog::CI::TestSuite) }
+
+    before do
+      allow(recorder).to receive(:active_test_suite).with(test_suite_name).and_return(ci_test_suite)
+    end
+
+    it { is_expected.to be(ci_test_suite) }
+  end
+
+  describe "::deactivate_test_suite" do
+    let(:test_suite_name) { "my-suite" }
+    subject(:deactivate_test_suite) { described_class.deactivate_test_suite(test_suite_name) }
+
+    before do
+      allow(recorder).to receive(:deactivate_test_suite).with(test_suite_name)
+    end
+
+    it { is_expected.to be_nil }
+  end
 end

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe Datadog::CI do
   end
 
   describe "::trace_test" do
-    subject(:trace_test) { described_class.trace_test(test_name, **options, &block) }
+    subject(:trace_test) { described_class.trace_test(test_name, test_suite_name, **options, &block) }
 
     let(:test_name) { "test name" }
+    let(:test_suite_name) { "test suite name" }
     let(:options) do
       {
         service_name: "my-serivce",
@@ -21,16 +22,17 @@ RSpec.describe Datadog::CI do
     let(:ci_test) { instance_double(Datadog::CI::Test) }
 
     before do
-      allow(recorder).to receive(:trace_test).with(test_name, **options, &block).and_return(ci_test)
+      allow(recorder).to receive(:trace_test).with(test_name, test_suite_name, **options, &block).and_return(ci_test)
     end
 
     it { is_expected.to be(ci_test) }
   end
 
   describe "::start_test" do
-    subject(:start_test) { described_class.start_test(test_name, **options) }
+    subject(:start_test) { described_class.start_test(test_name, test_suite_name, **options) }
 
     let(:test_name) { "test name" }
+    let(:test_suite_name) { "test suite name" }
     let(:options) do
       {
         service_name: "my-serivce",
@@ -42,7 +44,7 @@ RSpec.describe Datadog::CI do
     let(:ci_test) { instance_double(Datadog::CI::Test) }
 
     before do
-      allow(recorder).to receive(:trace_test).with(test_name, **options).and_return(ci_test)
+      allow(recorder).to receive(:trace_test).with(test_name, test_suite_name, **options).and_return(ci_test)
     end
 
     it { is_expected.to be(ci_test) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ require_relative "support/git_helpers"
 require_relative "support/provider_test_helpers"
 require_relative "support/ci_mode_helpers"
 require_relative "support/test_visibility_event_serialized"
+require_relative "support/concurrency_helpers"
 
 require "rspec/collection_matchers"
 require "climate_control"

--- a/spec/support/concurrency_helpers.rb
+++ b/spec/support/concurrency_helpers.rb
@@ -1,0 +1,18 @@
+RSpec.shared_context "Concurrency test" do
+  let(:threads_count) { 10 }
+  let(:repeat_count) { 20 }
+
+  def repeat
+    repeat_count.times do
+      yield
+    end
+  end
+
+  def run_concurrently
+    (1..threads_count).map do
+      Thread.new do
+        yield
+      end
+    end.map(&:join)
+  end
+end

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -25,11 +25,11 @@ module TracerHelpers
 
     Datadog::CI.trace_test(
       test_name,
+      test_suite,
       tags: {
         Datadog::CI::Ext::Test::TAG_FRAMEWORK => framework,
         Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION => "1.0.0",
-        Datadog::CI::Ext::Test::TAG_TYPE => "test",
-        Datadog::CI::Ext::Test::TAG_SUITE => test_suite
+        Datadog::CI::Ext::Test::TAG_TYPE => "test"
       },
       service_name: service,
       operation_name: operation

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -74,6 +74,8 @@ module TracerHelpers
 
     test_module = Datadog::CI.start_test_module(test_module_name)
 
+    test_suite_span = Datadog::CI.start_test_suite(test_suite)
+
     tests_count.times do |num|
       produce_test_trace(
         framework: framework, operation: operation,
@@ -86,9 +88,11 @@ module TracerHelpers
       )
     end
 
+    set_result(test_suite_span, result: result, exception: exception, skip_reason: skip_reason)
     set_result(test_module, result: result, exception: exception, skip_reason: skip_reason)
     set_result(test_session, result: result, exception: exception, skip_reason: skip_reason)
 
+    test_suite_span.finish
     test_module.finish
     test_session.finish
   end
@@ -99,6 +103,10 @@ module TracerHelpers
 
   def test_module_span
     spans.find { |span| span.type == "test_module_end" }
+  end
+
+  def test_suite_span
+    spans.find { |span| span.type == "test_suite_end" }
   end
 
   def first_test_span


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for test suites when test suite level visibility is enabled and a manual API to trace it.

To start a test suite:

```ruby
Datadog::CI.start_test_suite(test_suite_name)
```

To get an active test suite and finish it:
```ruby
test_suite = Datadog::CI.active_test_suite(test_suite_name)
test_suite.passed!
test_suite.finish
```

It supports running multiple test suites in parallel inside a process.

**How to test the change?**
Gist for testing: 
https://gist.github.com/anmarchenko/b58ebb39fe2f9e391344d7d66212e3da

Produces the following session trace:
<img width="1727" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/f28bf702-3c27-4045-8778-81fb8fade09d">
