### PR TITLE
minitest: fix rails parallel test runner

### DIFF
--- a/lib/datadog/ci/contrib/minitest/patcher.rb
+++ b/lib/datadog/ci/contrib/minitest/patcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "runner"
 require_relative "reporter"
 require_relative "hooks"
 require_relative "runnable"
@@ -19,9 +20,14 @@ module Datadog
           end
 
           def patch
-            ::Minitest::CompositeReporter.include(Reporter)
-            ::Minitest::Test.include(Hooks)
+            # test session start
+            ::Minitest.include(Runner)
+            # test suites (when not executed concurrently)
             ::Minitest::Runnable.include(Runnable)
+            # tests; test suites (when executed concurrently)
+            ::Minitest::Test.include(Hooks)
+            # test session finish
+            ::Minitest::CompositeReporter.include(Reporter)
           end
         end
       end

--- a/lib/datadog/ci/contrib/minitest/reporter.rb
+++ b/lib/datadog/ci/contrib/minitest/reporter.rb
@@ -37,21 +37,6 @@ module Datadog
               res
             end
 
-            def start(*)
-              return super unless datadog_configuration[:enabled]
-
-              test_session = CI.start_test_session(
-                tags: {
-                  CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
-                  CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s
-                },
-                service: datadog_configuration[:service_name]
-              )
-              CI.start_test_module(test_session.name) if test_session
-
-              super
-            end
-
             private
 
             def datadog_configuration

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../../ext/test"
+require_relative "ext"
+
+module Datadog
+  module CI
+    module Contrib
+      module Minitest
+        module Runner
+          def self.included(base)
+            base.singleton_class.prepend(ClassMethods)
+          end
+
+          module ClassMethods
+            def init_plugins(*)
+              super
+
+              return unless datadog_configuration[:enabled]
+
+              test_session = CI.start_test_session(
+                tags: {
+                  CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
+                  CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s
+                },
+                service: datadog_configuration[:service_name]
+              )
+              CI.start_test_module(test_session.name) if test_session
+            end
+
+            private
+
+            def datadog_configuration
+              Datadog.configuration.ci[:minitest]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/minitest/runner.rbs
+++ b/sig/datadog/ci/contrib/minitest/runner.rbs
@@ -2,11 +2,13 @@ module Datadog
   module CI
     module Contrib
       module Minitest
-        module Reporter
+        module Runner
           def self.included: (untyped base) -> untyped
 
-          class InstanceMethods < ::Minitest::AbstractReporter
-            def report: (*untyped) -> untyped
+          class ClassMethods
+            extend ::Minitest
+
+            def init_plugins: (*untyped) -> (nil | untyped)
 
             private
 


### PR DESCRIPTION
**What does this PR do?**
Fixes rails parallel test executor instrumentation that was broken since I added ci-queue support to minitest framework.

**Why was this broken?**
In the previous episode of "Datadog figures out how to instrument all possible ways one can use Minitest" we watched [minitest-reporters interfering with `datadog-ci` plugin](https://github.com/DataDog/datadog-ci-rb/pull/110) which caused me to remove plugin and instrument Minitest::CompositeReporter to mark start and end of test sessions.

But... (suspenseful music) there is a twist!
Here is the `Minitest.run` [method](https://github.com/minitest/minitest/blob/master/lib/minitest.rb#L143) (important parts only):

```ruby
  def self.run args = []
    self.load_plugins unless args.delete("--no-plugins") || ENV["MT_NO_PLUGINS"]

    # ... code omitted for brevity ...

    self.init_plugins options # <------------ here we start session after merging this PR

    self.parallel_executor.start if parallel_executor.respond_to?(:start) # here Rails forks process when using parallel executor
    reporter.start # <---------- here we started session before this PR 
    begin
      __run reporter, options
    rescue Interrupt
      warn "Interrupted. Exiting..."
    end
    self.parallel_executor.shutdown

    reporter.report # <---------- here we end session

    reporter.passed?
  end
```

Unfortunately as you can see `reporter.start` is called **after** the `self.parallel_executor.start`. This is usually not that important, but not for Rails parallel executor, ladies and gentlemen! When `#start` is called, it [forks](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/testing/parallelization/worker.rb#L15) processes copying memory and creating an independent process to run your tests. 

This worked fine when we used plugin to start session: datadog-ci stores test session in global context that is copied on fork to all child processes. But now, if we start session after workers are forked, then the session is stored only in main test process and not available to workers that actually execute tests.

This PR fixes this issue by moving session start (again) to the `init_plugins` method but instead of using official Minitest plugin system we are instrumenting this method directly because it is the only way to make it work for all cases discovered so far.

**How to test the change?**
Manual testing via https://github.com/anmarchenko/openstreetmap-website is required (this is how the issue was discovered). I am happy to pair if anyone would like to see that it works.

This project will be added to Datadog's integration testing environment later.

**Why don't you have unit tests for rails parallel executor?**
It is extremely tricky to get any data out of forked processes in unit tests, I created a task to investigate it and try figure out a method of creating test environment suitable for unit tests.