### PR TITLE
[CIVIS-8549] better skipped tests and suites support

### DIFF
--- a/lib/datadog/ci/concurrent_span.rb
+++ b/lib/datadog/ci/concurrent_span.rb
@@ -12,7 +12,8 @@ module Datadog
       def initialize(tracer_span)
         super
 
-        @mutex = Mutex.new
+        # we use Monitor instead of Mutex because it is reentrant
+        @mutex = Monitor.new
       end
 
       # Gets tag value by key. This method is thread-safe.

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -122,16 +122,12 @@ module Datadog
           end
 
           def finish_test(span, result)
-            if result.skipped? || result.pending? || result.undefined?
+            if !result.passed? && result.ok?(@config.strict)
               span.skipped!(reason: result.message)
-            elsif result.failed?
-              span.failed!(exception: result.exception)
-            elsif result.ok?
+            elsif result.passed?
               span.passed!
             else
-              Datadog.logger.warn do
-                "Unknown test result #{result.class.name} for test #{span.name}"
-              end
+              span.failed!(exception: result.exception)
             end
             span.finish
           end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -80,14 +80,6 @@ module Datadog
             test_span = CI.active_test
             return if test_span.nil?
 
-            # We need to track overall test failures manually if we are using cucumber < 8.0 because
-            # TestRunFinished event does not have a success attribute before 8.0.
-            #
-            if event.result.failed?
-              test_suite = @current_test_suite
-              test_suite.failed! if test_suite
-            end
-
             finish_test(test_span, event.result)
           end
 
@@ -127,6 +119,9 @@ module Datadog
             else
               span.failed!(exception: result.exception)
               @failed_tests_count += 1
+
+              test_suite = @current_test_suite
+              test_suite.failed! if test_suite
             end
             span.finish
           end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -15,11 +15,12 @@ module Datadog
 
           def initialize(config)
             @ast_lookup = ::Cucumber::Formatter::AstLookup.new(config) if defined?(::Cucumber::Formatter::AstLookup)
-
             @config = config
-            @failed_tests_count = 0
 
             @current_test_suite = nil
+
+            @failed_tests_count = 0
+            @test_suite_stats = Hash.new(0)
 
             bind_events(config)
           end
@@ -80,7 +81,9 @@ module Datadog
             test_span = CI.active_test
             return if test_span.nil?
 
-            finish_test(test_span, event.result)
+            datadog_status = finish_span(test_span, event.result)
+            @test_suite_stats[datadog_status] += 1
+            @failed_tests_count += 1 if datadog_status == :failed
           end
 
           def on_test_step_started(event)
@@ -91,7 +94,7 @@ module Datadog
             current_step_span = CI.active_span
             return if current_step_span.nil?
 
-            finish_test(current_step_span, event.result)
+            finish_span(current_step_span, event.result)
           end
 
           private
@@ -111,19 +114,23 @@ module Datadog
             end
           end
 
-          def finish_test(span, result)
-            if !result.passed? && result.ok?(@config.strict)
+          def finish_span(span, result)
+            datadog_status = if !result.passed? && result.ok?(@config.strict)
               span.skipped!(reason: result.message)
+
+              :skipped
             elsif result.passed?
               span.passed!
+
+              :passed
             else
               span.failed!(exception: result.exception)
-              @failed_tests_count += 1
 
-              test_suite = @current_test_suite
-              test_suite.failed! if test_suite
+              :failed
             end
             span.finish
+
+            datadog_status
           end
 
           def finish_session(result)
@@ -149,18 +156,25 @@ module Datadog
           def start_test_suite(test_suite_name)
             finish_current_test_suite
 
-            test_suite = CI.start_test_suite(test_suite_name)
-            # will be overridden if any test fails
-            test_suite.passed! if test_suite
-
-            @current_test_suite = test_suite
+            @current_test_suite = CI.start_test_suite(test_suite_name)
           end
 
           def finish_current_test_suite
             test_suite = @current_test_suite
             return unless test_suite
 
+            if @test_suite_stats[:failed] > 0
+              test_suite.failed!
+            elsif @test_suite_stats[:passed] > 0
+              test_suite.passed!
+            else
+              test_suite.skipped!
+            end
+
             test_suite.finish
+
+            @test_suite_stats = Hash.new(0)
+            @current_test_suite = nil
           end
 
           def same_test_suite_as_current?(test_suite_name)

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -122,12 +122,16 @@ module Datadog
           end
 
           def finish_test(span, result)
-            if result.skipped?
-              span.skipped!
-            elsif result.ok?
-              span.passed!
+            if result.skipped? || result.pending? || result.undefined?
+              span.skipped!(reason: result.message)
             elsif result.failed?
               span.failed!(exception: result.exception)
+            elsif result.ok?
+              span.passed!
+            else
+              Datadog.logger.warn do
+                "Unknown test result #{result.class.name} for test #{span.name}"
+              end
             end
             span.finish
           end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -84,8 +84,6 @@ module Datadog
             # TestRunFinished event does not have a success attribute before 8.0.
             #
             if event.result.failed?
-              @failed_tests_count += 1
-
               test_suite = @current_test_suite
               test_suite.failed! if test_suite
             end
@@ -128,6 +126,7 @@ module Datadog
               span.passed!
             else
               span.failed!(exception: result.exception)
+              @failed_tests_count += 1
             end
             span.finish
           end

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -41,9 +41,9 @@ module Datadog
             test_span = CI.active_test
             return super unless test_span
 
-            finish_test(test_span, result_code)
+            finish_with_result(test_span, result_code)
             if Helpers.parallel?(self.class)
-              finish_test_suite(test_span.test_suite, result_code)
+              finish_with_result(test_span.test_suite, result_code)
             end
 
             super
@@ -51,23 +51,9 @@ module Datadog
 
           private
 
-          def finish_test(test_span, result_code)
-            finish_with_result(test_span, result_code)
-
-            # mark test suite as failed if any test failed
-            if test_span.failed?
-              test_suite = test_span.test_suite
-              test_suite.failed! if test_suite
-            end
-          end
-
-          def finish_test_suite(test_suite, result_code)
-            return unless test_suite
-
-            finish_with_result(test_suite, result_code)
-          end
-
           def finish_with_result(span, result_code)
+            return unless span
+
             case result_code
             when "."
               span.passed!

--- a/lib/datadog/ci/contrib/minitest/runnable.rb
+++ b/lib/datadog/ci/contrib/minitest/runnable.rb
@@ -20,7 +20,6 @@ module Datadog
               test_suite_name = Helpers.test_suite_name(self, method)
 
               test_suite = Datadog::CI.start_test_suite(test_suite_name)
-              test_suite.passed! if test_suite # will be overridden if any test fails
 
               results = super
               return results unless test_suite

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -60,13 +60,11 @@ module Datadog
                     test_suite_span.failed! if test_suite_span
                   else
                     # :pending or nil
-                    if execution_result.pending_message
-                      test_span.skipped!(reason: execution_result.pending_message)
-                    elsif execution_result.example_skipped?
-                      test_span.skipped!(exception: execution_result.exception)
-                    else
-                      test_span.skipped!(exception: execution_result.pending_exception)
-                    end
+                    test_span.skipped!(
+                      reason: execution_result.pending_message,
+                      exception: execution_result.pending_exception
+                    )
+
                     test_suite_span.skipped! if test_suite_span
                   end
                 end

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -37,11 +37,13 @@ module Datadog
 
           def current_examples_count
             return 0 unless reporter_counts_examples?
+
             reporter.examples.count
           end
 
           def current_pending_examples_count
             return 0 unless reporter_counts_examples?
+
             reporter.pending_examples.count
           end
         end

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -7,6 +7,45 @@ module Datadog
   module CI
     module Contrib
       module RSpec
+        class ExampleResultsCounter
+          def initialize(reporter)
+            @reporter = reporter
+            @examples_start_count = current_examples_count
+            @pending_examples_start_count = current_pending_examples_count
+          end
+
+          def all_pending_since_start?
+            return false unless reporter_counts_examples?
+
+            examples_since_start_count = current_examples_count - @examples_start_count
+            pending_examples_since_start_count = current_pending_examples_count - @pending_examples_start_count
+
+            examples_since_start_count == pending_examples_since_start_count
+          end
+
+          private
+
+          attr_reader :reporter
+
+          def reporter_counts_examples?
+            return @reporter_counts_examples if defined?(@reporter_counts_examples)
+
+            @reporter_counts_examples = reporter.respond_to?(:examples) && !reporter.examples.nil? &&
+              reporter.examples.is_a?(Array) && reporter.respond_to?(:pending_examples) &&
+              !reporter.pending_examples.nil? && reporter.pending_examples.is_a?(Array)
+          end
+
+          def current_examples_count
+            return 0 unless reporter_counts_examples?
+            reporter.examples.count
+          end
+
+          def current_pending_examples_count
+            return 0 unless reporter_counts_examples?
+            reporter.pending_examples.count
+          end
+        end
+
         # Instrument RSpec::Core::ExampleGroup
         module ExampleGroup
           def self.included(base)
@@ -15,24 +54,31 @@ module Datadog
 
           # Instance methods for configuration
           module ClassMethods
-            def run(*)
+            def run(reporter = ::RSpec::Core::NullReporter)
               return super unless datadog_configuration[:enabled]
               return super unless top_level?
 
               suite_name = "#{description} at #{file_path}"
               test_suite = Datadog::CI.start_test_suite(suite_name)
 
-              result = super
-              return result unless test_suite
+              counter = ExampleResultsCounter.new(reporter)
 
-              if result
-                test_suite.passed!
+              success = super
+              return success unless test_suite
+
+              if success
+                if counter.all_pending_since_start?
+                  test_suite.skipped!
+                else
+                  test_suite.passed!
+                end
               else
                 test_suite.failed!
               end
+
               test_suite.finish
 
-              result
+              success
             end
 
             private

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -7,47 +7,6 @@ module Datadog
   module CI
     module Contrib
       module RSpec
-        class ExampleResultsCounter
-          def initialize(reporter)
-            @reporter = reporter
-            @examples_start_count = current_examples_count
-            @pending_examples_start_count = current_pending_examples_count
-          end
-
-          def all_pending_since_start?
-            return false unless reporter_counts_examples?
-
-            examples_since_start_count = current_examples_count - @examples_start_count
-            pending_examples_since_start_count = current_pending_examples_count - @pending_examples_start_count
-
-            examples_since_start_count == pending_examples_since_start_count
-          end
-
-          private
-
-          attr_reader :reporter
-
-          def reporter_counts_examples?
-            return @reporter_counts_examples if defined?(@reporter_counts_examples)
-
-            @reporter_counts_examples = reporter.respond_to?(:examples) && !reporter.examples.nil? &&
-              reporter.examples.is_a?(Array) && reporter.respond_to?(:pending_examples) &&
-              !reporter.pending_examples.nil? && reporter.pending_examples.is_a?(Array)
-          end
-
-          def current_examples_count
-            return 0 unless reporter_counts_examples?
-
-            reporter.examples.count
-          end
-
-          def current_pending_examples_count
-            return 0 unless reporter_counts_examples?
-
-            reporter.pending_examples.count
-          end
-        end
-
         # Instrument RSpec::Core::ExampleGroup
         module ExampleGroup
           def self.included(base)
@@ -63,20 +22,8 @@ module Datadog
               suite_name = "#{description} at #{file_path}"
               test_suite = Datadog::CI.start_test_suite(suite_name)
 
-              counter = ExampleResultsCounter.new(reporter)
-
               success = super
               return success unless test_suite
-
-              if success
-                if counter.all_pending_since_start?
-                  test_suite.skipped!
-                else
-                  test_suite.passed!
-                end
-              else
-                test_suite.failed!
-              end
 
               test_suite.finish
 

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -25,6 +25,14 @@ module Datadog
               success = super
               return success unless test_suite
 
+              if success && test_suite.passed_tests_count > 0
+                test_suite.passed!
+              elsif success
+                test_suite.skipped!
+              else
+                test_suite.failed!
+              end
+
               test_suite.finish
 
               success

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -62,6 +62,33 @@ module Datadog
         get_tag(Ext::Test::TAG_SOURCE_FILE)
       end
 
+      # Sets the status of the span to "pass".
+      # @return [void]
+      def passed!
+        super
+
+        record_test_result(Ext::Test::Status::PASS)
+      end
+
+      # Sets the status of the span to "fail".
+      # @param [Exception] exception the exception that caused the test to fail.
+      # @return [void]
+      def failed!(exception: nil)
+        super
+
+        record_test_result(Ext::Test::Status::FAIL)
+      end
+
+      # Sets the status of the span to "skip".
+      # @param [Exception] exception the exception that caused the test to fail.
+      # @param [String] reason the reason why the test was skipped.
+      # @return [void]
+      def skipped!(exception: nil, reason: nil)
+        super
+
+        record_test_result(Ext::Test::Status::SKIP)
+      end
+
       # Sets the parameters for this test (e.g. Cucumber example or RSpec shared specs).
       # Parameters are needed to compute test fingerprint to distinguish between different tests having same names.
       #
@@ -80,6 +107,13 @@ module Datadog
             }
           )
         )
+      end
+
+      private
+
+      def record_test_result(datadog_status)
+        suite = test_suite
+        suite.record_test_result(datadog_status) if suite
       end
     end
   end

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -23,7 +23,7 @@ module Datadog
       # @return [void]
       def finish
         synchronize do
-          # we need to derive test suite status from execution stats if no status was set explicitly
+          # we try to derive test suite status from execution stats if no status was set explicitly
           set_status_from_stats! if undefined?
 
           super

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -13,12 +13,63 @@ module Datadog
     #
     # @public_api
     class TestSuite < ConcurrentSpan
+      def initialize(tracer_span)
+        super
+
+        @test_suite_stats = Hash.new(0)
+      end
+
       # Finishes this test suite.
       # @return [void]
       def finish
-        super
+        synchronize do
+          # we need to derive test suite status from execution stats if no status was set explicitly
+          set_status_from_stats! if undefined?
 
-        recorder.deactivate_test_suite(name)
+          super
+
+          recorder.deactivate_test_suite(name)
+        end
+      end
+
+      # @internal
+      def record_test_result(datadog_test_status)
+        synchronize do
+          @test_suite_stats[datadog_test_status] += 1
+        end
+      end
+
+      # @internal
+      def passed_tests_count
+        synchronize do
+          @test_suite_stats[Ext::Test::Status::PASS]
+        end
+      end
+
+      # @internal
+      def skipped_tests_count
+        synchronize do
+          @test_suite_stats[Ext::Test::Status::SKIP]
+        end
+      end
+
+      # @internal
+      def failed_tests_count
+        synchronize do
+          @test_suite_stats[Ext::Test::Status::FAIL]
+        end
+      end
+
+      private
+
+      def set_status_from_stats!
+        if failed_tests_count > 0
+          failed!
+        elsif passed_tests_count == 0
+          skipped!
+        else
+          passed!
+        end
       end
     end
   end

--- a/sig/datadog/ci/concurrent_span.rbs
+++ b/sig/datadog/ci/concurrent_span.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module CI
     class ConcurrentSpan < Span
-      @mutex: Thread::Mutex
+      @mutex: Monitor
 
       def initialize: (Datadog::Tracing::SpanOperation tracer_span) -> void
       def passed!: () -> void

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -10,7 +10,6 @@ module Datadog
           @current_test_suite: Datadog::CI::TestSuite?
 
           @failed_tests_count: Integer
-          @test_suite_stats: Hash[Symbol, Integer]
 
           attr_reader config: untyped
 
@@ -44,7 +43,7 @@ module Datadog
 
           def finish_session: (bool result) -> void
 
-          def finish_span: (Datadog::CI::Span span, Cucumber::Core::Test::Result result) -> Symbol
+          def finish_span: (Datadog::CI::Span span, Cucumber::Core::Test::Result result) -> void
 
           def extract_parameters_hash: (untyped test_case) -> Hash[String, String]?
 

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -4,9 +4,13 @@ module Datadog
       module Cucumber
         class Formatter
           private
-          @failed_tests_count: Integer
-          @current_test_suite: Datadog::CI::Span?
           @ast_lookup: ::Cucumber::Formatter::AstLookup
+          @config: untyped
+
+          @current_test_suite: Datadog::CI::TestSuite?
+
+          @failed_tests_count: Integer
+          @test_suite_stats: Hash[Symbol, Integer]
 
           attr_reader config: untyped
 
@@ -40,7 +44,7 @@ module Datadog
 
           def finish_session: (bool result) -> void
 
-          def finish_test: (Datadog::CI::Span test, Cucumber::Core::Test::Result result) -> void
+          def finish_span: (Datadog::CI::Span span, Cucumber::Core::Test::Result result) -> Symbol
 
           def extract_parameters_hash: (untyped test_case) -> Hash[String, String]?
 

--- a/sig/datadog/ci/contrib/minitest/hooks.rbs
+++ b/sig/datadog/ci/contrib/minitest/hooks.rbs
@@ -13,11 +13,7 @@ module Datadog
 
           def datadog_configuration: () -> untyped
 
-          def finish_test: (Datadog::CI::Test test_span, String result_code) -> void
-
-          def finish_test_suite: (Datadog::CI::TestSuite? test_suite, String result_code) -> void
-
-          def finish_with_result: (Datadog::CI::Span span, String result_code) -> void
+          def finish_with_result: (Datadog::CI::Span? span, String result_code) -> void
 
           def self.test_order: () -> (nil | :parallel | :sorted | :random | :alpha)
         end

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -2,27 +2,6 @@ module Datadog
   module CI
     module Contrib
       module RSpec
-        class ExampleResultsCounter
-          @reporter: untyped
-          @examples_start_count: Integer
-          @pending_examples_start_count: Integer
-          @reporter_counts_examples: bool
-
-
-          def initialize: (untyped reporter) -> void
-
-          def all_pending_since_start?: () -> bool
-
-          private
-          attr_reader reporter: untyped
-
-          def reporter_counts_examples?: () -> bool
-
-          def current_examples_count: () -> Integer
-
-          def current_pending_examples_count: () -> Integer
-        end
-
         module ExampleGroup
           def self.included: (untyped base) -> untyped
 

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -2,6 +2,27 @@ module Datadog
   module CI
     module Contrib
       module RSpec
+        class ExampleResultsCounter
+          @reporter: untyped
+          @examples_start_count: Integer
+          @pending_examples_start_count: Integer
+          @reporter_counts_examples: bool
+
+
+          def initialize: (untyped reporter) -> void
+
+          def all_pending_since_start?: () -> bool
+
+          private
+          attr_reader reporter: untyped
+
+          def reporter_counts_examples?: () -> bool
+
+          def current_examples_count: () -> Integer
+
+          def current_pending_examples_count: () -> Integer
+        end
+
         module ExampleGroup
           def self.included: (untyped base) -> untyped
 

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -8,6 +8,10 @@ module Datadog
       def test_module_id: () -> String?
       def test_session_id: () -> String?
       def source_file: () -> String?
+
+      private
+
+      def record_test_result: (String datadog_status) -> void
     end
   end
 end

--- a/sig/datadog/ci/test_suite.rbs
+++ b/sig/datadog/ci/test_suite.rbs
@@ -1,6 +1,17 @@
 module Datadog
   module CI
     class TestSuite < ConcurrentSpan
+      @test_suite_stats: Hash[String, Integer]
+
+      def record_test_result: (String datadog_test_status) -> void
+
+      def passed_tests_count: () -> Integer
+      def skipped_tests_count: () -> Integer
+      def failed_tests_count: () -> Integer
+
+      private
+
+      def set_status_from_stats!: () -> void
     end
   end
 end

--- a/spec/datadog/ci/contrib/cucumber/features/passing.feature
+++ b/spec/datadog/ci/contrib/cucumber/features/passing.feature
@@ -4,3 +4,17 @@ Feature: Datadog integration
     Given datadog
     And datadog
     Then datadog
+
+  Scenario: undefined scenario
+    Given datadog
+    And undefined
+    Then undefined
+
+  Scenario: pending scenario
+    Given datadog
+    Then pending
+
+  Scenario: skipped scenario
+    Given datadog
+    And skip
+    Then datadog

--- a/spec/datadog/ci/contrib/cucumber/features/skipped.feature
+++ b/spec/datadog/ci/contrib/cucumber/features/skipped.feature
@@ -1,0 +1,11 @@
+Feature: All scenarios are skipped
+
+  Scenario: undefined scenario
+    Given datadog
+    And undefined
+    Then undefined
+
+  Scenario: skipped scenario
+    Given datadog
+    And skip
+    Then datadog

--- a/spec/datadog/ci/contrib/cucumber/features/step_definitions/steps.rb
+++ b/spec/datadog/ci/contrib/cucumber/features/step_definitions/steps.rb
@@ -6,6 +6,14 @@ Then "failure" do
   expect(1 + 1).to eq(3)
 end
 
+Then "pending" do
+  pending("implementation")
+end
+
+Then "skip" do
+  skip_this_scenario
+end
+
 Then(/I add (-?\d+) and (-?\d+)/) do |n1, n2|
   @res = n1.to_i + n2.to_i
 end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -70,6 +70,8 @@ RSpec.describe "Cucumber formatter" do
     let(:feature_file_to_run) { "passing.feature" }
 
     it "creates spans for each scenario and step" do
+      expect(test_spans).to have(4).items
+
       scenario_span = spans.find { |s| s.resource == "cucumber scenario" }
 
       expect(scenario_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
@@ -106,6 +108,39 @@ RSpec.describe "Cucumber formatter" do
         expect(span.get_tag(Datadog::Tracing::Metadata::Ext::Distributed::TAG_ORIGIN))
           .to eq(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
       end
+    end
+
+    it "marks undefined cucumber scenario as skipped" do
+      undefined_scenario_span = spans.find { |s| s.resource == "undefined scenario" }
+      expect(undefined_scenario_span).not_to be_nil
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
+        Datadog::CI::Ext::Test::Status::SKIP
+      )
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq(
+        'Undefined step: "undefined"'
+      )
+    end
+
+    it "marks pending cucumber scenario as skipped" do
+      undefined_scenario_span = spans.find { |s| s.resource == "pending scenario" }
+      expect(undefined_scenario_span).not_to be_nil
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
+        Datadog::CI::Ext::Test::Status::SKIP
+      )
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq(
+        "implementation"
+      )
+    end
+
+    it "marks skipped cucumber scenario as skipped" do
+      undefined_scenario_span = spans.find { |s| s.resource == "skipped scenario" }
+      expect(undefined_scenario_span).not_to be_nil
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
+        Datadog::CI::Ext::Test::Status::SKIP
+      )
+      expect(undefined_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq(
+        "Scenario skipped"
+      )
     end
 
     it "creates test session span" do

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -317,6 +317,11 @@ RSpec.describe "Cucumber formatter" do
       expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
     end
 
+    it "marks test suite as failed" do
+      expect(test_suite_span).not_to be_nil
+      expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::FAIL)
+    end
+
     it "marks undefined cucumber scenario as failed" do
       undefined_scenario_span = spans.find { |s| s.resource == "undefined scenario" }
       expect(undefined_scenario_span).not_to be_nil

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe "Cucumber formatter" do
     let(:feature_file_to_run) { "with_parameters.feature" }
 
     it "a single test suite, and a test span for each example with parameters JSON" do
-      expect(test_spans.count).to eq(3)
-      expect(test_suite_spans.count).to eq(1)
+      expect(test_spans).to have(3).items
+      expect(test_suite_spans).to have(1).item
 
       test_spans.each_with_index do |span, index|
         # test parameters are available since cucumber 4
@@ -269,7 +269,7 @@ RSpec.describe "Cucumber formatter" do
     let(:failing_test_suite) { test_suite_spans.find { |span| span.name =~ /failing/ } }
 
     it "creates a test suite span for each feature" do
-      expect(test_suite_spans.count).to eq(3)
+      expect(test_suite_spans).to have(4).items
       expect(passing_test_suite.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
         Datadog::CI::Ext::Test::Status::PASS
       )
@@ -345,6 +345,27 @@ RSpec.describe "Cucumber formatter" do
       expect(skipped_scenario_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(
         Datadog::CI::Ext::Test::Status::SKIP
       )
+    end
+  end
+
+  context "executing a feature where all scenarios are skipped" do
+    let(:feature_file_to_run) { "skipped.feature" }
+
+    it "marks all test spans as skipped" do
+      expect(test_spans).to have(2).items
+      expect(test_spans.map { |span| span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS) }.uniq).to eq(
+        [Datadog::CI::Ext::Test::Status::SKIP]
+      )
+    end
+
+    it "marks test session as passed" do
+      expect(test_session_span).not_to be_nil
+      expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
+    end
+
+    it "marks test suite as skipped" do
+      expect(test_suite_span).not_to be_nil
+      expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::SKIP)
     end
   end
 end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -675,6 +675,39 @@ RSpec.describe "Minitest instrumentation" do
           )
         end
       end
+
+      context "skipped suite" do
+        before(:context) do
+          Minitest::Runnable.reset
+
+          class SkippedTest < Minitest::Test
+            def test_1
+              skip
+            end
+
+            def test_2
+              skip
+            end
+          end
+        end
+
+        it "marks all test spans as skipped" do
+          expect(test_spans).to have(2).items
+          expect(test_spans.map { |span| span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS) }.uniq).to eq(
+            [Datadog::CI::Ext::Test::Status::SKIP]
+          )
+        end
+
+        it "marks test session as passed" do
+          expect(test_session_span).not_to be_nil
+          expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::PASS)
+        end
+
+        it "marks test suite as skipped" do
+          expect(test_suite_span).not_to be_nil
+          expect(test_suite_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::SKIP)
+        end
+      end
     end
   end
 end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -343,7 +343,7 @@ RSpec.describe "RSpec hooks" do
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::SKIP)
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("foo")
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq("did not fix the math yet")
-      expect(first_test_span).not_to have_error
+      expect(first_test_span).to have_error
     end
 
     it "with pending keyword and passing" do
@@ -374,7 +374,7 @@ RSpec.describe "RSpec hooks" do
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_STATUS)).to eq(Datadog::CI::Ext::Test::Status::SKIP)
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_NAME)).to eq("foo")
       expect(first_test_span.get_tag(Datadog::CI::Ext::Test::TAG_SKIP_REASON)).to eq("did not fix the math yet")
-      expect(first_test_span).not_to have_error
+      expect(first_test_span).to have_error
     end
   end
 

--- a/spec/datadog/ci/test_suite_spec.rb
+++ b/spec/datadog/ci/test_suite_spec.rb
@@ -6,20 +6,99 @@ RSpec.describe Datadog::CI::TestSuite do
   let(:recorder) { spy("recorder") }
 
   before { allow_any_instance_of(described_class).to receive(:recorder).and_return(recorder) }
+  subject(:ci_test_suite) { described_class.new(tracer_span) }
+
+  describe "#record_test_result" do
+    let(:failed_tests_count) { 2 }
+    let(:skipped_tests_count) { 3 }
+    let(:passed_tests_count) { 5 }
+
+    before do
+      failed_tests_count.times do
+        ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::FAIL)
+      end
+      skipped_tests_count.times do
+        ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::SKIP)
+      end
+      passed_tests_count.times do
+        ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::PASS)
+      end
+    end
+
+    it "records the test results" do
+      expect(ci_test_suite.failed_tests_count).to eq(failed_tests_count)
+      expect(ci_test_suite.skipped_tests_count).to eq(skipped_tests_count)
+      expect(ci_test_suite.passed_tests_count).to eq(passed_tests_count)
+    end
+  end
 
   describe "#finish" do
-    subject(:ci_test_suite) { described_class.new(tracer_span) }
+    subject(:finish) { ci_test_suite.finish }
 
     before do
       expect(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_STATUS).and_return(
-        Datadog::CI::Ext::Test::Status::PASS
+        test_suite_status
       )
     end
 
-    it "deactivates the test suite" do
-      ci_test_suite.finish
+    context "when test suite has status" do
+      let(:test_suite_status) { Datadog::CI::Ext::Test::Status::PASS }
 
-      expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+      it "deactivates the test suite" do
+        finish
+
+        expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+      end
+    end
+
+    context "when test suite has no status" do
+      let(:test_suite_status) { nil }
+
+      context "and there are test failures" do
+        before do
+          ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::FAIL)
+        end
+
+        it "sets the status to fail" do
+          expect(tracer_span).to receive(:set_tag).with(
+            Datadog::CI::Ext::Test::TAG_STATUS, Datadog::CI::Ext::Test::Status::FAIL
+          )
+          expect(tracer_span).to receive(:status=).with(1)
+
+          finish
+        end
+      end
+
+      context "and there are only skipped tests" do
+        before do
+          ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::SKIP)
+        end
+
+        it "sets the status to skip" do
+          expect(tracer_span).to receive(:set_tag).with(
+            Datadog::CI::Ext::Test::TAG_STATUS, Datadog::CI::Ext::Test::Status::SKIP
+          )
+
+          finish
+        end
+      end
+
+      context "and there are some passed tests" do
+        before do
+          2.times do
+            ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::SKIP)
+          end
+          ci_test_suite.record_test_result(Datadog::CI::Ext::Test::Status::PASS)
+        end
+
+        it "sets the status to pass" do
+          expect(tracer_span).to receive(:set_tag).with(
+            Datadog::CI::Ext::Test::TAG_STATUS, Datadog::CI::Ext::Test::Status::PASS
+          )
+
+          finish
+        end
+      end
     end
   end
 end

--- a/spec/datadog/ci/test_suite_spec.rb
+++ b/spec/datadog/ci/test_suite_spec.rb
@@ -66,6 +66,8 @@ RSpec.describe Datadog::CI::TestSuite do
           expect(tracer_span).to receive(:status=).with(1)
 
           finish
+
+          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
 
@@ -80,6 +82,8 @@ RSpec.describe Datadog::CI::TestSuite do
           )
 
           finish
+
+          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
 
@@ -97,6 +101,8 @@ RSpec.describe Datadog::CI::TestSuite do
           )
 
           finish
+
+          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
     end

--- a/spec/datadog/ci/test_suite_spec.rb
+++ b/spec/datadog/ci/test_suite_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Datadog::CI::TestSuite do
   describe "#finish" do
     subject(:ci_test_suite) { described_class.new(tracer_span) }
 
+    before do
+      expect(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_STATUS).and_return(
+        Datadog::CI::Ext::Test::Status::PASS
+      )
+    end
+
     it "deactivates the test suite" do
       ci_test_suite.finish
 

--- a/vendor/rbs/cucumber/0/cucumber.rbs
+++ b/vendor/rbs/cucumber/0/cucumber.rbs
@@ -16,8 +16,9 @@ end
 
 class Cucumber::Core::Test::Result
   def failed?: () -> bool
-  def ok?: () -> bool
+  def ok?: (?untyped strict) -> bool
   def skipped?: () -> bool
+  def passed?: () -> bool
   def pending?: () -> bool
   def undefined?: () -> bool
   def message: () -> String

--- a/vendor/rbs/cucumber/0/cucumber.rbs
+++ b/vendor/rbs/cucumber/0/cucumber.rbs
@@ -18,6 +18,9 @@ class Cucumber::Core::Test::Result
   def failed?: () -> bool
   def ok?: () -> bool
   def skipped?: () -> bool
+  def pending?: () -> bool
+  def undefined?: () -> bool
+  def message: () -> String
   def exception: () -> untyped
 end
 


### PR DESCRIPTION
**What does this PR do?**
Solves multiple issues around skipped tests and test suites:
- all frameworks now correctly report test suite as skipped if there are no passed and no failed tests
- Cucumber now correctly reports undefined scenarios as skipped (if not running in strict mode)
- Cucumber strict mode support: in strict mode undefined scenarios are marked as failed
- RSpec: previously pending tests with failures were reported without any status, now they are reported as skipped

**Motivation**
Wrapping up last bugs and problems before GA for Ruby

**Additional Notes**
As Ruby test frameworks mostly do not provide statuses of test suites (and do not care much about the concept of a test suite), now we track count of passed/failed/skipped tests per test suite in `Datadog::CI::TestSuite` object