### PR TITLE
remove occurences of span_type in specs

### DIFF
--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Cucumber formatter" do
     it "creates spans for each scenario and step" do
       scenario_span = spans.find { |s| s.resource == "cucumber scenario" }
 
-      expect(scenario_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+      expect(scenario_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
       expect(scenario_span.name).to eq("cucumber scenario")
       expect(scenario_span.resource).to eq("cucumber scenario")
       expect(scenario_span.service).to eq("jalapenos")

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Minitest instrumentation" do
 
     klass.new(:test_foo).run
 
-    expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
     expect(span.name).to eq("SomeTest#test_foo")
     expect(span.resource).to eq("SomeTest#test_foo")
     expect(span.service).to eq("ltest")
@@ -91,7 +91,7 @@ RSpec.describe "Minitest instrumentation" do
     method_name = klass.runnable_methods.first
     klass.new(method_name).run
 
-    expect(span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
     expect(span.resource).to eq("SomeSpec##{method_name}")
     expect(span.service).to eq("ltest")
     expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("SomeSpec##{method_name}")
@@ -389,7 +389,7 @@ RSpec.describe "Minitest instrumentation" do
 
       it "creates a test session span" do
         expect(test_session_span).not_to be_nil
-        expect(test_session_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
+        expect(test_session_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
         expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
           Datadog::CI::Ext::AppTypes::TYPE_TEST
         )
@@ -410,7 +410,7 @@ RSpec.describe "Minitest instrumentation" do
       it "creates a test module span" do
         expect(test_module_span).not_to be_nil
 
-        expect(test_module_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
+        expect(test_module_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
         expect(test_module_span.name).to eq(test_command)
 
         expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
@@ -433,7 +433,7 @@ RSpec.describe "Minitest instrumentation" do
       it "creates a test suite span" do
         expect(test_suite_span).not_to be_nil
 
-        expect(test_suite_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
+        expect(test_suite_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
         expect(test_suite_span.name).to eq("SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb")
 
         expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "RSpec hooks" do
       end.tap(&:run)
     end
 
-    expect(first_test_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+    expect(first_test_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
     expect(first_test_span.name).to eq("some test foo")
     expect(first_test_span.resource).to eq("some test foo")
     expect(first_test_span.service).to eq("lspec")
@@ -263,7 +263,7 @@ RSpec.describe "RSpec hooks" do
 
       expect(test_session_span).not_to be_nil
 
-      expect(test_session_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
+      expect(test_session_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
       expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
         Datadog::CI::Ext::AppTypes::TYPE_TEST
       )
@@ -286,7 +286,7 @@ RSpec.describe "RSpec hooks" do
 
       expect(test_module_span).not_to be_nil
 
-      expect(test_module_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
+      expect(test_module_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
       expect(test_module_span.name).to eq(test_command)
 
       expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
@@ -311,7 +311,7 @@ RSpec.describe "RSpec hooks" do
 
       expect(test_suite_span).not_to be_nil
 
-      expect(test_suite_span.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
+      expect(test_suite_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
       expect(test_suite_span.name).to eq(spec.file_path)
 
       expect(test_module_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         it "traces the block" do
           expect(subject.resource).to eq(span_name)
-          expect(subject.span_type).to eq(span_type)
+          expect(subject.type).to eq(span_type)
         end
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         it "traces the block" do
           expect(subject.resource).to eq(span_name)
-          expect(subject.span_type).to eq(span_type)
+          expect(subject.type).to eq(span_type)
         end
 
         it "sets the custom metric correctly" do
@@ -158,7 +158,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           subject.finish
 
           expect(span.resource).to eq(span_name)
-          expect(span.span_type).to eq(span_type)
+          expect(span.type).to eq(span_type)
         end
 
         it_behaves_like "span with environment tags"
@@ -326,7 +326,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           expect(subject.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq(test_name)
           expect(subject.service).to eq(test_service)
           expect(subject.name).to eq(test_name)
-          expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+          expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
         end
 
         it "sets the provided tags correctly" do

--- a/spec/datadog/ci/transport/api/builder_spec.rb
+++ b/spec/datadog/ci/transport/api/builder_spec.rb
@@ -103,8 +103,7 @@ RSpec.describe Datadog::CI::Transport::Api::Builder do
         hostname: "localhost",
         port: 5555,
         uds_path: nil,
-        timeout_seconds: 42,
-        deprecated_for_removal_transport_configuration_proc: nil
+        timeout_seconds: 42
       )
     end
 

--- a/spec/datadog/ci/transport/api/builder_spec.rb
+++ b/spec/datadog/ci/transport/api/builder_spec.rb
@@ -103,7 +103,8 @@ RSpec.describe Datadog::CI::Transport::Api::Builder do
         hostname: "localhost",
         port: 5555,
         uds_path: nil,
-        timeout_seconds: 42
+        timeout_seconds: 42,
+        deprecated_for_removal_transport_configuration_proc: nil
       )
     end
 


### PR DESCRIPTION
**What does this PR do?**
There are more occurences of deprecated span_type method in specs, remove them before ddtrace 2.0 release
