### PR TITLE
Deprecate operation name setting, change service_name to service in public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether RSpec tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `rspec` instrumentation. | `'rspec'` |
-| `operation_name` | Operation name used for `rspec` instrumentation. | `'rspec.example'` |
+| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `rspec` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'rspec.example'` |
 
 ### Minitest
 
@@ -84,7 +84,7 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether Minitest tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `minitest` instrumentation. | `'minitest'` |
-| `operation_name` | Operation name used for `minitest` instrumentation. | `'minitest.test'` |
+| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `minitest` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'minitest.test'` |
 
 ### Cucumber
 
@@ -115,7 +115,7 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether Cucumber tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `cucumber` instrumentation. | `'cucumber'` |
-| `operation_name` | Operation name used for `cucumber` instrumentation. | `'cucumber.test'` |
+| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `cucumber` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'cucumber.test'` |
 
 ## Agentless mode
 

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -189,7 +189,6 @@ module Datadog
       # Datadog::CI.trace_test(
       #   "test_add_two_numbers",
       #   service_name: "my-web-site-tests",
-      #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # ) do |ci_test|
       #   result = run_test
@@ -207,7 +206,6 @@ module Datadog
       # ci_test = Datadog::CI.trace_test(
       #   "test_add_two_numbers',
       #   service_name: "my-web-site-tests",
-      #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       # run_test
@@ -218,7 +216,6 @@ module Datadog
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
       # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
-      # @param [String] operation_name defines label for a test span in trace view ("test" if it's missing)
       # @param [String] service_name the service name for this test
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Object] If a block is provided, returns the result of the block execution.
@@ -230,8 +227,8 @@ module Datadog
       # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def trace_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {}, &block)
-        recorder.trace_test(test_name, test_suite_name, service_name: service_name, operation_name: operation_name, tags: tags, &block)
+      def trace_test(test_name, test_suite_name, service_name: nil, tags: {}, &block)
+        recorder.trace_test(test_name, test_suite_name, service_name: service_name, tags: tags, &block)
       end
 
       # Same as {#trace_test} but it does not accept a block.
@@ -243,7 +240,6 @@ module Datadog
       # ci_test = Datadog::CI.start_test(
       #   "test_add_two_numbers',
       #   service_name: "my-web-site-tests",
-      #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       # run_test
@@ -252,15 +248,14 @@ module Datadog
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
       # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
-      # @param [String] operation_name the resource this span refers, or `test` if it's missing
       # @param [String] service_name the service name for this span.
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Datadog::CI::Test] Returns the active, unfinished {Datadog::CI::Test}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def start_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {})
-        recorder.trace_test(test_name, test_suite_name, service_name: service_name, operation_name: operation_name, tags: tags)
+      def start_test(test_name, test_suite_name, service_name: nil, tags: {})
+        recorder.trace_test(test_name, test_suite_name, service_name: service_name, tags: tags)
       end
 
       # Trace any custom span inside a test. For example, you could trace:
@@ -345,7 +340,6 @@ module Datadog
       # Datadog::CI.start_test(
       #   "test_add_two_numbers',
       #   service_name: "my-web-site-tests",
-      #   operation_name: "test",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -20,7 +20,7 @@ module Datadog
       # The {#start_test_session} method is used to mark the start of the test session:
       # ```
       # Datadog::CI.start_test_session(
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -30,16 +30,16 @@ module Datadog
       #
       # Remember that calling {Datadog::CI::TestSession#finish} is mandatory.
       #
-      # @param [String] service_name the service name for this session (optional, defaults to DD_SERVICE)
+      # @param [String] service the service name for this session (optional, defaults to DD_SERVICE)
       # @param [Hash<String,String>] tags extra tags which should be added to the test session.
       # @return [Datadog::CI::TestSession] returns the active, running {Datadog::CI::TestSession}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled or if old Datadog agent is
       #         detected and test suite level visibility cannot be supported.
       #
       # @public_api
-      def start_test_session(service_name: nil, tags: {})
-        service_name ||= Datadog.configuration.service
-        recorder.start_test_session(service_name: service_name, tags: tags)
+      def start_test_session(service: nil, tags: {})
+        service ||= Datadog.configuration.service
+        recorder.start_test_session(service: service, tags: tags)
       end
 
       # The active, unfinished test session.
@@ -49,7 +49,7 @@ module Datadog
       # ```
       # # start a test session
       # Datadog::CI.start_test_session(
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -77,7 +77,7 @@ module Datadog
       # ```
       # Datadog::CI.start_test_module(
       #   "my-module",
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -88,15 +88,15 @@ module Datadog
       # Remember that calling {Datadog::CI::TestModule#finish} is mandatory.
       #
       # @param [String] test_module_name the name for this module
-      # @param [String] service_name the service name for this session (optional, inherited from test session if not provided)
+      # @param [String] service the service name for this session (optional, inherited from test session if not provided)
       # @param [Hash<String,String>] tags extra tags which should be added to the test module (optional, some tags are inherited from test session).
       # @return [Datadog::CI::TestModule] returns the active, running {Datadog::CI::TestModule}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled or if old Datadog agent is
       #         detected and test suite level visibility cannot be supported.
       #
       # @public_api
-      def start_test_module(test_module_name, service_name: nil, tags: {})
-        recorder.start_test_module(test_module_name, service_name: service_name, tags: tags)
+      def start_test_module(test_module_name, service: nil, tags: {})
+        recorder.start_test_module(test_module_name, service: service, tags: tags)
       end
 
       # The active, unfinished test module.
@@ -107,7 +107,7 @@ module Datadog
       # # start a test module
       # Datadog::CI.start_test_module(
       #   "my-module",
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -132,7 +132,7 @@ module Datadog
       # ```
       # Datadog::CI.start_test_suite(
       #   "calculator_tests",
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -143,15 +143,15 @@ module Datadog
       # Remember that calling {Datadog::CI::TestSuite#finish} is mandatory.
       #
       # @param [String] test_suite_name the name of the test suite
-      # @param [String] service_name the service name for this test suite (optional, inherited from test session if not provided)
+      # @param [String] service the service name for this test suite (optional, inherited from test session if not provided)
       # @param [Hash<String,String>] tags extra tags which should be added to the test module (optional, some tags are inherited from test session)
       # @return [Datadog::CI::TestSuite] returns the active, running {Datadog::CI::TestSuite}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled or if old Datadog agent is
       #         detected and test suite level visibility cannot be supported.
       #
       # @public_api
-      def start_test_suite(test_suite_name, service_name: nil, tags: {})
-        recorder.start_test_suite(test_suite_name, service_name: service_name, tags: tags)
+      def start_test_suite(test_suite_name, service: nil, tags: {})
+        recorder.start_test_suite(test_suite_name, service: service, tags: tags)
       end
 
       # The active, unfinished test suite.
@@ -162,7 +162,7 @@ module Datadog
       # # start a test suite
       # Datadog::CI.start_test_suite(
       #   "calculator_tests",
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #
@@ -188,7 +188,7 @@ module Datadog
       # ```
       # Datadog::CI.trace_test(
       #   "test_add_two_numbers",
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # ) do |ci_test|
       #   result = run_test
@@ -205,7 +205,7 @@ module Datadog
       # ```
       # ci_test = Datadog::CI.trace_test(
       #   "test_add_two_numbers',
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       # run_test
@@ -216,7 +216,7 @@ module Datadog
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
       # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
-      # @param [String] service_name the service name for this test
+      # @param [String] service the service name for this test
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Object] If a block is provided, returns the result of the block execution.
       # @return [Datadog::CI::Test] If no block is provided, returns the active,
@@ -227,8 +227,8 @@ module Datadog
       # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def trace_test(test_name, test_suite_name, service_name: nil, tags: {}, &block)
-        recorder.trace_test(test_name, test_suite_name, service_name: service_name, tags: tags, &block)
+      def trace_test(test_name, test_suite_name, service: nil, tags: {}, &block)
+        recorder.trace_test(test_name, test_suite_name, service: service, tags: tags, &block)
       end
 
       # Same as {#trace_test} but it does not accept a block.
@@ -239,7 +239,7 @@ module Datadog
       # ```
       # ci_test = Datadog::CI.start_test(
       #   "test_add_two_numbers',
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       # run_test
@@ -248,14 +248,14 @@ module Datadog
       #
       # @param [String] test_name {Datadog::CI::Test} name (example: "test_add_two_numbers").
       # @param [String] test_suite_name name of test suite this test belongs to (example: "CalculatorTest").
-      # @param [String] service_name the service name for this span.
+      # @param [String] service the service name for this span.
       # @param [Hash<String,String>] tags extra tags which should be added to the test.
       # @return [Datadog::CI::Test] Returns the active, unfinished {Datadog::CI::Test}.
       # @return [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
       #
       # @public_api
-      def start_test(test_name, test_suite_name, service_name: nil, tags: {})
-        recorder.trace_test(test_name, test_suite_name, service_name: service_name, tags: tags)
+      def start_test(test_name, test_suite_name, service: nil, tags: {})
+        recorder.trace_test(test_name, test_suite_name, service: service, tags: tags)
       end
 
       # Trace any custom span inside a test. For example, you could trace:
@@ -339,7 +339,7 @@ module Datadog
       # # start a test
       # Datadog::CI.start_test(
       #   "test_add_two_numbers',
-      #   service_name: "my-web-site-tests",
+      #   service: "my-web-site-tests",
       #   tags: { Datadog::CI::Ext::Test::TAG_FRAMEWORK => "my-test-framework" }
       # )
       #

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "datadog/core"
+
 require_relative "../ext"
 require_relative "../../settings"
 
@@ -26,6 +28,14 @@ module Datadog
               o.type :string
               o.env Ext::ENV_OPERATION_NAME
               o.default Ext::OPERATION_NAME
+
+              o.after_set do |value|
+                if value
+                  Datadog::Core.log_deprecation do
+                    "The operation_name setting has no effect and will be removed in 1.0"
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -30,7 +30,7 @@ module Datadog
               o.default Ext::OPERATION_NAME
 
               o.after_set do |value|
-                if value
+                if value && value != Ext::OPERATION_NAME
                   Datadog::Core.log_deprecation do
                     "The operation_name setting has no effect and will be removed in 1.0"
                   end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -35,8 +35,7 @@ module Datadog
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Cucumber::Integration.version.to_s,
                 CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
-              service_name: configuration[:service_name],
-              operation_name: configuration[:operation_name]
+              service_name: configuration[:service_name]
             )
           end
 

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -35,7 +35,7 @@ module Datadog
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Cucumber::Integration.version.to_s,
                 CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
-              service_name: configuration[:service_name]
+              service: configuration[:service_name]
             )
           end
 

--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
               o.default Ext::OPERATION_NAME
 
               o.after_set do |value|
-                if value
+                if value && value != Ext::OPERATION_NAME
                   Datadog::Core.log_deprecation do
                     "The operation_name setting has no effect and will be removed in 1.0"
                   end

--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -26,6 +26,14 @@ module Datadog
               o.type :string
               o.env Ext::ENV_OPERATION_NAME
               o.default Ext::OPERATION_NAME
+
+              o.after_set do |value|
+                if value
+                  Datadog::Core.log_deprecation do
+                    "The operation_name setting has no effect and will be removed in 1.0"
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -26,7 +26,7 @@ module Datadog
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s,
                 CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
-              service_name: configuration[:service_name]
+              service: configuration[:service_name]
             )
           end
 

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -26,8 +26,7 @@ module Datadog
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s,
                 CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
               },
-              service_name: configuration[:service_name],
-              operation_name: configuration[:operation_name]
+              service_name: configuration[:service_name]
             )
           end
 

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -28,7 +28,7 @@ module Datadog
               o.default Ext::OPERATION_NAME
 
               o.after_set do |value|
-                if value
+                if value && value != Ext::OPERATION_NAME
                   Datadog::Core.log_deprecation do
                     "The operation_name setting has no effect and will be removed in 1.0"
                   end

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -26,6 +26,14 @@ module Datadog
               o.type :string
               o.env Ext::ENV_OPERATION_NAME
               o.default Ext::OPERATION_NAME
+
+              o.after_set do |value|
+                if value
+                  Datadog::Core.log_deprecation do
+                    "The operation_name setting has no effect and will be removed in 1.0"
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -32,7 +32,7 @@ module Datadog
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
                   CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
                 },
-                service_name: configuration[:service_name]
+                service: configuration[:service_name]
               ) do |test_span|
                 result = super
 

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -32,8 +32,7 @@ module Datadog
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
                   CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
                 },
-                service_name: configuration[:service_name],
-                operation_name: configuration[:operation_name]
+                service_name: configuration[:service_name]
               ) do |test_span|
                 result = super
 

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -35,12 +35,12 @@ module Datadog
         @global_context = Context::Global.new
       end
 
-      def start_test_session(service_name: nil, tags: {})
+      def start_test_session(service: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
         @global_context.fetch_or_activate_test_session do
           tracer_span = start_datadog_tracer_span(
-            "test.session", build_span_options(service_name, Ext::AppTypes::TYPE_TEST_SESSION)
+            "test.session", build_span_options(service, Ext::AppTypes::TYPE_TEST_SESSION)
           )
           set_session_context(tags, tracer_span)
 
@@ -48,7 +48,7 @@ module Datadog
         end
       end
 
-      def start_test_module(test_module_name, service_name: nil, tags: {})
+      def start_test_module(test_module_name, service: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
         @global_context.fetch_or_activate_test_module do
@@ -56,7 +56,7 @@ module Datadog
           set_session_context(tags)
 
           tracer_span = start_datadog_tracer_span(
-            test_module_name, build_span_options(service_name, Ext::AppTypes::TYPE_TEST_MODULE)
+            test_module_name, build_span_options(service, Ext::AppTypes::TYPE_TEST_MODULE)
           )
           set_module_context(tags, tracer_span)
 
@@ -64,7 +64,7 @@ module Datadog
         end
       end
 
-      def start_test_suite(test_suite_name, service_name: nil, tags: {})
+      def start_test_suite(test_suite_name, service: nil, tags: {})
         return skip_tracing unless test_suite_level_visibility_enabled
 
         @global_context.fetch_or_activate_test_suite(test_suite_name) do
@@ -73,7 +73,7 @@ module Datadog
           set_module_context(tags)
 
           tracer_span = start_datadog_tracer_span(
-            test_suite_name, build_span_options(service_name, Ext::AppTypes::TYPE_TEST_SUITE)
+            test_suite_name, build_span_options(service, Ext::AppTypes::TYPE_TEST_SUITE)
           )
           set_suite_context(tags, span: tracer_span)
 
@@ -81,7 +81,7 @@ module Datadog
         end
       end
 
-      def trace_test(test_name, test_suite_name, service_name: nil, tags: {}, &block)
+      def trace_test(test_name, test_suite_name, service: nil, tags: {}, &block)
         return skip_tracing(block) unless enabled
 
         set_inherited_globals(tags)
@@ -92,7 +92,7 @@ module Datadog
         tags[Ext::Test::TAG_NAME] = test_name
 
         span_options = build_span_options(
-          service_name,
+          service,
           Ext::AppTypes::TYPE_TEST,
           # :resource is needed for the agent APM protocol to work correctly (for older agent versions)
           # :continue_from is required to start a new trace for each test
@@ -218,8 +218,8 @@ module Datadog
         span
       end
 
-      def build_span_options(service_name, span_type, other_options = {})
-        other_options[:service] = service_name || @global_context.service
+      def build_span_options(service, span_type, other_options = {})
+        other_options[:service] = service || @global_context.service
         other_options[:span_type] = span_type
 
         other_options

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -100,7 +100,7 @@ module Datadog
         )
 
         if block
-          start_datadog_tracer_span(operation_name, span_options) do |tracer_span|
+          start_datadog_tracer_span(test_name, span_options) do |tracer_span|
             test = build_test(tracer_span, tags)
 
             @local_context.activate_test!(test) do
@@ -108,7 +108,7 @@ module Datadog
             end
           end
         else
-          tracer_span = start_datadog_tracer_span(operation_name, span_options)
+          tracer_span = start_datadog_tracer_span(test_name, span_options)
 
           test = build_test(tracer_span, tags)
           @local_context.activate_test!(test)

--- a/lib/datadog/ci/recorder.rb
+++ b/lib/datadog/ci/recorder.rb
@@ -81,7 +81,7 @@ module Datadog
         end
       end
 
-      def trace_test(test_name, test_suite_name, service_name: nil, operation_name: "test", tags: {}, &block)
+      def trace_test(test_name, test_suite_name, service_name: nil, tags: {}, &block)
         return skip_tracing(block) unless enabled
 
         set_inherited_globals(tags)

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -1,14 +1,14 @@
 module Datadog
   module CI
-    def self.trace_test: (String test_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
+    def self.trace_test: (String test_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
 
-    def self.start_test: (String test_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test: (String test_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-    def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test_session: (?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-    def self.start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test_module: (String test_module_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-    def self.start_test_suite: (String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test_suite: (String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
     def self.trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -1,8 +1,8 @@
 module Datadog
   module CI
-    def self.trace_test: (String test_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
+    def self.trace_test: (String test_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span test) -> untyped } -> untyped
 
-    def self.start_test: (String test_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+    def self.start_test: (String test_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
     def self.start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -16,15 +16,15 @@ module Datadog
 
       def initialize: (?enabled: bool, ?test_suite_level_visibility_enabled: bool) -> void
 
-      def trace_test: (String span_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+      def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
       def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
-      def start_test_session: (?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+      def start_test_session: (?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-      def start_test_module: (String test_module_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+      def start_test_module: (String test_module_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-      def start_test_suite: (String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
+      def start_test_suite: (String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
       def active_test_session: () -> Datadog::CI::TestSession?
 

--- a/sig/datadog/ci/recorder.rbs
+++ b/sig/datadog/ci/recorder.rbs
@@ -16,7 +16,7 @@ module Datadog
 
       def initialize: (?enabled: bool, ?test_suite_level_visibility_enabled: bool) -> void
 
-      def trace_test: (String span_name, String test_suite_name, ?service_name: String?, ?operation_name: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+      def trace_test: (String span_name, String test_suite_name, ?service_name: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
       def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Cucumber formatter" do
       expect(scenario_span.resource).to eq("cucumber scenario")
       expect(scenario_span.service).to eq("jalapenos")
       expect(scenario_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-      expect(scenario_span.name).to eq(Datadog::CI::Contrib::Cucumber::Ext::OPERATION_NAME)
+      expect(scenario_span.name).to eq("cucumber scenario")
       expect(step_span.resource).to eq("datadog")
 
       spans.each do |span|

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Minitest hooks" do
     klass.new(:test_foo).run
 
     expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-    expect(span.name).to eq(Datadog::CI::Contrib::Minitest::Ext::OPERATION_NAME)
+    expect(span.name).to eq("SomeTest#test_foo")
     expect(span.resource).to eq("SomeTest#test_foo")
     expect(span.service).to eq("ltest")
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("SomeTest#test_foo")

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "RSpec hooks" do
     end
 
     expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-    expect(span.name).to eq(Datadog::CI::Contrib::RSpec::Ext::OPERATION_NAME)
+    expect(span.name).to eq("some test foo")
     expect(span.resource).to eq("some test foo")
     expect(span.service).to eq("lspec")
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("some test foo")

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Datadog::CI::Recorder do
   end
 
   context "when test suite level visibility is disabled" do
-    let(:service_name) { "my-service" }
+    let(:service) { "my-service" }
     let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
     include_context "CI mode activated" do
@@ -116,7 +116,7 @@ RSpec.describe Datadog::CI::Recorder do
     end
 
     describe "#trace_test_session" do
-      subject { recorder.start_test_session(service_name: service_name, tags: tags) }
+      subject { recorder.start_test_session(service: service, tags: tags) }
 
       it { is_expected.to be_kind_of(Datadog::CI::NullSpan) }
 
@@ -128,7 +128,7 @@ RSpec.describe Datadog::CI::Recorder do
     describe "#trace_test_module" do
       let(:module_name) { "my-module" }
 
-      subject { recorder.start_test_module(module_name, service_name: service_name, tags: tags) }
+      subject { recorder.start_test_module(module_name, service: service, tags: tags) }
 
       it { is_expected.to be_kind_of(Datadog::CI::NullSpan) }
 
@@ -140,7 +140,7 @@ RSpec.describe Datadog::CI::Recorder do
     describe "#trace_test_suite" do
       let(:suite_name) { "my-module" }
 
-      subject { recorder.start_test_suite(suite_name, service_name: service_name, tags: tags) }
+      subject { recorder.start_test_suite(suite_name, service: service, tags: tags) }
 
       it { is_expected.to be_kind_of(Datadog::CI::NullSpan) }
 
@@ -233,7 +233,7 @@ RSpec.describe Datadog::CI::Recorder do
     describe "#trace_test" do
       let(:test_name) { "my test" }
       let(:test_suite_name) { "my suite" }
-      let(:test_service_name) { "my-service" }
+      let(:test_service) { "my-service" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
       context "without a block" do
@@ -241,7 +241,7 @@ RSpec.describe Datadog::CI::Recorder do
           recorder.trace_test(
             test_name,
             test_suite_name,
-            service_name: test_service_name,
+            service: test_service,
             tags: tags
           )
         end
@@ -250,7 +250,7 @@ RSpec.describe Datadog::CI::Recorder do
           it "returns a new CI test span" do
             expect(subject).to be_kind_of(Datadog::CI::Test)
             expect(subject.name).to eq(test_name)
-            expect(subject.service).to eq(test_service_name)
+            expect(subject.service).to eq(test_service)
             expect(subject.tracer_span.name).to eq(test_name)
             expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
           end
@@ -283,10 +283,10 @@ RSpec.describe Datadog::CI::Recorder do
 
         context "when there is an active test session" do
           let(:test_session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
-          let(:session_service_name) { "my-session-service" }
-          let(:test_service_name) { nil }
+          let(:session_service) { "my-session-service" }
+          let(:test_service) { nil }
 
-          let(:test_session) { recorder.start_test_session(service_name: session_service_name, tags: test_session_tags) }
+          let(:test_session) { recorder.start_test_session(service: session_service, tags: test_session_tags) }
 
           before do
             test_session
@@ -296,7 +296,7 @@ RSpec.describe Datadog::CI::Recorder do
             it "returns a new CI test span using service from the test session" do
               expect(subject).to be_kind_of(Datadog::CI::Test)
               expect(subject.name).to eq(test_name)
-              expect(subject.service).to eq(session_service_name)
+              expect(subject.service).to eq(session_service)
             end
 
             it "sets the provided tags correctly while inheriting some tags from the session" do
@@ -377,7 +377,7 @@ RSpec.describe Datadog::CI::Recorder do
           recorder.trace_test(
             test_name,
             test_suite_name,
-            service_name: test_service_name,
+            service: test_service,
             tags: tags
           ) do |test_span|
             test_span.set_metric("my.metric", 42)
@@ -387,7 +387,7 @@ RSpec.describe Datadog::CI::Recorder do
 
         it "traces and finishes a test" do
           expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq(test_name)
-          expect(subject.service).to eq(test_service_name)
+          expect(subject.service).to eq(test_service)
           expect(subject.name).to eq(test_name)
           expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
         end
@@ -413,15 +413,15 @@ RSpec.describe Datadog::CI::Recorder do
     end
 
     describe "#start_test_session" do
-      let(:service_name) { "my-service" }
+      let(:service) { "my-service" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-      subject { recorder.start_test_session(service_name: service_name, tags: tags) }
+      subject { recorder.start_test_session(service: service, tags: tags) }
 
       it "returns a new CI test_session span" do
         expect(subject).to be_kind_of(Datadog::CI::TestSession)
         expect(subject.name).to eq("test.session")
-        expect(subject.service).to eq(service_name)
+        expect(subject.service).to eq(service)
         expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
       end
 
@@ -448,16 +448,16 @@ RSpec.describe Datadog::CI::Recorder do
 
     describe "#start_test_module" do
       let(:module_name) { "my-module" }
-      let(:service_name) { "my-service" }
+      let(:service) { "my-service" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-      subject { recorder.start_test_module(module_name, service_name: service_name, tags: tags) }
+      subject { recorder.start_test_module(module_name, service: service, tags: tags) }
 
       context "when there is no active test session" do
         it "returns a new CI test_module span" do
           expect(subject).to be_kind_of(Datadog::CI::TestModule)
           expect(subject.name).to eq(module_name)
-          expect(subject.service).to eq(service_name)
+          expect(subject.service).to eq(service)
           expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
         end
 
@@ -491,10 +491,10 @@ RSpec.describe Datadog::CI::Recorder do
       end
 
       context "when there is an active test session" do
-        let(:service_name) { nil }
-        let(:session_service_name) { "session_service_name" }
+        let(:service) { nil }
+        let(:session_service) { "session_service" }
         let(:session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
-        let(:test_session) { recorder.start_test_session(service_name: session_service_name, tags: session_tags) }
+        let(:test_session) { recorder.start_test_session(service: session_service, tags: session_tags) }
 
         before do
           test_session
@@ -503,7 +503,7 @@ RSpec.describe Datadog::CI::Recorder do
         it "returns a new CI module span using service from the test session" do
           expect(subject).to be_kind_of(Datadog::CI::TestModule)
           expect(subject.name).to eq(module_name)
-          expect(subject.service).to eq(session_service_name)
+          expect(subject.service).to eq(session_service)
         end
 
         it "sets the provided tags correctly while inheriting some tags from the session" do
@@ -525,10 +525,10 @@ RSpec.describe Datadog::CI::Recorder do
 
     describe "start_test_suite" do
       let(:module_name) { "my-module" }
-      let(:session_service_name) { "session_service_name" }
+      let(:session_service) { "session_service" }
       let(:session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
 
-      let(:test_session) { recorder.start_test_session(service_name: session_service_name, tags: session_tags) }
+      let(:test_session) { recorder.start_test_session(service: session_service, tags: session_tags) }
       let(:test_module) { recorder.start_test_module(module_name) }
 
       before do
@@ -545,7 +545,7 @@ RSpec.describe Datadog::CI::Recorder do
         it "returns a new CI test_suite span" do
           expect(subject).to be_kind_of(Datadog::CI::TestSuite)
           expect(subject.name).to eq(suite_name)
-          expect(subject.service).to eq(session_service_name)
+          expect(subject.service).to eq(session_service)
           expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
         end
 

--- a/spec/datadog/ci/recorder_spec.rb
+++ b/spec/datadog/ci/recorder_spec.rb
@@ -234,7 +234,6 @@ RSpec.describe Datadog::CI::Recorder do
       let(:test_name) { "my test" }
       let(:test_suite_name) { "my suite" }
       let(:test_service_name) { "my-service" }
-      let(:operation_name) { "my-operation" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
       context "without a block" do
@@ -243,7 +242,6 @@ RSpec.describe Datadog::CI::Recorder do
             test_name,
             test_suite_name,
             service_name: test_service_name,
-            operation_name: operation_name,
             tags: tags
           )
         end
@@ -253,7 +251,7 @@ RSpec.describe Datadog::CI::Recorder do
             expect(subject).to be_kind_of(Datadog::CI::Test)
             expect(subject.name).to eq(test_name)
             expect(subject.service).to eq(test_service_name)
-            expect(subject.tracer_span.name).to eq(operation_name)
+            expect(subject.tracer_span.name).to eq(test_name)
             expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
           end
 
@@ -380,7 +378,6 @@ RSpec.describe Datadog::CI::Recorder do
             test_name,
             test_suite_name,
             service_name: test_service_name,
-            operation_name: operation_name,
             tags: tags
           ) do |test_span|
             test_span.set_metric("my.metric", 42)
@@ -391,7 +388,7 @@ RSpec.describe Datadog::CI::Recorder do
         it "traces and finishes a test" do
           expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq(test_name)
           expect(subject.service).to eq(test_service_name)
-          expect(subject.name).to eq(operation_name)
+          expect(subject.name).to eq(test_name)
           expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
         end
 

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe Datadog::CI do
     let(:options) do
       {
         service_name: "my-serivce",
-        operation_name: "rspec.example",
         tags: {"foo" => "bar"}
       }
     end
@@ -36,7 +35,6 @@ RSpec.describe Datadog::CI do
     let(:options) do
       {
         service_name: "my-serivce",
-        operation_name: "rspec.example",
         tags: {"foo" => "bar"}
       }
     end

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Datadog::CI do
     let(:test_suite_name) { "test suite name" }
     let(:options) do
       {
-        service_name: "my-serivce",
+        service: "my-serivce",
         tags: {"foo" => "bar"}
       }
     end
@@ -34,7 +34,7 @@ RSpec.describe Datadog::CI do
     let(:test_suite_name) { "test suite name" }
     let(:options) do
       {
-        service_name: "my-serivce",
+        service: "my-serivce",
         tags: {"foo" => "bar"}
       }
     end
@@ -101,7 +101,7 @@ RSpec.describe Datadog::CI do
 
   describe "::start_test_session" do
     let(:service) { nil }
-    subject(:start_test_session) { described_class.start_test_session(service_name: service) }
+    subject(:start_test_session) { described_class.start_test_session(service: service) }
 
     let(:ci_test_session) { instance_double(Datadog::CI::TestSession) }
 
@@ -109,7 +109,7 @@ RSpec.describe Datadog::CI do
       let(:service) { "my-service" }
 
       before do
-        allow(recorder).to receive(:start_test_session).with(service_name: service, tags: {}).and_return(ci_test_session)
+        allow(recorder).to receive(:start_test_session).with(service: service, tags: {}).and_return(ci_test_session)
       end
 
       it { is_expected.to be(ci_test_session) }
@@ -120,7 +120,7 @@ RSpec.describe Datadog::CI do
         before do
           allow(Datadog.configuration).to receive(:service).and_return("configured-service")
           allow(recorder).to receive(:start_test_session).with(
-            service_name: "configured-service", tags: {}
+            service: "configured-service", tags: {}
           ).and_return(ci_test_session)
         end
 
@@ -158,7 +158,7 @@ RSpec.describe Datadog::CI do
 
     before do
       allow(recorder).to(
-        receive(:start_test_module).with("my-module", service_name: nil, tags: {}).and_return(ci_test_module)
+        receive(:start_test_module).with("my-module", service: nil, tags: {}).and_return(ci_test_module)
       )
     end
 
@@ -194,7 +194,7 @@ RSpec.describe Datadog::CI do
 
     before do
       allow(recorder).to(
-        receive(:start_test_suite).with("my-suite", service_name: nil, tags: {}).and_return(ci_test_suite)
+        receive(:start_test_suite).with("my-suite", service: nil, tags: {}).and_return(ci_test_suite)
       )
     end
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -10,7 +10,7 @@ module TracerHelpers
   end
 
   def produce_test_trace(
-    framework: "rspec", operation: "rspec.example",
+    framework: "rspec",
     test_name: "test_add", test_suite: "calculator_tests",
     service: "rspec-test-suite", result: "PASSED", exception: nil,
     skip_reason: nil, start_time: Time.now, duration_seconds: 2,
@@ -31,8 +31,7 @@ module TracerHelpers
         Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION => "1.0.0",
         Datadog::CI::Ext::Test::TAG_TYPE => "test"
       },
-      service_name: service,
-      operation_name: operation
+      service_name: service
     ) do |test|
       if with_http_span
         Datadog::Tracing.trace("http-call", type: "http", service: "net-http") do |span, trace|
@@ -53,7 +52,7 @@ module TracerHelpers
   end
 
   def produce_test_session_trace(
-    tests_count: 1, framework: "rspec", operation: "rspec.example",
+    tests_count: 1, framework: "rspec",
     test_name: "test_add", test_suite: "calculator_tests", test_module_name: "arithmetic",
     service: "rspec-test-suite", result: "PASSED", exception: nil,
     skip_reason: nil, start_time: Time.now, duration_seconds: 2,
@@ -78,7 +77,7 @@ module TracerHelpers
 
     tests_count.times do |num|
       produce_test_trace(
-        framework: framework, operation: operation,
+        framework: framework,
         test_name: "#{test_name}.run.#{num}", test_suite: test_suite,
         # service is inherited from test_session
         service: nil,

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -31,7 +31,7 @@ module TracerHelpers
         Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION => "1.0.0",
         Datadog::CI::Ext::Test::TAG_TYPE => "test"
       },
-      service_name: service
+      service: service
     ) do |test|
       if with_http_span
         Datadog::Tracing.trace("http-call", type: "http", service: "net-http") do |span, trace|
@@ -63,7 +63,7 @@ module TracerHelpers
     )
 
     test_session = Datadog::CI.start_test_session(
-      service_name: service,
+      service: service,
       tags: {
         Datadog::CI::Ext::Test::TAG_FRAMEWORK => framework,
         Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION => "1.0.0",

--- a/vendor/rbs/ddtrace/0/datadog/core.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/core.rbs
@@ -1,5 +1,6 @@
 module Datadog
   module Core
+    def self.log_deprecation: () ?{() -> untyped} -> untyped
   end
 
   extend Core::Configuration

--- a/vendor/rbs/ddtrace/0/datadog/core/configuration/option_definition.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/core/configuration/option_definition.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         attr_reader default: untyped
 
-        attr_reader experimental_default_proc: untyped
+        attr_reader default_proc: untyped
 
         attr_reader env: untyped
 
@@ -14,13 +14,11 @@ module Datadog
 
         attr_reader env_parser: untyped
 
-        attr_reader delegate_to: untyped
-
         attr_reader depends_on: untyped
 
         attr_reader name: untyped
 
-        attr_reader on_set: untyped
+        attr_reader after_set: untyped
 
         attr_reader resetter: untyped
 
@@ -39,9 +37,7 @@ module Datadog
 
           def default: (?untyped? value) ?{ () -> untyped } -> untyped
 
-          def experimental_default_proc: () { () -> untyped } -> untyped
-
-          def delegate_to: () { () -> untyped } -> untyped
+          def default_proc: () { () -> untyped } -> untyped
 
           def env: (untyped value) -> untyped
 
@@ -53,7 +49,7 @@ module Datadog
 
           def helper: (untyped name, *untyped _args) { () -> untyped } -> untyped
 
-          def on_set: () { (untyped value) -> untyped } -> untyped
+          def after_set: () { (untyped value) -> untyped } -> untyped
 
           def resetter: () { (untyped value) -> untyped } -> untyped
 
@@ -63,7 +59,7 @@ module Datadog
 
           def to_definition: () -> untyped
 
-          def meta: () -> { default: untyped, delegate_to: untyped, depends_on: untyped, on_set: untyped, resetter: untyped, setter: untyped }
+          def meta: () -> { default: untyped, after_set: untyped, resetter: untyped, setter: untyped }
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
This PR cleans up some of the confusion caused by service_name and operation_name parameters in CI tracing public API:
- service_name is renamed to service
- operation_name is removed from manual API
- operation_name settings option is deprecated

**Motivation**
operation_name is a setting that is used for internal span naming only, with event-based encoding it does not reach backend at all - so it is very confusing to keep it in the public API

service_name parameter was named after the legacy contrib setting, but actually it is called service everywhere nowadays (including environment variable DD_SERVICE)

**How to test the change?**
Unit tests are provided