### PR TITLE
[CIVIS-7722] Deduplicate dynamically generated RSpec examples using metadata.scoped_id

### DIFF
--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -37,6 +37,8 @@ module Datadog
                 },
                 service: configuration[:service_name]
               ) do |test_span|
+                test_span.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
+
                 result = super
 
                 case execution_result.status

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -139,7 +139,7 @@ module Datadog
       # @param [Hash] metadata optional metadata
       # @return [void]
       def set_parameters(arguments, metadata = {})
-        return if arguments.nil? || arguments.empty?
+        return if arguments.nil?
 
         set_tag(
           Ext::Test::TAG_PARAMETERS,

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -375,8 +375,12 @@ RSpec.describe "RSpec hooks" do
         shared_test_spans = test_spans.filter { |test_span| test_span.name == "SomeTest shared examples adds 1 and 1" }
         expect(shared_test_spans).to have(2).items
 
-        shared_test_spans.each do |shared_test_span|
+        shared_test_spans.each_with_index do |shared_test_span, index|
           expect(shared_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+
+          expect(shared_test_span.get_tag(Datadog::CI::Ext::Test::TAG_PARAMETERS)).to eq(
+            "{\"arguments\":{},\"metadata\":{\"scoped_id\":\"1:#{2 + index}:1\"}}"
+          )
         end
 
         test_spans.each do |test_span|

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -246,7 +246,8 @@ RSpec.describe "RSpec hooks" do
 
           if with_shared_test
             require_relative "some_shared_examples"
-            include_examples "Testing shared examples"
+            include_examples "Testing shared examples", 2
+            include_examples "Testing shared examples", 1
           end
         end
 
@@ -371,8 +372,12 @@ RSpec.describe "RSpec hooks" do
       let!(:spec) { rspec_session_run(with_shared_test: true) }
 
       it "creates correct test spans connects all tests to a single test suite" do
-        shared_test_span = test_spans.find { |test_span| test_span.name == "SomeTest shared examples adds 1 and 1" }
-        expect(shared_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+        shared_test_spans = test_spans.filter { |test_span| test_span.name == "SomeTest shared examples adds 1 and 1" }
+        expect(shared_test_spans).to have(2).items
+
+        shared_test_spans.each do |shared_test_span|
+          expect(shared_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(spec.file_path)
+        end
 
         test_spans.each do |test_span|
           expect(test_span.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(test_suite_span.id.to_s)

--- a/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
+++ b/spec/datadog/ci/contrib/rspec/some_shared_examples.rb
@@ -1,7 +1,7 @@
-RSpec.shared_examples "Testing shared examples" do
+RSpec.shared_examples "Testing shared examples" do |expected_result|
   context "shared examples" do
     it "adds 1 and 1" do
-      expect(1 + 1).to eq(2)
+      expect(1 + 1).to eq(expected_result)
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds deduplication for RSpec examples using "test.parameters.metadata" and "scoped_id" provided by rspec which is a stable label assigned to each example:

<img width="315" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/b1905b25-f71e-4e05-a760-5f1000ea2bfb">

**Motivation**
Shared examples and dynamically generated examples with the same name were having the same fingerprint in Datadog test runs view.

**Why does it work like that?**
RSpec has many ways to define test with parameters.

1. Using shared examples ([source](https://github.com/anmarchenko/rubocop/blob/b61887841df781e4c34f1bef5c6f2859273737a7/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb)):

```ruby
  shared_examples 'literal interpolation' do |literal, expected = literal|
    it "registers an offense for #{literal} in interpolation " \
       'and removes interpolation around it' do
      expect_offense(<<~'RUBY', literal: literal)
        "this is the #{%{literal}}"
                       ^{literal} Literal interpolation detected.
      RUBY

      expect_correction(<<~RUBY)
        "this is the #{expected}"
      RUBY
    end

  it_behaves_like('literal interpolation in words literal', '%W')
  it_behaves_like('literal interpolation in words literal', '%I')
```

2. Dynamically generating examples with the same name in place ([source](https://github.com/anmarchenko/rubocop/blob/b61887841df781e4c34f1bef5c6f2859273737a7/spec/rubocop/cop/style/one_line_conditional_spec.rb#L76)):
```ruby
    %w[| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~ && ||].each do |operator|
      it 'registers and corrects an offense with ternary operator and adding parentheses ' \
         'when if/then/else/end is preceded by an operator' do
        expect_offense(<<~RUBY, operator: operator)
          a %{operator} if cond then run else dont end
            _{operator} ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ #{if_offense_message}
        RUBY

        expect_correction(<<~RUBY)
          a #{operator} (cond ? run : dont)
        RUBY
      end
    end
```

In both cases the creation of examples happens on code loading stage before the test is executed which is trickier and more error-prone to instrument. Conveniently, for this case rspec provides metadata[:scoped_id] field that uniquely identifies example in example group hierarchy (test in test suite hierarchy using Datadog terms). I decided to use this field in metadata key under `test.parameters` to make it part of fingerprint for all tests thus ensuring their uniqueness without making test names less readable by including obscure ids in them.