### PR TITLE
support validation errors for CI spans

### DIFF
--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -182,6 +182,10 @@ module Datadog
             (duration * 1e9).to_i
           end
 
+          def to_s
+            "#{self.class.name}(id:#{span_id},name:#{name})"
+          end
+
           def to_integer(value)
             value.to_i if value
           end

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -94,15 +94,15 @@ module Datadog
 
             if encoded.size > max_payload_size
               # This single event is too large, we can't flush it
-              Datadog.logger.debug { "Dropping test event. Payload too large: '#{span.inspect}'" }
-              Datadog.logger.debug { encoded }
+              Datadog.logger.warn("Dropping test event. Payload too large: '#{span.inspect}'")
+              Datadog.logger.warn(encoded)
 
               return nil
             end
 
             encoded
           else
-            Datadog.logger.warn("Invalid event skipped: #{serializer}")
+            Datadog.logger.warn("Invalid event skipped: #{serializer} Errors: #{serializer.validation_errors}")
             nil
           end
         end

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -102,7 +102,7 @@ module Datadog
 
             encoded
           else
-            Datadog.logger.debug { "Invalid span skipped: #{span}" }
+            Datadog.logger.warn("Invalid event skipped: #{serializer}")
             nil
           end
         end

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -14,15 +14,21 @@ module Datadog
           @start: Integer
           @duration: Integer
           @meta: Hash[untyped, untyped]
+          @errors: Hash[String, Set[String]]
+          @validated: bool
 
           attr_reader trace: Datadog::Tracing::TraceSegment
           attr_reader span: Datadog::Tracing::Span
+          attr_reader meta: Hash[untyped, untyped]
 
           def initialize: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> void
 
           def to_msgpack: (?untyped? packer) -> untyped
 
           def valid?: () -> bool
+          def validate!: () -> void
+          def validation_errors: () -> Hash[String, Set[String]]
+
           def content_fields: () -> ::Array[String | Hash[String, String]]
           def content_map_size: () -> Integer
 
@@ -56,8 +62,6 @@ module Datadog
 
           def duration: () -> Integer
 
-          def meta: () -> Hash[String, untyped]
-
           def metrics: () -> Hash[String, untyped]
 
           def error: () -> Integer
@@ -66,9 +70,14 @@ module Datadog
 
           private
 
-          def valid_start_time?: () -> bool
-          def valid_duration?: () -> bool
-          def required_fields_present?: () -> bool
+          def validate_start_time!: () -> void
+          def validate_duration!: () -> void
+          def validate_required_fields!: () -> void
+          def validate_required!: (String field) -> void
+          def validate_greater_than_or_equal!: (String field, Integer value) -> void
+          def validate_less_than_or_equal!: (String field, Integer value) -> void
+          def add_error: (String field, String message) -> void
+
           def required_fields: () -> Array[String]
 
           def write_field: (untyped packer, String field_name, ?String? method) -> untyped

--- a/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
         it "returns false" do
           expect(subject.valid?).to eq(false)
+          expect(subject.validation_errors["test_session_id"]).to include("is required")
         end
       end
     end
@@ -99,6 +100,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
 
         it "returns false" do
           expect(subject.valid?).to eq(false)
+          expect(subject.validation_errors["test_module_id"]).to include("is required")
         end
       end
     end

--- a/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
@@ -91,12 +91,22 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
         let(:duration) { -1 }
 
         it { is_expected.not_to be_valid }
+
+        it "includes validation error" do
+          subject.valid?
+          expect(subject.validation_errors["duration"]).to include("must be greater than or equal to 0")
+        end
       end
 
       context "when too big" do
         let(:duration) { Datadog::CI::TestVisibility::Serializers::Base::MAXIMUM_DURATION_NANO + 1 }
 
         it { is_expected.not_to be_valid }
+
+        it "includes validation error" do
+          subject.valid?
+          expect(subject.validation_errors["duration"]).to include("must be less than or equal to 9223372036854775807")
+        end
       end
     end
 
@@ -116,6 +126,11 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
         let(:start_time) { Time.at(0) }
 
         it { is_expected.not_to be_valid }
+
+        it "has validation error" do
+          subject.valid?
+          expect(subject.validation_errors["start"]).to include("must be greater than or equal to 946684800000000000")
+        end
       end
     end
   end

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -112,7 +112,9 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
           subject.send_traces(traces)
 
           expect(Datadog.logger).to have_received(:warn).with(
-            "Invalid event skipped: Datadog::CI::TestVisibility::Serializers::Span(id:#{http_span.id},name:#{http_span.name})"
+            "Invalid event skipped: " \
+            "Datadog::CI::TestVisibility::Serializers::Span(id:#{http_span.id},name:#{http_span.name}) " \
+            "Errors: {\"start\"=>#<Set: {\"must be greater than or equal to 946684800000000000\"}>}"
           )
         end
       end


### PR DESCRIPTION
**Motivation**
Currently we don't see any feedback when invalid events are being discarded during serialization phase. This behaviour was inherited from ddtrace-rb where such errors are only emitted in debug mode.

For CI visibility library it is very important to report all the spans, so skipping invalid spans is a serious error that requires an action.

**What does this PR do?**
- Elevates logging level for invalid spans skipping to WARN
- Now event serializer stores validation errors so that they could be logged for easier debugging

**How to test the change?**
Unit tests are provided