### PR TITLE
do not collect environment tags when CI is not enabled

### DIFF
--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -31,7 +31,7 @@ module Datadog
           @enabled = enabled
           @test_suite_level_visibility_enabled = enabled && test_suite_level_visibility_enabled
 
-          @environment_tags = Ext::Environment.tags(ENV).freeze
+          @environment_tags = @enabled ? Ext::Environment.tags(ENV).freeze : {}
           @local_context = Context::Local.new
           @global_context = Context::Global.new
         end

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       let(:ci_enabled) { false }
     end
 
+    describe "#initialize" do
+      subject do
+        described_class.new(
+          enabled: ci_enabled,
+          test_suite_level_visibility_enabled: experimental_test_suite_level_visibility_enabled
+        )
+      end
+
+      it "doesn't collect environment tags" do
+        expect(Datadog::CI::Ext::Environment).not_to receive(:tags)
+
+        subject
+      end
+    end
+
     describe "#trace_test" do
       context "when given a block" do
         let(:spy_under_test) { spy("spy") }


### PR DESCRIPTION
Fixes https://github.com/DataDog/dd-trace-rb/issues/3314

**What does this PR do?**
Prevents Datadog::CI::Ext::Environment from collecting environment information and validating it if CI mode is not enabled.

**Motivation**
Regression introduced in 0.5.0 release: ddtrace started to emit error logs in production about CI environment tags not being provided

**How to test the change?**
Run ruby application with ddtrace in production mode