### PR TITLE
do not publish sig folder when publishing this gem

### DIFF
--- a/datadog-ci.gemspec
+++ b/datadog-ci.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
       NOTICE
       README.md
       lib/**/*
-      sig/**/*
     ]].select { |fn| File.file?(fn) } # We don't want directories, only files
 
   spec.require_paths = ["lib"]

--- a/spec/datadog/ci/release_gem_spec.rb
+++ b/spec/datadog/ci/release_gem_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "gem release process" do
         directories_excluded = %r{
           ^(
             spec
+            |sig
             |docs
             |\.circleci
             |\.github


### PR DESCRIPTION
**What does this PR do?**
Fixes #111

Removes sig folder from the published gem as it causes issues with typechecks in customer code

**Motivation**
Bug reported via GitHub issues