### PR TITLE
[CIVIS-7950] Add rspec instrumentation for test suite level visibility

### DIFF
--- a/integration/app/spec/basic_spec.rb
+++ b/integration/app/spec/basic_spec.rb
@@ -1,4 +1,8 @@
+require_relative "shared_examples"
+
 RSpec.describe "Let's do some math" do
+  include_examples "Testing shared examples"
+
   it "add" do
     expect(1 + 1).to eq(2)
   end

--- a/integration/app/spec/shared_examples.rb
+++ b/integration/app/spec/shared_examples.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "Testing shared examples" do
+  context "shared examples" do
+    it "adds 1 and 1" do
+      expect(1 + 1).to eq(2)
+    end
+  end
+end

--- a/integration/app/spec/spec_helper.rb
+++ b/integration/app/spec/spec_helper.rb
@@ -5,9 +5,6 @@ Datadog.configure do |c|
   c.service = "datadog-ci-integration-app"
   c.env = "local"
 
-  c.tracing.enabled = true
-  c.tracing.test_mode.enabled = true
-
   c.ci.enabled = true
   c.ci.instrument :rspec
 end

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -19,7 +19,7 @@ module Datadog
 
             option :service_name do |o|
               o.type :string
-              o.default { Datadog.configuration.service_without_fallback || Ext::SERVICE_NAME }
+              o.default { Datadog.configuration.service_without_fallback || Ext::DEFAULT_SERVICE_NAME }
             end
 
             # @deprecated Will be removed in 1.0

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -26,7 +26,7 @@ module Datadog
 
               CI.trace_test(
                 test_name,
-                metadata[:example_group][:file_path],
+                metadata[:example_group][:rerun_file_path],
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -30,7 +30,7 @@ module Datadog
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
-                  CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
+                  CI::Ext::Test::TAG_TYPE => CI::Ext::Test::TEST_TYPE
                 },
                 service: configuration[:service_name]
               ) do |test_span|

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative "../../ext/test"
+require_relative "ext"
+
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        # Instrument RSpec::Core::Example
+        module ExampleGroup
+          def self.included(base)
+            base.singleton_class.prepend(ClassMethods)
+          end
+
+          # Instance methods for configuration
+          module ClassMethods
+            def run(reporter = ::RSpec::Core::NullReporter)
+              return super unless configuration[:enabled]
+              return super unless top_level?
+
+              test_suite = Datadog::CI.start_test_suite(file_path)
+
+              result = super
+
+              if result
+                test_suite.passed!
+              else
+                test_suite.failed!
+              end
+              test_suite.finish
+
+              result
+            end
+
+            private
+
+            def configuration
+              Datadog.configuration.ci[:rspec]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/rspec/ext.rb
+++ b/lib/datadog/ci/contrib/rspec/ext.rb
@@ -12,9 +12,6 @@ module Datadog
 
           ENV_ENABLED = "DD_TRACE_RSPEC_ENABLED"
 
-          # the resource for rspec module is "rspec.test_module.run"
-          TEST_MODULE_NAME = "run"
-
           # TODO: remove in 1.0
           ENV_OPERATION_NAME = "DD_TRACE_RSPEC_OPERATION_NAME"
           OPERATION_NAME = "rspec.example"

--- a/lib/datadog/ci/contrib/rspec/ext.rb
+++ b/lib/datadog/ci/contrib/rspec/ext.rb
@@ -7,13 +7,17 @@ module Datadog
         # RSpec integration constants
         # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
         module Ext
-          APP = "rspec"
-          ENV_ENABLED = "DD_TRACE_RSPEC_ENABLED"
-          ENV_OPERATION_NAME = "DD_TRACE_RSPEC_OPERATION_NAME"
           FRAMEWORK = "rspec"
+          DEFAULT_SERVICE_NAME = "rspec"
+
+          ENV_ENABLED = "DD_TRACE_RSPEC_ENABLED"
+
+          # the resource for rspec module is "rspec.test_module.run"
+          TEST_MODULE_NAME = "run"
+
+          # TODO: remove in 1.0
+          ENV_OPERATION_NAME = "DD_TRACE_RSPEC_OPERATION_NAME"
           OPERATION_NAME = "rspec.example"
-          SERVICE_NAME = "rspec"
-          TEST_TYPE = "test"
         end
       end
     end

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -2,6 +2,7 @@
 
 require "datadog/tracing/contrib/patcher"
 require_relative "example"
+require_relative "runner"
 
 module Datadog
   module CI
@@ -19,6 +20,7 @@ module Datadog
 
           def patch
             ::RSpec::Core::Example.include(Example)
+            ::RSpec::Core::Runner.include(Runner)
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "datadog/tracing/contrib/patcher"
+
 require_relative "example"
+require_relative "example_group"
 require_relative "runner"
 
 module Datadog
@@ -21,26 +23,7 @@ module Datadog
           def patch
             ::RSpec::Core::Example.include(Example)
             ::RSpec::Core::Runner.include(Runner)
-
-            ::RSpec::Core::ExampleGroup.class_eval do
-              class << self
-                alias_method :__run, :run
-
-                def run(reporter = ::RSpec::Core::NullReporter)
-                  return __run(reporter) unless top_level?
-
-                  test_suite = Datadog::CI.start_test_suite(file_path)
-                  result = __run(reporter)
-                  if result
-                    test_suite.passed!
-                  else
-                    test_suite.failed!
-                  end
-                  test_suite.finish
-                  result
-                end
-              end
-            end
+            ::RSpec::Core::ExampleGroup.include(ExampleGroup)
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -21,6 +21,26 @@ module Datadog
           def patch
             ::RSpec::Core::Example.include(Example)
             ::RSpec::Core::Runner.include(Runner)
+
+            ::RSpec::Core::ExampleGroup.class_eval do
+              class << self
+                alias_method :__run, :run
+
+                def run(reporter = ::RSpec::Core::NullReporter)
+                  return __run(reporter) unless top_level?
+
+                  test_suite = Datadog::CI.start_test_suite(file_path)
+                  result = __run(reporter)
+                  if result
+                    test_suite.passed!
+                  else
+                    test_suite.failed!
+                  end
+                  test_suite.finish
+                  result
+                end
+              end
+            end
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -21,18 +21,24 @@ module Datadog
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
-                  CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
+                  CI::Ext::Test::TAG_TYPE => CI::Ext::Test::TEST_TYPE
                 },
                 service: configuration[:service_name]
               )
 
+              test_module = CI.start_test_module(Ext::TEST_MODULE_NAME)
+
               result = super
 
               if result != 0
+                # TODO: repeating this twice feels clunky, we need to remove test_module API before GA
+                test_module.failed!
                 test_session.failed!
               else
+                test_module.passed!
                 test_session.passed!
               end
+              test_module.finish
               test_session.finish
 
               result

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -14,7 +14,7 @@ module Datadog
           end
 
           module InstanceMethods
-            def run(err, out)
+            def run_specs(example_groups)
               return super unless configuration[:enabled]
 
               test_session = CI.start_test_session(

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -26,7 +26,7 @@ module Datadog
                 service: configuration[:service_name]
               )
 
-              test_module = CI.start_test_module(Ext::TEST_MODULE_NAME)
+              test_module = CI.start_test_module(test_session.name)
 
               result = super
 

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require_relative "../../ext/test"
+require_relative "ext"
+
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        # Instrument RSpec::Core::Runner
+        module Runner
+          def self.included(base)
+            base.prepend(InstanceMethods)
+          end
+
+          module InstanceMethods
+            def run(err, out)
+              return super unless configuration[:enabled]
+
+              test_session = CI.start_test_session(
+                tags: {
+                  CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
+                  CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
+                  CI::Ext::Test::TAG_TYPE => Ext::TEST_TYPE
+                },
+                service: configuration[:service_name]
+              )
+
+              result = super
+
+              if result != 0
+                test_session.failed!
+              else
+                test_session.passed!
+              end
+              test_session.finish
+
+              result
+            end
+
+            private
+
+            def configuration
+              Datadog.configuration.ci[:rspec]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -20,6 +20,8 @@ module Datadog
         TAG_TYPE = "test.type"
         TAG_COMMAND = "test.command"
 
+        TEST_TYPE = "test"
+
         # those tags are special and they are used to correlate tests with the test sessions, suites, and modules
         TAG_TEST_SESSION_ID = "_test.session_id"
         TAG_TEST_MODULE_ID = "_test.module_id"

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -20,6 +20,28 @@ module Datadog
 
         CI.deactivate_test(self)
       end
+
+      # Span id of the running test suite this test belongs to.
+      # @return [String] the span id of the test suite.
+      def test_suite_id
+        get_tag(Ext::Test::TAG_TEST_SUITE_ID)
+      end
+
+      def test_suite_name
+        get_tag(Ext::Test::TAG_SUITE)
+      end
+
+      # Span id of the running test module this test belongs to.
+      # @return [String] the span id of the test module.
+      def test_module_id
+        get_tag(Ext::Test::TAG_TEST_MODULE_ID)
+      end
+
+      # Span id of the running test module this test belongs to.
+      # @return [String] the span id of the test session.
+      def test_session_id
+        get_tag(Ext::Test::TAG_TEST_SESSION_ID)
+      end
     end
   end
 end

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -20,6 +20,14 @@ module Datadog
         CI.deactivate_test_session
       end
 
+      # Return the test session's name which is equal to test command used
+      # @return [String] the command for this test session.
+      def name
+        get_tag(Ext::Test::TAG_COMMAND)
+      end
+
+      # Return the test session tags that could be inherited by sub-spans
+      # @return [Hash] the tags to be inherited by sub-spans.
       def inheritable_tags
         return @inheritable_tags if defined?(@inheritable_tags)
 

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -210,6 +210,7 @@ module Datadog
         def build_test(tracer_span, tags)
           test = Test.new(tracer_span)
           set_initial_tags(test, tags)
+          validate_test_suite_level_visibility_correctness(test)
           test
         end
 
@@ -286,6 +287,31 @@ module Datadog
 
         def null_span
           @null_span ||= NullSpan.new
+        end
+
+        def validate_test_suite_level_visibility_correctness(test)
+          return unless test_suite_level_visibility_enabled
+
+          if test.test_suite_id.nil?
+            Datadog.logger.debug do
+              "Test [#{test.name}] does not have a test suite associated with it. " \
+              "Expected test suite [#{test.test_suite_name}] to be running."
+            end
+          end
+
+          if test.test_module_id.nil?
+            Datadog.logger.debug do
+              "Test [#{test.name}] does not have a test module associated with it. " \
+              "Make sure that there is a test module running within a session."
+            end
+          end
+
+          if test.test_session_id.nil?
+            Datadog.logger.debug do
+              "Test [#{test.name}] does not have a test session associated with it. " \
+              "Make sure that there is a test session running."
+            end
+          end
         end
       end
     end

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -18,6 +18,8 @@ module Datadog
 
     def self.active_test: () -> Datadog::CI::Test?
 
+    def self.active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
+
     def self.active_span: (String span_type) -> Datadog::CI::Span?
 
     def self.deactivate_test: (Datadog::CI::Test test) -> void

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        module ExampleGroup
+          def self.included: (untyped base) -> untyped
+
+          module ClassMethods
+            include ::RSpec::Core::ExampleGroup::ClassMethods
+
+            def run: (?untyped reporter) -> untyped
+
+            private
+
+            def configuration: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/rspec/ext.rbs
+++ b/sig/datadog/ci/contrib/rspec/ext.rbs
@@ -11,8 +11,6 @@ module Datadog
           OPERATION_NAME: String
           ENV_OPERATION_NAME: String
 
-          SERVICE_NAME: String
-
           TEST_MODULE_NAME: String
         end
       end

--- a/sig/datadog/ci/contrib/rspec/ext.rbs
+++ b/sig/datadog/ci/contrib/rspec/ext.rbs
@@ -3,19 +3,17 @@ module Datadog
     module Contrib
       module RSpec
         module Ext
-          APP: String
-
           ENV_ENABLED: String
 
-          ENV_OPERATION_NAME: String
-
           FRAMEWORK: String
+          DEFAULT_SERVICE_NAME: String
 
           OPERATION_NAME: String
+          ENV_OPERATION_NAME: String
 
           SERVICE_NAME: String
 
-          TEST_TYPE: String
+          TEST_MODULE_NAME: String
         end
       end
     end

--- a/sig/datadog/ci/contrib/rspec/ext.rbs
+++ b/sig/datadog/ci/contrib/rspec/ext.rbs
@@ -10,8 +10,6 @@ module Datadog
 
           OPERATION_NAME: String
           ENV_OPERATION_NAME: String
-
-          TEST_MODULE_NAME: String
         end
       end
     end

--- a/sig/datadog/ci/contrib/rspec/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/runner.rbs
@@ -8,7 +8,7 @@ module Datadog
           module InstanceMethods
             include ::RSpec::Core::Runner
 
-            def run: (untyped err, untyped out) -> untyped
+            def run_specs: (untyped example_groups) -> untyped
 
             private
 

--- a/sig/datadog/ci/contrib/rspec/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/runner.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        module Runner
+          def self.included: (untyped base) -> untyped
+
+          module InstanceMethods
+            include ::RSpec::Core::Runner
+
+            def run: (untyped err, untyped out) -> untyped
+
+            private
+
+            def configuration: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -32,6 +32,8 @@ module Datadog
 
         TAG_TEST_SUITE_ID: String
 
+        TEST_TYPE: String
+
         SPECIAL_TAGS: Array[String]
 
         INHERITABLE_TAGS: Array[String]

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -2,6 +2,10 @@ module Datadog
   module CI
     class Test < Span
       def finish: () -> void
+      def test_suite_id: () -> String?
+      def test_suite_name: () -> String?
+      def test_module_id: () -> String?
+      def test_session_id: () -> String?
     end
   end
 end

--- a/sig/datadog/ci/test_visibility/recorder.rbs
+++ b/sig/datadog/ci/test_visibility/recorder.rbs
@@ -79,6 +79,8 @@ module Datadog
         def start_datadog_tracer_span: (String span_name, Hash[untyped, untyped] span_options) ?{ (untyped) -> untyped } -> untyped
 
         def set_inherited_globals: (Hash[untyped, untyped] tags) -> void
+
+        def validate_test_suite_level_visibility_correctness: (Datadog::CI::Test test) -> void
       end
     end
   end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -29,19 +29,19 @@ RSpec.describe "RSpec hooks" do
       end.tap(&:run)
     end
 
-    expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-    expect(span.name).to eq("some test foo")
-    expect(span.resource).to eq("some test foo")
-    expect(span.service).to eq("lspec")
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("some test foo")
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(Datadog::CI::Ext::Test::TEST_TYPE)
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(Datadog::CI::Contrib::RSpec::Ext::FRAMEWORK)
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION)).to eq(
+    expect(first_test_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(first_test_span.name).to eq("some test foo")
+    expect(first_test_span.resource).to eq("some test foo")
+    expect(first_test_span.service).to eq("lspec")
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("some test foo")
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(Datadog::CI::Ext::Test::TEST_TYPE)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(Datadog::CI::Contrib::RSpec::Ext::FRAMEWORK)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION)).to eq(
       Datadog::CI::Contrib::RSpec::Integration.version.to_s
     )
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
   end
 
   it "creates correct span on shared examples" do
@@ -52,7 +52,7 @@ RSpec.describe "RSpec hooks" do
       end.tap(&:run)
     end
 
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
   end
 
   it "creates spans for several examples" do
@@ -69,7 +69,7 @@ RSpec.describe "RSpec hooks" do
       end.run
     end
 
-    expect(spans).to have(num_examples).items
+    expect(test_spans).to have(num_examples).items
   end
 
   it "creates span for unnamed examples" do
@@ -79,7 +79,7 @@ RSpec.describe "RSpec hooks" do
       end.run
     end
 
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to match(/some unnamed test example at .+/)
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to match(/some unnamed test example at .+/)
   end
 
   it "creates span for deeply nested examples" do
@@ -111,9 +111,9 @@ RSpec.describe "RSpec hooks" do
       end.tap(&:run)
     end
 
-    expect(span.resource).to eq("some nested test 1 2 3 4 5 6 7 8 9 10 foo")
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("some nested test 1 2 3 4 5 6 7 8 9 10 foo")
-    expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+    expect(first_test_span.resource).to eq("some nested test 1 2 3 4 5 6 7 8 9 10 foo")
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("some nested test 1 2 3 4 5 6 7 8 9 10 foo")
+    expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
   end
 
   it "creates spans for example with instrumentation" do
@@ -127,9 +127,10 @@ RSpec.describe "RSpec hooks" do
       end.tap(&:run)
     end
 
-    expect(spans).to have(2).items
+    expect(test_spans).to have(1).items
+    expect(tracer_spans).to have(1).items
 
-    spans.each do |span|
+    tracer_spans.each do |span|
       expect(span.get_tag(Datadog::Tracing::Metadata::Ext::Distributed::TAG_ORIGIN))
         .to eq(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
     end
@@ -137,11 +138,11 @@ RSpec.describe "RSpec hooks" do
 
   context "catches failures" do
     def expect_failure
-      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
-      expect(span).to have_error
-      expect(span).to have_error_type
-      expect(span).to have_error_message
-      expect(span).to have_error_stack
+      expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
+      expect(first_test_span).to have_error
+      expect(first_test_span).to have_error_type
+      expect(first_test_span).to have_error_message
+      expect(first_test_span).to have_error_stack
     end
 
     it "within let" do
@@ -215,7 +216,7 @@ RSpec.describe "RSpec hooks" do
 
     def rspec_session_run(with_failed_test: false)
       with_new_rspec_environment do
-        RSpec.describe "SomeTest" do
+        spec = RSpec.describe "SomeTest" do
           it "foo" do
             # DO NOTHING
           end
@@ -229,6 +230,8 @@ RSpec.describe "RSpec hooks" do
 
         options = ::RSpec::Core::ConfigurationOptions.new(%w[--pattern none])
         ::RSpec::Core::Runner.new(options).run(devnull, devnull)
+
+        spec
       end
     end
 
@@ -280,6 +283,39 @@ RSpec.describe "RSpec hooks" do
       )
     end
 
+    it "creates test suite span" do
+      spec = rspec_session_run
+
+      expect(test_suite_span).not_to be_nil
+
+      expect(test_suite_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
+      expect(test_suite_span.name).to eq(spec.file_path)
+
+      expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
+        Datadog::CI::Ext::AppTypes::TYPE_TEST
+      )
+      expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(
+        Datadog::CI::Ext::Test::TEST_TYPE
+      )
+      expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(
+        Datadog::CI::Contrib::RSpec::Ext::FRAMEWORK
+      )
+      expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION)).to eq(
+        Datadog::CI::Contrib::RSpec::Integration.version.to_s
+      )
+      expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
+        Datadog::CI::Ext::Test::Status::PASS
+      )
+    end
+
+    it "connects test to the session, module, and suite" do
+      rspec_session_run
+
+      expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID)).to eq(test_session_span.id.to_s)
+      expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID)).to eq(test_module_span.id.to_s)
+      expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(test_suite_span.id.to_s)
+    end
+
     context "with failures" do
       it "creates test session span with failed state" do
         rspec_session_run(with_failed_test: true)
@@ -295,6 +331,15 @@ RSpec.describe "RSpec hooks" do
 
         expect(test_module_span).not_to be_nil
         expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
+          Datadog::CI::Ext::Test::Status::FAIL
+        )
+      end
+
+      it "creates test suite span with failed state" do
+        rspec_session_run(with_failed_test: true)
+
+        expect(test_suite_span).not_to be_nil
+        expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
           Datadog::CI::Ext::Test::Status::FAIL
         )
       end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe "RSpec hooks" do
       expect(test_module_span).not_to be_nil
 
       expect(test_module_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
-      expect(test_module_span.name).to eq(Datadog::CI::Contrib::RSpec::Ext::TEST_MODULE_NAME)
+      expect(test_module_span.name).to eq(test_command)
 
       expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
         Datadog::CI::Ext::AppTypes::TYPE_TEST

--- a/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
+++ b/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
@@ -1,3 +1,7 @@
 RSpec.shared_examples "Testing shared examples" do
-  it { expect(1 + 1).to eq(2) }
+  context "shared examples" do
+    it "adds 1 and 1" do
+      expect(1 + 1).to eq(2)
+    end
+  end
 end

--- a/spec/datadog/ci/test_session_spec.rb
+++ b/spec/datadog/ci/test_session_spec.rb
@@ -34,4 +34,16 @@ RSpec.describe Datadog::CI::TestSession do
       )
     end
   end
+
+  describe "#name" do
+    subject(:name) { ci_test_session.name }
+
+    let(:ci_test_session) { described_class.new(tracer_span) }
+
+    before do
+      allow(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_COMMAND).and_return("test command")
+    end
+
+    it { is_expected.to eq("test command") }
+  end
 end

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -22,4 +22,54 @@ RSpec.describe Datadog::CI::Test do
       expect(Datadog::CI).to have_received(:deactivate_test).with(ci_test)
     end
   end
+
+  describe "#test_suite_id" do
+    subject(:test_suite_id) { ci_test.test_suite_id }
+    let(:ci_test) { described_class.new(tracer_span) }
+
+    before do
+      allow(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID).and_return("test suite id")
+    end
+
+    it { is_expected.to eq("test suite id") }
+  end
+
+  describe "#test_suite_name" do
+    subject(:test_suite_name) { ci_test.test_suite_name }
+    let(:ci_test) { described_class.new(tracer_span) }
+
+    before do
+      allow(tracer_span).to(
+        receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_SUITE).and_return("test suite name")
+      )
+    end
+
+    it { is_expected.to eq("test suite name") }
+  end
+
+  describe "#test_module_id" do
+    subject(:test_module_id) { ci_test.test_module_id }
+    let(:ci_test) { described_class.new(tracer_span) }
+
+    before do
+      allow(tracer_span).to(
+        receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_TEST_MODULE_ID).and_return("test module id")
+      )
+    end
+
+    it { is_expected.to eq("test module id") }
+  end
+
+  describe "#test_session_id" do
+    subject(:test_session_id) { ci_test.test_session_id }
+    let(:ci_test) { described_class.new(tracer_span) }
+
+    before do
+      allow(tracer_span).to(
+        receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_TEST_SESSION_ID).and_return("test session id")
+      )
+    end
+
+    it { is_expected.to eq("test session id") }
+  end
 end

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -435,7 +435,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
       it "returns a new CI test_session span" do
         expect(subject).to be_kind_of(Datadog::CI::TestSession)
-        expect(subject.name).to eq("test.session")
+        expect(subject.name).to eq(test_command)
         expect(subject.service).to eq(service)
         expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
       end

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -108,11 +108,19 @@ module TracerHelpers
   end
 
   def first_test_span
-    spans.find { |span| span.type == "test" }
+    test_spans.first
   end
 
   def first_other_span
-    spans.find { |span| !Datadog::CI::Ext::AppTypes::CI_SPAN_TYPES.include?(span.type) }
+    tracer_spans.first
+  end
+
+  def test_spans
+    spans.filter { |span| span.type == "test" }
+  end
+
+  def tracer_spans
+    spans.filter { |span| !Datadog::CI::Ext::AppTypes::CI_SPAN_TYPES.include?(span.type) }
   end
 
   # Returns traces and caches it (similar to +let(:traces)+).

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -13,7 +13,7 @@ module RSpec::Core::Example
 end
 
 module RSpec::Core::Runner
-  def run: (untyped err, untyped out) -> untyped
+  def run_specs: (untyped example_groups) -> untyped
 end
 
 module RSpec::Core::ExampleGroup

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -11,3 +11,7 @@ module RSpec::Core::Example
   def description: () -> String
   def full_description: () -> String
 end
+
+module RSpec::Core::Runner
+  def run: (untyped err, untyped out) -> untyped
+end

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -17,5 +17,12 @@ module RSpec::Core::Runner
 end
 
 module RSpec::Core::ExampleGroup
-  def self.run: () -> bool
+  module ClassMethods
+    def run: () -> bool
+    def top_level?: () -> bool
+    def file_path: () -> String
+  end
+end
+
+class RSpec::Core::NullReporter
 end

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -15,3 +15,7 @@ end
 module RSpec::Core::Runner
   def run: (untyped err, untyped out) -> untyped
 end
+
+module RSpec::Core::ExampleGroup
+  def self.run: () -> bool
+end


### PR DESCRIPTION
**What does this PR do?**
Adds RSpec instrumentation for test suite level visibility

**Additional Notes**
This change is mostly compatible with current rspec instrumentation except one important change:
test suite name for a test is now `metadata[:example_group][:rerun_file_path]` instead of `metadata[:example_group][:file_path]`. The reason for that is if ExampleGroup is defined in shared examples inside a context like that:

```ruby
RSpec.shared_examples "Testing shared examples" do
  context "shared examples" do
    it "adds 1 and 1" do
      expect(1 + 1).to eq(2)
    end
  end
end
```

...then `file_path` contains the path of shared examples file whereas `rerun_file_path` contains the path of test file.

**How to test the change?**
There are open source projects I used for testing:
https://github.com/anmarchenko/middleman
https://github.com/anmarchenko/rubocop
https://github.com/anmarchenko/vagrant

Example of sesison trace for middleman specs:
<img width="1715" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/e8c54b11-996f-491f-8ced-4551d435e223">
