### PR TITLE
[CIVIS-2985] use ruby 2.7 syntax

### DIFF
--- a/.standard.yml
+++ b/.standard.yml
@@ -1,4 +1,4 @@
-ruby_version: 2.1
+ruby_version: 2.7
 format: progress
 
 ignore:

--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -4,14 +4,6 @@
 ignore:
   - lib/datadog/ci/test_visibility/serializers/base.rb:
       - Style/HashExcept
-  - lib/datadog/ci/contrib/minitest/integration.rb:
-      - Style/SafeNavigation
-  - lib/datadog/ci/contrib/cucumber/integration.rb:
-      - Style/SafeNavigation
-  - lib/datadog/ci/contrib/rspec/integration.rb:
-      - Style/SafeNavigation
-  - lib/datadog/ci/ext/environment.rb:
-      - Style/SafeNavigation
   - spec/support/log_helpers.rb:
       - Performance/UnfreezeString
   - Appraisals:

--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -47,7 +47,7 @@ module Datadog
                 o.after_set do |value|
                   if value
                     Datadog::Core.log_deprecation do
-                      "The experimental_test_suite_level_visibility_enabled setting has no effect and will be removed in 1.0. " \
+                      "The experimental_test_suite_level_visibility_enabled setting has no effect and will be removed in 2.0. " \
                         "Test suite level visibility is now enabled by default. " \
                         "If you want to disable test suite level visibility set configuration.ci.force_test_level_visibility = true."
                     end

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -71,8 +71,8 @@ module Datadog
               service: configuration[:service_name]
             )
 
-            if test_span && (parameters = extract_parameters_hash(event.test_case))
-              test_span.set_parameters(parameters)
+            if (parameters = extract_parameters_hash(event.test_case))
+              test_span&.set_parameters(parameters)
             end
           end
 
@@ -100,9 +100,8 @@ module Datadog
           def test_suite_name(test_case)
             feature = if test_case.respond_to?(:feature)
               test_case.feature
-            elsif @ast_lookup
-              gherkin_doc = @ast_lookup.gherkin_document(test_case.location.file)
-              gherkin_doc.feature if gherkin_doc
+            else
+              @ast_lookup&.gherkin_document(test_case.location.file)&.feature
             end
 
             if feature
@@ -150,19 +149,13 @@ module Datadog
           end
 
           def finish_current_test_suite
-            test_suite = @current_test_suite
-            return unless test_suite
-
-            test_suite.finish
+            @current_test_suite&.finish
 
             @current_test_suite = nil
           end
 
           def same_test_suite_as_current?(test_suite_name)
-            test_suite = @current_test_suite
-            return false unless test_suite
-
-            test_suite.name == test_suite_name
+            @current_test_suite&.name == test_suite_name
           end
 
           def extract_parameters_hash(test_case)

--- a/lib/datadog/ci/contrib/cucumber/integration.rb
+++ b/lib/datadog/ci/contrib/cucumber/integration.rb
@@ -17,8 +17,7 @@ module Datadog
           register_as :cucumber
 
           def self.version
-            Gem.loaded_specs["cucumber"] \
-              && Gem.loaded_specs["cucumber"].version
+            Gem.loaded_specs["cucumber"]&.version
           end
 
           def self.loaded?

--- a/lib/datadog/ci/contrib/minitest/integration.rb
+++ b/lib/datadog/ci/contrib/minitest/integration.rb
@@ -17,7 +17,7 @@ module Datadog
           register_as :minitest
 
           def self.version
-            Gem.loaded_specs["minitest"] && Gem.loaded_specs["minitest"].version
+            Gem.loaded_specs["minitest"]&.version
           end
 
           def self.loaded?

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -48,28 +48,26 @@ module Datadog
               ) do |test_span|
                 result = super
 
-                if test_span
-                  test_span.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
+                test_span&.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
 
-                  case execution_result.status
-                  when :passed
-                    test_span.passed!
-                    test_suite_span.passed! if test_suite_span
-                  when :failed
-                    test_span.failed!(exception: execution_result.exception)
-                    test_suite_span.failed! if test_suite_span
-                  else
-                    # :pending or nil
-                    test_span.skipped!(
-                      reason: execution_result.pending_message,
-                      exception: execution_result.pending_exception
-                    )
+                case execution_result.status
+                when :passed
+                  test_span&.passed!
+                  test_suite_span&.passed!
+                when :failed
+                  test_span&.failed!(exception: execution_result.exception)
+                  test_suite_span&.failed!
+                else
+                  # :pending or nil
+                  test_span&.skipped!(
+                    reason: execution_result.pending_message,
+                    exception: execution_result.pending_exception
+                  )
 
-                    test_suite_span.skipped! if test_suite_span
-                  end
+                  test_suite_span&.skipped!
                 end
 
-                test_suite_span.finish if test_suite_span
+                test_suite_span&.finish
 
                 result
               end

--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -17,8 +17,7 @@ module Datadog
           register_as :rspec
 
           def self.version
-            Gem.loaded_specs["rspec-core"] \
-              && Gem.loaded_specs["rspec-core"].version
+            Gem.loaded_specs["rspec-core"]&.version
           end
 
           def self.loaded?

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -71,7 +71,7 @@ module Datadog
             return
           end
 
-          unless HEX_NUMBER_REGEXP =~ git_sha
+          unless HEX_NUMBER_REGEXP.match?(git_sha)
             message += " Expected SHA to be a valid HEX number, got #{git_sha}."
             Datadog.logger.error(message)
           end

--- a/lib/datadog/ci/ext/environment/providers/base.rb
+++ b/lib/datadog/ci/ext/environment/providers/base.rb
@@ -103,7 +103,7 @@ module Datadog
               @branch = @tag = nil
 
               # @type var branch_or_tag_string: untyped
-              if branch_or_tag_string && branch_or_tag_string.include?("tags/")
+              if branch_or_tag_string&.include?("tags/")
                 @tag = branch_or_tag_string
               else
                 @branch = branch_or_tag_string

--- a/lib/datadog/ci/ext/environment/providers/bitbucket.rb
+++ b/lib/datadog/ci/ext/environment/providers/bitbucket.rb
@@ -20,7 +20,7 @@ module Datadog
             end
 
             def pipeline_id
-              env["BITBUCKET_PIPELINE_UUID"] ? env["BITBUCKET_PIPELINE_UUID"].tr("{}", "") : nil
+              env["BITBUCKET_PIPELINE_UUID"]&.tr("{}", "")
             end
 
             def pipeline_name

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -112,8 +112,7 @@ module Datadog
       private
 
       def record_test_result(datadog_status)
-        suite = test_suite
-        suite.record_test_result(datadog_status) if suite
+        test_suite&.record_test_result(datadog_status)
       end
     end
   end

--- a/lib/datadog/ci/test_visibility/context/global.rb
+++ b/lib/datadog/ci/test_visibility/context/global.rb
@@ -47,9 +47,7 @@ module Datadog
 
           def service
             @mutex.synchronize do
-              # thank you RBS for this weirdness
-              test_session = @test_session
-              test_session.service if test_session
+              @test_session&.service
             end
           end
 

--- a/lib/datadog/ci/test_visibility/null_recorder.rb
+++ b/lib/datadog/ci/test_visibility/null_recorder.rb
@@ -45,7 +45,7 @@ module Datadog
         private
 
         def skip_tracing(block = nil)
-          block.call(nil) if block
+          block&.call(nil)
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -178,12 +178,12 @@ module Datadog
         private
 
         def skip_tracing(block = nil)
-          block.call(nil) if block
+          block&.call(nil)
         end
 
         # Sets trace's origin to ciapp-test
         def set_trace_origin(trace)
-          trace.origin = Ext::Test::CONTEXT_ORIGIN if trace
+          trace&.origin = Ext::Test::CONTEXT_ORIGIN
         end
 
         def build_test_session(tracer_span, tags)

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -241,7 +241,7 @@ module Datadog
           end
 
           def to_integer(value)
-            value.to_i if value
+            value&.to_i
           end
         end
       end

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -76,13 +76,7 @@ module Datadog
 
         def encode_traces(traces)
           traces.flat_map do |trace|
-            spans = trace.spans
-            # TODO: remove condition when 1.0 is released
-            if spans.respond_to?(:filter_map)
-              spans.filter_map { |span| encode_span(trace, span) }
-            else
-              spans.map { |span| encode_span(trace, span) }.reject(&:nil?)
-            end
+            trace.spans.filter_map { |span| encode_span(trace, span) }
           end
         end
 

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -65,7 +65,7 @@ module Datadog
         end
 
         # this is needed because Datadog::Tracing::Writer is not fully compatiple with Datadog::Core::Transport
-        # TODO: remove before 1.0 when CI implements its own worker
+        # TODO: remove when CI implements its own worker
         class ResponseDecorator < ::SimpleDelegator
           def trace_count
             0

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -12,7 +12,7 @@ module Datadog
 
       STRING = [MAJOR, MINOR, PATCH, PRE, BUILD].compact.join(".")
 
-      MINIMUM_RUBY_VERSION = "2.1.0"
+      MINIMUM_RUBY_VERSION = "2.7.0"
 
       # Restrict the installation of this gem with untested future versions of Ruby.
       #

--- a/spec/datadog/ci/test_visibility/null_recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/null_recorder_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
         recorder.trace_test("my test", "my suite") do |test_span|
           spy_under_test.call
 
-          test_span.passed! if test_span
+          test_span&.passed!
         end
       end
 
@@ -71,7 +71,7 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
         recorder.trace("step", "my step") do |span|
           spy_under_test.call
 
-          span.set_metric("my.metric", 42) if span
+          span&.set_metric("my.metric", 42)
         end
       end
 

--- a/spec/support/tracer_helpers.rb
+++ b/spec/support/tracer_helpers.rb
@@ -38,8 +38,8 @@ module TracerHelpers
         end
       end
 
-      Datadog::CI.active_test.set_tag("test_owner", "my_team") if Datadog::CI.active_test
-      Datadog::CI.active_test.set_metric("memory_allocations", 16) if Datadog::CI.active_test
+      Datadog::CI.active_test&.set_tag("test_owner", "my_team")
+      Datadog::CI.active_test&.set_metric("memory_allocations", 16)
 
       set_result(test, result: result, exception: exception, skip_reason: skip_reason) if test
 


### PR DESCRIPTION
**What does this PR do?**
Migrates this library to use Ruby 2.7 syntax: safe navigation operator, filter_map method

**Motivation**
We don't support older rubies anymore and can simplify some code
