### PR TITLE
replace span_type option with type for Datadog::Tracing.trace

### DIFF
--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -225,7 +225,7 @@ module Datadog
 
         def build_span_options(service, span_type, other_options = {})
           other_options[:service] = service || @global_context.service
-          other_options[:span_type] = span_type
+          other_options[:type] = span_type
 
           other_options
         end


### PR DESCRIPTION
**What does this PR do?**
Replaces deprecated span_type option with type when using Datadog::Tracing.trace

**Motivation**
span_type is removed in ddtrace 2.0:
https://github.com/DataDog/dd-trace-rb/pull/3330

