### PR TITLE
[Cucumber contrib] remove tracking failed tests count per test suite, mark test suite as failed if any test fails

### DIFF
--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -6,7 +6,6 @@ module Datadog
           private
           @failed_tests_count: Integer
           @current_test_suite: Datadog::CI::Span?
-          @failed_tests_in_current_test_suite: Integer
 
           attr_reader config: untyped
 


### PR DESCRIPTION
**What does this PR do?**
Simplifies test suite failure tracking for Cucumber integration: instead of counting how many tests failed per current test suite, we will mark test suite as failed if any of the tests failed.

This will eliminate additional variable and condition checks that could cause bugs.

**Motivation**
Making test suite failure tracking for Cucumber simpler and similar to Minitest implementation.

**Additional Notes**
Tracking failure counts still exists for test session for the following reasons:
- we don't have to reset this number during the test session
- we use it only for Cucumber < 8 as since Cucumber 8.0 we have a proper support for test session result

**How to test the change?**
Unit tests stay the same, it is a refactoring without behaviour change