### PR TITLE
Document how to use WebMock with datadog-ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ they will **not** show up in Datadog APM.
 
 For the full list of available instrumentations see [ddtrace documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md)
 
-### Webmock
+### WebMock
 
-[Webmock](https://github.com/bblimke/webmock)
+[WebMock](https://github.com/bblimke/webmock)
 is a popular Ruby library that stubs HTTP requests when running tests.
 By default it fails when used together with datadog-ci as traces are being sent
 to Datadog via HTTP calls.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,28 @@ they will **not** show up in Datadog APM.
 
 For the full list of available instrumentations see [ddtrace documentation](https://github.com/DataDog/dd-trace-rb/blob/master/docs/GettingStarted.md)
 
+### Webmock
+
+[Webmock](https://github.com/bblimke/webmock)
+is a popular Ruby library that stubs HTTP requests when running tests.
+By default it fails when used together with datadog-ci as traces are being sent
+to Datadog via HTTP calls.
+
+In order to allow HTTP connections for Datadog backend you would need to configure
+Webmock accordingly.
+
+```ruby
+# when using agentless mode
+# note to use the correct datadog site (e.g. datadoghq.eu, etc)
+WebMock.disable_net_connect!(:allow => "citestcycle-intake.datadoghq.com")
+
+# when using agent
+WebMock.disable_net_connect!(:allow_localhost => true)
+
+# or for more granular setting set your agent URL
+WebMock.disable_net_connect!(:allow => "localhost:8126")
+```
+
 ### Disabling startup logs
 
 Startup logs produce a report of tracing state when the application is initially configured.


### PR DESCRIPTION
Closes #63
**What does this PR do?**
Adds a short instruction to README about configuring webmock with CI visibility to allow HTTP requests to agent or Datadog backend

