### PR TITLE
[CIVIS-8333] get rid of span_type in tracer-related models

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -280,7 +280,7 @@ module Datadog
       # ```
       # Remember that in this case, calling {Datadog::CI::Span#finish} is mandatory.
       #
-      # @param [String] span_type custom, user-defined span type (for example "step" or "query").
+      # @param [String] type custom, user-defined span type (for example "step" or "query").
       # @param [String] span_name the resource this span refers, or `test` if it's missing
       # @param [Hash<String,String>] tags extra tags which should be added to the span.
       # @return [Object] If a block is provided, returns the result of the block execution.
@@ -290,8 +290,8 @@ module Datadog
       # @yield Optional block where newly created {Datadog::CI::Span} captures the execution.
       # @yieldparam [Datadog::CI::Span] ci_span the newly created and active [Datadog::CI::Span]
       # @yieldparam [Datadog::CI::NullSpan] ci_span null object if CI visibility is disabled
-      def trace(span_type, span_name, tags: {}, &block)
-        recorder.trace(span_type, span_name, tags: tags, &block)
+      def trace(type, span_name, tags: {}, &block)
+        recorder.trace(type, span_name, tags: tags, &block)
       end
 
       # The active, unfinished custom span if it matches given type.
@@ -314,12 +314,12 @@ module Datadog
       # step_span.finish()
       # ```
       #
-      # @param [String] span_type type of the span to retrieve (for example "step" or "query") that was provided to {.trace}
+      # @param [String] type type of the span to retrieve (for example "step" or "query") that was provided to {.trace}
       # @return [Datadog::CI::Span] the active span
       # @return [nil] if no span is active, or if the active span is not a custom span with given type
-      def active_span(span_type)
+      def active_span(type)
         span = recorder.active_span
-        span if span && span.span_type == span_type
+        span if span && span.type == type
       end
 
       # The active, unfinished test span.

--- a/lib/datadog/ci/null_span.rb
+++ b/lib/datadog/ci/null_span.rb
@@ -22,7 +22,7 @@ module Datadog
       def service
       end
 
-      def span_type
+      def type
       end
 
       def passed!

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -32,7 +32,7 @@ module Datadog
       end
 
       # @return [String] the type of the span (for example "test" or type that was provided to [Datadog::CI.trace]).
-      def span_type
+      def type
         tracer_span.type
       end
 

--- a/lib/datadog/ci/test_visibility/null_recorder.rb
+++ b/lib/datadog/ci/test_visibility/null_recorder.rb
@@ -23,7 +23,7 @@ module Datadog
           skip_tracing(block)
         end
 
-        def trace(span_type, span_name, tags: {}, &block)
+        def trace(type, span_name, tags: {}, &block)
           skip_tracing(block)
         end
 

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -121,10 +121,10 @@ module Datadog
           end
         end
 
-        def trace(span_type, span_name, tags: {}, &block)
+        def trace(type, span_name, tags: {}, &block)
           span_options = build_span_options(
             nil, # service name is completely optional for custom spans
-            span_type,
+            type,
             {resource: span_name}
           )
 
@@ -224,9 +224,9 @@ module Datadog
           span
         end
 
-        def build_span_options(service, span_type, other_options = {})
+        def build_span_options(service, type, other_options = {})
           other_options[:service] = service || @global_context.service
-          other_options[:type] = span_type
+          other_options[:type] = type
 
           other_options
         end

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -45,7 +45,7 @@ module Datadog
 
             packer.write_map_header(3)
 
-            write_field(packer, "type")
+            write_field(packer, "type", "event_type")
             write_field(packer, "version")
 
             packer.write("content")
@@ -119,15 +119,16 @@ module Datadog
             to_integer(@span.get_tag(Ext::Test::TAG_TEST_SUITE_ID))
           end
 
-          def type
-          end
-
           def version
             1
           end
 
           def span_type
             @span.type
+          end
+
+          def event_type
+            "span"
           end
 
           def name

--- a/lib/datadog/ci/test_visibility/serializers/span.rb
+++ b/lib/datadog/ci/test_visibility/serializers/span.rb
@@ -21,7 +21,7 @@ module Datadog
             CONTENT_MAP_SIZE
           end
 
-          def type
+          def event_type
             "span"
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/test_module.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_module.rb
@@ -22,7 +22,7 @@ module Datadog
             CONTENT_MAP_SIZE
           end
 
-          def type
+          def event_type
             Ext::AppTypes::TYPE_TEST_MODULE
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/test_session.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_session.rb
@@ -22,7 +22,7 @@ module Datadog
             CONTENT_MAP_SIZE
           end
 
-          def type
+          def event_type
             Ext::AppTypes::TYPE_TEST_SESSION
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/test_suite.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_suite.rb
@@ -22,7 +22,7 @@ module Datadog
             CONTENT_MAP_SIZE
           end
 
-          def type
+          def event_type
             Ext::AppTypes::TYPE_TEST_SUITE
           end
 

--- a/lib/datadog/ci/test_visibility/serializers/test_v1.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_v1.rb
@@ -22,7 +22,7 @@ module Datadog
             CONTENT_MAP_SIZE
           end
 
-          def type
+          def event_type
             Ext::AppTypes::TYPE_TEST
           end
 

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -10,7 +10,7 @@ module Datadog
 
     def self.start_test_suite: (String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
-    def self.trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+    def self.trace: (String type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
     def self.active_test_session: () -> Datadog::CI::TestSession?
 
@@ -20,7 +20,7 @@ module Datadog
 
     def self.active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
 
-    def self.active_span: (String span_type) -> Datadog::CI::Span?
+    def self.active_span: (String type) -> Datadog::CI::Span?
 
     def self.deactivate_test: (Datadog::CI::Test test) -> void
 

--- a/sig/datadog/ci/null_span.rbs
+++ b/sig/datadog/ci/null_span.rbs
@@ -9,7 +9,7 @@ module Datadog
 
       def service: () -> nil
 
-      def span_type: () -> nil
+      def type: () -> nil
 
       def passed!: () -> nil
 

--- a/sig/datadog/ci/span.rbs
+++ b/sig/datadog/ci/span.rbs
@@ -37,7 +37,7 @@ module Datadog
 
       def finish: () -> void
 
-      def span_type: () -> String
+      def type: () -> String
 
       def set_environment_runtime_tags: () -> void
 

--- a/sig/datadog/ci/test_visibility/null_recorder.rbs
+++ b/sig/datadog/ci/test_visibility/null_recorder.rbs
@@ -8,7 +8,7 @@ module Datadog
 
         def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
-        def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+        def trace: (String type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
         def start_test_session: (?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 

--- a/sig/datadog/ci/test_visibility/recorder.rbs
+++ b/sig/datadog/ci/test_visibility/recorder.rbs
@@ -18,7 +18,7 @@ module Datadog
 
         def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
-        def trace: (String span_type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
+        def trace: (String type, String span_name, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
         def start_test_session: (?service: String?, ?tags: Hash[untyped, untyped]) -> Datadog::CI::Span
 
@@ -60,7 +60,7 @@ module Datadog
 
         def build_span: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Span
 
-        def build_span_options: (String? service_name, String span_type, ?Hash[Symbol, untyped] other_options) -> Hash[Symbol, untyped]
+        def build_span_options: (String? service_name, String type, ?Hash[Symbol, untyped] other_options) -> Hash[Symbol, untyped]
 
         def set_initial_tags: (Datadog::CI::Span ci_span, Hash[untyped, untyped] tags) -> void
 

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -46,11 +46,11 @@ module Datadog
 
           def test_suite_id: () -> Integer?
 
-          def type: () -> nil
-
           def version: () -> 1
 
-          def span_type: () -> String
+          def type: () -> String
+
+          def event_type: () -> String
 
           def name: () -> String
 

--- a/spec/datadog/ci/null_span_spec.rb
+++ b/spec/datadog/ci/null_span_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe Datadog::CI::NullSpan do
     end
   end
 
-  describe "#span_type" do
+  describe "#type" do
     it "returns nil" do
-      expect(span.span_type).to be_nil
+      expect(span.type).to be_nil
     end
   end
 end

--- a/spec/datadog/ci/span_spec.rb
+++ b/spec/datadog/ci/span_spec.rb
@@ -223,9 +223,9 @@ RSpec.describe Datadog::CI::Span do
     end
   end
 
-  describe "#span_type" do
+  describe "#type" do
     it "returns 'test'" do
-      expect(span.span_type).to eq("test")
+      expect(span.type).to eq("test")
     end
   end
 

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -87,13 +87,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
     end
 
     describe "#trace" do
-      let(:span_type) { "step" }
+      let(:type) { "step" }
       let(:span_name) { "my test step" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
       context "when given a block" do
         before do
-          recorder.trace(span_type, span_name, tags: tags) do |span|
+          recorder.trace(type, span_name, tags: tags) do |span|
             span.set_metric("my.metric", 42)
           end
         end
@@ -101,7 +101,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         it "traces the block" do
           expect(subject.resource).to eq(span_name)
-          expect(subject.type).to eq(span_type)
+          expect(subject.type).to eq(type)
         end
       end
     end
@@ -111,13 +111,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
     include_context "CI mode activated"
 
     describe "#trace" do
-      let(:span_type) { "step" }
+      let(:type) { "step" }
       let(:span_name) { "my test step" }
       let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
       context "when given a block" do
         before do
-          recorder.trace(span_type, span_name, tags: tags) do |span|
+          recorder.trace(type, span_name, tags: tags) do |span|
             span.set_metric("my.metric", 42)
           end
         end
@@ -125,7 +125,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         it "traces the block" do
           expect(subject.resource).to eq(span_name)
-          expect(subject.type).to eq(span_type)
+          expect(subject.type).to eq(type)
         end
 
         it "sets the custom metric correctly" do
@@ -158,7 +158,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           subject.finish
 
           expect(span.resource).to eq(span_name)
-          expect(span.type).to eq(span_type)
+          expect(span.type).to eq(type)
         end
 
         it_behaves_like "span with environment tags"
@@ -189,7 +189,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
             expect(subject.name).to eq(test_name)
             expect(subject.service).to eq(test_service)
             expect(subject.tracer_span.name).to eq(test_name)
-            expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+            expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
           end
 
           it "sets the provided tags correctly" do
@@ -359,7 +359,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         expect(subject).to be_kind_of(Datadog::CI::TestSession)
         expect(subject.name).to eq(test_command)
         expect(subject.service).to eq(service)
-        expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
+        expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
       end
 
       it "sets the test session id" do
@@ -395,7 +395,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           expect(subject).to be_kind_of(Datadog::CI::TestModule)
           expect(subject.name).to eq(module_name)
           expect(subject.service).to eq(service)
-          expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
+          expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE)
         end
 
         it "sets the test module id" do
@@ -483,7 +483,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           expect(subject).to be_kind_of(Datadog::CI::TestSuite)
           expect(subject.name).to eq(suite_name)
           expect(subject.service).to eq(session_service)
-          expect(subject.span_type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
+          expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE)
         end
 
         it "sets the provided tags correctly while inheriting some tags from the session" do

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Datadog::CI do
     end
 
     describe "::trace" do
-      subject(:trace) { described_class.trace(span_type, span_name, **options, &block) }
+      subject(:trace) { described_class.trace(type, span_name, **options, &block) }
 
-      let(:span_type) { "span type" }
+      let(:type) { "span type" }
       let(:span_name) { "span name" }
       let(:options) { {tags: {"foo" => "bar"}} }
       let(:block) { proc {} }
@@ -60,19 +60,19 @@ RSpec.describe Datadog::CI do
       let(:ci_span) { instance_double(Datadog::CI::Span) }
 
       before do
-        allow(recorder).to receive(:trace).with(span_type, span_name, **options, &block).and_return(ci_span)
+        allow(recorder).to receive(:trace).with(type, span_name, **options, &block).and_return(ci_span)
       end
 
       it { is_expected.to be(ci_span) }
     end
 
     describe "::active_span" do
-      subject(:active_span) { described_class.active_span(span_type) }
+      subject(:active_span) { described_class.active_span(type) }
 
-      let(:span_type) { "span type" }
+      let(:type) { "span type" }
 
       context "when span type matches current active span" do
-        let(:ci_span) { instance_double(Datadog::CI::Span, span_type: span_type) }
+        let(:ci_span) { instance_double(Datadog::CI::Span, type: type) }
 
         before do
           allow(recorder).to receive(:active_span).and_return(ci_span)
@@ -82,7 +82,7 @@ RSpec.describe Datadog::CI do
       end
 
       context "when span type does not match current active span" do
-        let(:ci_span) { instance_double(Datadog::CI::Span, span_type: "other span type") }
+        let(:ci_span) { instance_double(Datadog::CI::Span, type: "other span type") }
 
         before do
           allow(recorder).to receive(:active_span).and_return(ci_span)

--- a/vendor/rbs/ddtrace/0/datadog/tracing/span_operation.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/tracing/span_operation.rbs
@@ -126,10 +126,6 @@ module Datadog
       def duration_nano: () -> untyped
 
       alias span_id id
-
-      alias span_type type
-
-      alias span_type= type=
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
dd-trace-rb recently dropped span_type method for SpanOperation. In order to avoid confusion, I do the same in Datadog::CI context.

For serializers span_type method stays to distinguish it from event type (that can have slightly different meaning). To reduce confusion for future self and other contributors, `Serializers::Base#type` is renamed to `Serializers::Base#event_type`

**Motivation**
Reducing confusion and surprise level of our API
