### PR TITLE
Add note to README on using VCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,26 @@ WebMock.disable_net_connect!(:allow_localhost => true)
 WebMock.disable_net_connect!(:allow => "localhost:8126")
 ```
 
+### VCR
+
+[VCR](https://github.com/vcr/vcr) is another popular testing library for HTTP interactions.
+
+It requires additional configuration to correctly work with datadog-ci:
+
+```ruby
+VCR.configure do |config|
+  # ... your usual configuration here ...
+
+  # when using agent
+  config.ignore_hosts "127.0.0.1", "localhost"
+
+
+  # when using agentless mode
+  # note to use the correct datadog site (e.g. datadoghq.eu, etc)
+  config.ignore_hosts "citestcycle-intake.datadoghq.com"
+end
+```
+
 ### Disabling startup logs
 
 Startup logs produce a report of tracing state when the application is initially configured.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ VCR.configure do |config|
   # when using agent
   config.ignore_hosts "127.0.0.1", "localhost"
 
-
   # when using agentless mode
   # note to use the correct datadog site (e.g. datadoghq.eu, etc)
   config.ignore_hosts "citestcycle-intake.datadoghq.com"


### PR DESCRIPTION
**What does this PR do?**
Adds note to README on how to configure VCR with datadog-ci

**Motivation**
One of our users pointed out that we lack instructions on how to make datadog-ci work when using VCR gem

