### PR TITLE
Validate DD_SITE variable

### DIFF
--- a/lib/datadog/ci/ext/settings.rb
+++ b/lib/datadog/ci/ext/settings.rb
@@ -9,6 +9,16 @@ module Datadog
         ENV_AGENTLESS_MODE_ENABLED = "DD_CIVISIBILITY_AGENTLESS_ENABLED"
         ENV_AGENTLESS_URL = "DD_CIVISIBILITY_AGENTLESS_URL"
         ENV_EXPERIMENTAL_TEST_SUITE_LEVEL_VISIBILITY_ENABLED = "DD_CIVISIBILITY_EXPERIMENTAL_TEST_SUITE_LEVEL_VISIBILITY_ENABLED"
+
+        # Source: https://docs.datadoghq.com/getting_started/site/
+        DD_SITE_ALLOWLIST = [
+          "datadoghq.com",
+          "us3.datadoghq.com",
+          "us5.datadoghq.com",
+          "datadoghq.eu",
+          "ddog-gov.com",
+          "ap1.datadoghq.com"
+        ].freeze
       end
     end
   end

--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -14,6 +14,7 @@ module Datadog
         def build_evp_proxy_transport: (untyped settings, untyped agent_settings) -> Datadog::CI::TestVisibility::Transport
         def can_use_evp_proxy?: (untyped settings, untyped agent_settings) -> bool
         def serializers_factory: (untyped settings) -> (singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel))
+        def check_dd_site: (untyped settings) -> void
       end
     end
   end

--- a/sig/datadog/ci/ext/settings.rbs
+++ b/sig/datadog/ci/ext/settings.rbs
@@ -6,6 +6,8 @@ module Datadog
         ENV_AGENTLESS_MODE_ENABLED: String
         ENV_AGENTLESS_URL: String
         ENV_EXPERIMENTAL_TEST_SUITE_LEVEL_VISIBILITY_ENABLED: String
+
+        DD_SITE_ALLOWLIST: Array[String]
       end
     end
   end


### PR DESCRIPTION
Closes #62

**What does this PR do?**
Validates that DD_SITE variable has one of the allowed values as defined by [docs](https://docs.datadoghq.com/getting_started/site/) and emits warning in logs otherwise

**Motivation**
More often than not users are confused by DD_SITE setting required by Agentless mode (when not using default datadog site). 

This validation is supposed to help users to debug this issue themselves by calling out invalid setting in the logs.

**How to test the change?**
Unit tests are provided or: set DD_SITE to any wrong value and run tests with CI visibility enabled