### PR TITLE
[CIVIS-2985] remove operation_name from integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether RSpec tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `rspec` instrumentation. | `'rspec'` |
-| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `rspec` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'rspec.example'` |
 
 ### Minitest
 
@@ -85,7 +84,6 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether Minitest tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `minitest` instrumentation. | `'minitest'` |
-| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `minitest` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'minitest.test'` |
 
 ### Cucumber
 
@@ -116,7 +114,6 @@ end
 | --- | ----------- | ------- |
 | `enabled` | Defines whether Cucumber tests should be traced. Useful for temporarily disabling tracing. `true` or `false` | `true` |
 | `service_name` | Service name used for `cucumber` instrumentation. | `'cucumber'` |
-| `operation_name` | *DEPRECATED, to be removed in 1.0* Operation name used for `cucumber` instrumentation (has no effect in agentless mode or when using newer agent versions). | `'cucumber.test'` |
 
 ## Agentless mode
 

--- a/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/cucumber/configuration/settings.rb
@@ -26,21 +26,6 @@ module Datadog
                 Utils::Configuration.fetch_service_name(Ext::DEFAULT_SERVICE_NAME)
               end
             end
-
-            # @deprecated Will be removed in 1.0
-            option :operation_name do |o|
-              o.type :string
-              o.env Ext::ENV_OPERATION_NAME
-              o.default Ext::OPERATION_NAME
-
-              o.after_set do |value|
-                if value && value != Ext::OPERATION_NAME
-                  Datadog::Core.log_deprecation do
-                    "The operation_name setting has no effect and will be removed in 1.0"
-                  end
-                end
-              end
-            end
           end
         end
       end

--- a/lib/datadog/ci/contrib/cucumber/ext.rb
+++ b/lib/datadog/ci/contrib/cucumber/ext.rb
@@ -5,7 +5,7 @@ module Datadog
     module Contrib
       module Cucumber
         # Cucumber integration constants
-        # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
+        # @public_api
         module Ext
           ENV_ENABLED = "DD_TRACE_CUCUMBER_ENABLED"
           DEFAULT_SERVICE_NAME = "cucumber"
@@ -13,10 +13,6 @@ module Datadog
           FRAMEWORK = "cucumber"
 
           STEP_SPAN_TYPE = "step"
-
-          # TODO: remove in 1.0
-          ENV_OPERATION_NAME = "DD_TRACE_CUCUMBER_OPERATION_NAME"
-          OPERATION_NAME = "cucumber.test"
         end
       end
     end

--- a/lib/datadog/ci/contrib/minitest/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/minitest/configuration/settings.rb
@@ -24,21 +24,6 @@ module Datadog
                 Utils::Configuration.fetch_service_name(Ext::DEFAULT_SERVICE_NAME)
               end
             end
-
-            # @deprecated Will be removed in 1.0
-            option :operation_name do |o|
-              o.type :string
-              o.env Ext::ENV_OPERATION_NAME
-              o.default Ext::OPERATION_NAME
-
-              o.after_set do |value|
-                if value && value != Ext::OPERATION_NAME
-                  Datadog::Core.log_deprecation do
-                    "The operation_name setting has no effect and will be removed in 1.0"
-                  end
-                end
-              end
-            end
           end
         end
       end

--- a/lib/datadog/ci/contrib/minitest/ext.rb
+++ b/lib/datadog/ci/contrib/minitest/ext.rb
@@ -5,17 +5,13 @@ module Datadog
     module Contrib
       module Minitest
         # Minitest integration constants
-        # TODO: mark as `@public_api` when GA, to protect from resource and tag name changes.
+        # @public_api
         module Ext
           ENV_ENABLED = "DD_TRACE_MINITEST_ENABLED"
 
           FRAMEWORK = "minitest"
 
           DEFAULT_SERVICE_NAME = "minitest"
-
-          # TODO: remove in 1.0
-          ENV_OPERATION_NAME = "DD_TRACE_MINITEST_OPERATION_NAME"
-          OPERATION_NAME = "minitest.test"
         end
       end
     end

--- a/lib/datadog/ci/contrib/rspec/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/rspec/configuration/settings.rb
@@ -24,21 +24,6 @@ module Datadog
                 Utils::Configuration.fetch_service_name(Ext::DEFAULT_SERVICE_NAME)
               end
             end
-
-            # @deprecated Will be removed in 1.0
-            option :operation_name do |o|
-              o.type :string
-              o.env Ext::ENV_OPERATION_NAME
-              o.default Ext::OPERATION_NAME
-
-              o.after_set do |value|
-                if value && value != Ext::OPERATION_NAME
-                  Datadog::Core.log_deprecation do
-                    "The operation_name setting has no effect and will be removed in 1.0"
-                  end
-                end
-              end
-            end
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/ext.rb
+++ b/lib/datadog/ci/contrib/rspec/ext.rb
@@ -11,10 +11,6 @@ module Datadog
           DEFAULT_SERVICE_NAME = "rspec"
 
           ENV_ENABLED = "DD_TRACE_RSPEC_ENABLED"
-
-          # TODO: remove in 1.0
-          ENV_OPERATION_NAME = "DD_TRACE_RSPEC_OPERATION_NAME"
-          OPERATION_NAME = "rspec.example"
         end
       end
     end

--- a/lib/datadog/ci/contrib/settings.rb
+++ b/lib/datadog/ci/contrib/settings.rb
@@ -11,9 +11,6 @@ module Datadog
         option :enabled, default: true
         option :service_name
 
-        # @deprecated Will be removed in 1.0
-        option :operation_name
-
         def configure(options = {})
           self.class.options.each do |name, _value|
             self[name] = options[name] if options.key?(name)

--- a/sig/datadog/ci/contrib/cucumber/ext.rbs
+++ b/sig/datadog/ci/contrib/cucumber/ext.rbs
@@ -5,11 +5,7 @@ module Datadog
         module Ext
           ENV_ENABLED: String
 
-          ENV_OPERATION_NAME: String
-
           FRAMEWORK: String
-
-          OPERATION_NAME: String
 
           DEFAULT_SERVICE_NAME: String
 

--- a/sig/datadog/ci/contrib/minitest/ext.rbs
+++ b/sig/datadog/ci/contrib/minitest/ext.rbs
@@ -5,11 +5,7 @@ module Datadog
         module Ext
           ENV_ENABLED: String
 
-          ENV_OPERATION_NAME: String
-
           FRAMEWORK: String
-
-          OPERATION_NAME: String
 
           DEFAULT_SERVICE_NAME: String
         end

--- a/sig/datadog/ci/contrib/rspec/ext.rbs
+++ b/sig/datadog/ci/contrib/rspec/ext.rbs
@@ -7,9 +7,6 @@ module Datadog
 
           FRAMEWORK: String
           DEFAULT_SERVICE_NAME: String
-
-          OPERATION_NAME: String
-          ENV_OPERATION_NAME: String
         end
       end
     end

--- a/sig/datadog/ci/contrib/settings.rbs
+++ b/sig/datadog/ci/contrib/settings.rbs
@@ -18,7 +18,6 @@ module Datadog
         #
         def enabled: () -> bool
         def service_name: () -> String
-        def operation_name: () -> String
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
Removes deprecated config option for version 1.0
