### PR TITLE
[CIVIS-8548] make test suite names more readable

### DIFF
--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -14,8 +14,6 @@ module Datadog
             super
             return unless datadog_configuration[:enabled]
 
-            test_name = "#{class_name}##{name}"
-
             test_suite_name = Helpers.test_suite_name(self.class, name)
             if Helpers.parallel?(self.class)
               test_suite_name = "#{test_suite_name} (#{name} concurrently)"
@@ -27,7 +25,7 @@ module Datadog
             source_file, line_number = method(name).source_location
 
             CI.start_test(
-              test_name,
+              name,
               test_suite_name,
               tags: {
                 CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -28,7 +28,7 @@ module Datadog
               suite_name = "#{test_suite_description} at #{metadata[:example_group][:rerun_file_path]}"
 
               # remove suite name from test name to avoid duplication
-              test_name = test_name.sub("#{test_suite_description} ", "").strip
+              test_name = test_name.sub(test_suite_description, "").strip
 
               CI.trace_test(
                 test_name,

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -14,10 +14,9 @@ module Datadog
             base.prepend(InstanceMethods)
           end
 
-          # Instance methods for configuration
           module InstanceMethods
-            def run(example_group_instance, reporter)
-              return super unless configuration[:enabled]
+            def run(*)
+              return super unless datadog_configuration[:enabled]
 
               test_name = full_description.strip
               if metadata[:description].empty?
@@ -25,9 +24,15 @@ module Datadog
                 test_name += " #{description}"
               end
 
+              test_suite_description = fetch_top_level_example_group[:description]
+              suite_name = "#{test_suite_description} at #{metadata[:example_group][:rerun_file_path]}"
+
+              # remove suite name from test name to avoid duplication
+              test_name = test_name.sub("#{test_suite_description} ", "").strip
+
               CI.trace_test(
                 test_name,
-                metadata[:example_group][:rerun_file_path],
+                suite_name,
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
@@ -35,7 +40,7 @@ module Datadog
                   CI::Ext::Test::TAG_SOURCE_FILE => Utils::Git.relative_to_root(metadata[:file_path]),
                   CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s
                 },
-                service: configuration[:service_name]
+                service: datadog_configuration[:service_name]
               ) do |test_span|
                 test_span.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
 
@@ -56,7 +61,17 @@ module Datadog
 
             private
 
-            def configuration
+            def fetch_top_level_example_group
+              return metadata[:example_group] unless metadata[:example_group][:parent_example_group]
+
+              res = metadata[:example_group][:parent_example_group]
+              while (parent = res[:parent_example_group])
+                res = parent
+              end
+              res
+            end
+
+            def datadog_configuration
               Datadog.configuration.ci[:rspec]
             end
           end

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -7,7 +7,7 @@ module Datadog
   module CI
     module Contrib
       module RSpec
-        # Instrument RSpec::Core::Example
+        # Instrument RSpec::Core::ExampleGroup
         module ExampleGroup
           def self.included(base)
             base.singleton_class.prepend(ClassMethods)
@@ -15,11 +15,12 @@ module Datadog
 
           # Instance methods for configuration
           module ClassMethods
-            def run(reporter = ::RSpec::Core::NullReporter)
-              return super unless configuration[:enabled]
+            def run(*)
+              return super unless datadog_configuration[:enabled]
               return super unless top_level?
 
-              test_suite = Datadog::CI.start_test_suite(file_path)
+              suite_name = "#{description} at #{file_path}"
+              test_suite = Datadog::CI.start_test_suite(suite_name)
 
               result = super
 
@@ -35,7 +36,7 @@ module Datadog
 
             private
 
-            def configuration
+            def datadog_configuration
               Datadog.configuration.ci[:rspec]
             end
           end

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -14,8 +14,8 @@ module Datadog
           end
 
           module InstanceMethods
-            def run_specs(example_groups)
-              return super unless configuration[:enabled]
+            def run_specs(*)
+              return super unless datadog_configuration[:enabled]
 
               test_session = CI.start_test_session(
                 tags: {
@@ -23,7 +23,7 @@ module Datadog
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
                   CI::Ext::Test::TAG_TYPE => CI::Ext::Test::TEST_TYPE
                 },
-                service: configuration[:service_name]
+                service: datadog_configuration[:service_name]
               )
 
               test_module = CI.start_test_module(test_session.name)
@@ -46,7 +46,7 @@ module Datadog
 
             private
 
-            def configuration
+            def datadog_configuration
               Datadog.configuration.ci[:rspec]
             end
           end

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -30,6 +30,8 @@ module Datadog
 
           private
 
+          def test_suite_name: (untyped test_case) -> String
+
           def start_test_suite: (String test_suite_name) -> void
 
           def finish_current_test_suite: () -> void

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -11,7 +11,8 @@ module Datadog
 
             private
 
-            def configuration: () -> untyped
+            def fetch_top_level_example_group: () -> Hash[Symbol, untyped]
+            def datadog_configuration: () -> untyped
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -12,7 +12,7 @@ module Datadog
 
             private
 
-            def configuration: () -> untyped
+            def datadog_configuration: () -> untyped
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/runner.rbs
@@ -12,7 +12,7 @@ module Datadog
 
             private
 
-            def configuration: () -> untyped
+            def datadog_configuration: () -> untyped
           end
         end
       end

--- a/spec/datadog/ci/contrib/cucumber/features/failing.feature
+++ b/spec/datadog/ci/contrib/cucumber/features/failing.feature
@@ -1,4 +1,4 @@
-Feature: Datadog integration
+Feature: Datadog integration - test failing features
   Scenario: cucumber failing scenario
     Given datadog
     And datadog

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Cucumber formatter" do
       expect(scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
       expect(scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("cucumber scenario")
       expect(scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(
-        "spec/datadog/ci/contrib/cucumber/features/passing.feature"
+        "Datadog integration at spec/datadog/ci/contrib/cucumber/features/passing.feature"
       )
       expect(scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_TYPE)).to eq(Datadog::CI::Ext::Test::TEST_TYPE)
       expect(scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK)).to eq(
@@ -147,7 +147,7 @@ RSpec.describe "Cucumber formatter" do
 
     it "creates test suite span" do
       expect(test_suite_span).not_to be_nil
-      expect(test_suite_span.name).to eq(features_path)
+      expect(test_suite_span.name).to eq("Datadog integration at spec/datadog/ci/contrib/cucumber/features/passing.feature")
       expect(test_suite_span.service).to eq("jalapenos")
       expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_SPAN_KIND)).to eq(
         Datadog::CI::Ext::AppTypes::TYPE_TEST
@@ -189,7 +189,9 @@ RSpec.describe "Cucumber formatter" do
         Datadog::CI::Ext::Test::Status::FAIL
       )
 
-      expect(test_suite_span.name).to eq(features_path)
+      expect(test_suite_span.name).to eq(
+        "Datadog integration - test failing features at spec/datadog/ci/contrib/cucumber/features/failing.feature"
+      )
       expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
         Datadog::CI::Ext::Test::Status::FAIL
       )
@@ -224,7 +226,7 @@ RSpec.describe "Cucumber formatter" do
           )
         end
         expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(
-          "spec/datadog/ci/contrib/cucumber/features/with_parameters.feature"
+          "Datadog integration for parametrized tests at spec/datadog/ci/contrib/cucumber/features/with_parameters.feature"
         )
         expect(span.get_tag(Datadog::CI::Ext::Test::TAG_TEST_SUITE_ID)).to eq(test_suite_span.id.to_s)
         expect(span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe "Minitest instrumentation" do
       klass.new(:test_foo).run
 
       expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-      expect(span.name).to eq("SomeTest#test_foo")
-      expect(span.resource).to eq("SomeTest#test_foo")
+      expect(span.name).to eq("test_foo")
+      expect(span.resource).to eq("test_foo")
       expect(span.service).to eq("ltest")
-      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("SomeTest#test_foo")
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("test_foo")
       expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(
         "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
@@ -110,9 +110,9 @@ RSpec.describe "Minitest instrumentation" do
       klass.new(method_name).run
 
       expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-      expect(span.resource).to eq("SomeSpec##{method_name}")
+      expect(span.resource).to eq(method_name)
       expect(span.service).to eq("ltest")
-      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("SomeSpec##{method_name}")
+      expect(span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq(method_name)
       expect(span.get_tag(Datadog::CI::Ext::Test::TAG_SUITE)).to eq(
         "SomeSpec at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
@@ -514,7 +514,7 @@ RSpec.describe "Minitest instrumentation" do
         end
 
         it "traces test, test session, test module with failed status" do
-          expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("SomeFailedTest#test_fail")
+          expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("test_fail")
           expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
             Datadog::CI::Ext::Test::Status::FAIL
           )
@@ -561,10 +561,10 @@ RSpec.describe "Minitest instrumentation" do
 
           expect(test_names).to eq(
             [
-              "SomeSpec#test_0001_does not fail",
-              "in context#test_0001_does not fail",
-              "in context::deeper context#test_0001_does not fail",
-              "in other context#test_0001_does not fail"
+              "test_0001_does not fail",
+              "test_0001_does not fail",
+              "test_0001_does not fail",
+              "test_0001_does not fail"
             ]
           )
         end
@@ -635,10 +635,10 @@ RSpec.describe "Minitest instrumentation" do
           test_names = test_spans.map { |span| span.get_tag(Datadog::CI::Ext::Test::TAG_NAME) }.sort
           expect(test_names).to eq(
             [
-              "TestA#test_a_1",
-              "TestA#test_a_2",
-              "TestB#test_b_1",
-              "TestB#test_b_2"
+              "test_a_1",
+              "test_a_2",
+              "test_b_1",
+              "test_b_2"
             ]
           )
 

--- a/vendor/rbs/cucumber/0/cucumber.rbs
+++ b/vendor/rbs/cucumber/0/cucumber.rbs
@@ -14,7 +14,6 @@ end
 module Cucumber::Formatter
 end
 
-
 class Cucumber::Core::Test::Result
   def failed?: () -> bool
   def ok?: () -> bool
@@ -26,4 +25,16 @@ class Cucumber::Formatter::AstLookup
   def initialize: (untyped config) -> void
 
   def scenario_source: (untyped test_case) -> untyped
+  def gherkin_document: (String uri) -> Cucumber::Messages::GherkinDocument?
+end
+
+module Cucumber::Messages
+end
+
+class Cucumber::Messages::GherkinDocument
+  def feature: () -> Cucumber::Messages::Feature
+end
+
+class Cucumber::Messages::Feature
+  def name: () -> String
 end

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -21,6 +21,7 @@ module RSpec::Core::ExampleGroup
     def run: () -> bool
     def top_level?: () -> bool
     def file_path: () -> String
+    def description: () -> String
   end
 end
 


### PR DESCRIPTION
**What does this PR do?**
Changes test suite name and test name definitions to improve UX and make test dashboard look nicer.

**Cucumber**
- uses feature name as a prefix for test suite name

Before:
<img width="899" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/39228a34-a9a5-43fc-b222-f7996ad91044">

After:
<img width="1023" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/fd66da85-b6e0-425a-aece-f9f1858e0169">

**RSpec**
- uses top-level example group description as test suite name
- removes top-level example group description from test name to avoid repetition

Before:
<img width="1108" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/7dca8298-9da0-4825-b7ef-6ca9f53dc865">

After:
<img width="1007" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/2e297610-e26b-457c-a6e2-5be2b4496990">

**Minitest**
- remove test suite class name from test.name tag to avoid unnecessary repetition

Before:
<img width="1211" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/8b9c55a9-fdaf-44c4-aa80-870b2074cdcf">

After:
<img width="1074" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/1759f2ec-6010-4884-b984-f9c0eab802da">


**Motivation**
Current test suite names and test names are not easily readable in test runs table

**How to test the change?**
Tested using a number of open source projects (see screenshots above)