### PR TITLE
[CIVIS-8782] gzip agent payloads support via evp_proxy/v4

### DIFF
--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -12,7 +12,14 @@ module Datadog
         HEADER_EVP_SUBDOMAIN = "X-Datadog-EVP-Subdomain"
         HEADER_CONTAINER_ID = "Datadog-Container-ID"
 
-        EVP_PROXY_PATH_PREFIX = "/evp_proxy/v2/"
+        EVP_PROXY_V2_PATH_PREFIX = "/evp_proxy/v2/"
+        EVP_PROXY_V4_PATH_PREFIX = "/evp_proxy/v4/"
+        EVP_PROXY_PATH_PREFIXES = [EVP_PROXY_V4_PATH_PREFIX, EVP_PROXY_V2_PATH_PREFIX].freeze
+        EVP_PROXY_COMPRESSION_SUPPORTED = {
+          EVP_PROXY_V4_PATH_PREFIX => true,
+          EVP_PROXY_V2_PATH_PREFIX => false
+        }
+
         TEST_VISIBILITY_INTAKE_HOST_PREFIX = "citestcycle-intake"
         TEST_VISIBILITY_INTAKE_PATH = "/api/v2/citestcycle"
 

--- a/lib/datadog/ci/transport/api/agentless.rb
+++ b/lib/datadog/ci/transport/api/agentless.rb
@@ -7,7 +7,7 @@ module Datadog
   module CI
     module Transport
       module Api
-        class CiTestCycle < Base
+        class Agentless < Base
           attr_reader :api_key
 
           def initialize(api_key:, http:)

--- a/lib/datadog/ci/transport/api/builder.rb
+++ b/lib/datadog/ci/transport/api/builder.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "ci_test_cycle"
+require "datadog/core/configuration/agent_settings_resolver"
+require "datadog/core/remote/negotiation"
+
+require_relative "agentless"
 require_relative "evp_proxy"
 require_relative "../http"
 require_relative "../../ext/transport"
@@ -10,7 +13,9 @@ module Datadog
     module Transport
       module Api
         module Builder
-          def self.build_ci_test_cycle_api(settings)
+          def self.build_agentless_api(settings)
+            return nil if settings.api_key.nil?
+
             dd_site = settings.site || Ext::Transport::DEFAULT_DD_SITE
             url = settings.ci.agentless_url ||
               "https://#{Ext::Transport::TEST_VISIBILITY_INTAKE_HOST_PREFIX}.#{dd_site}:443"
@@ -25,19 +30,31 @@ module Datadog
               compress: true
             )
 
-            CiTestCycle.new(api_key: settings.api_key, http: http)
+            Agentless.new(api_key: settings.api_key, http: http)
           end
 
-          def self.build_evp_proxy_api(agent_settings)
+          def self.build_evp_proxy_api(settings)
+            agent_settings = Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
+            negotiation = Datadog::Core::Remote::Negotiation.new(settings, agent_settings)
+
+            # temporary, remove this when patch will be accepted in Core to make logging configurable
+            negotiation.instance_variable_set(:@logged, {no_config_endpoint: true})
+
+            evp_proxy_path_prefix = Ext::Transport::EVP_PROXY_PATH_PREFIXES.find do |path_prefix|
+              negotiation.endpoint?(path_prefix)
+            end
+
+            return nil if evp_proxy_path_prefix.nil?
+
             http = Datadog::CI::Transport::HTTP.new(
               host: agent_settings.hostname,
               port: agent_settings.port,
               ssl: agent_settings.ssl,
               timeout: agent_settings.timeout_seconds,
-              compress: false
+              compress: Ext::Transport::EVP_PROXY_COMPRESSION_SUPPORTED[evp_proxy_path_prefix]
             )
 
-            EvpProxy.new(http: http)
+            EvpProxy.new(http: http, path_prefix: evp_proxy_path_prefix)
           end
         end
       end

--- a/lib/datadog/ci/transport/api/evp_proxy.rb
+++ b/lib/datadog/ci/transport/api/evp_proxy.rb
@@ -10,8 +10,15 @@ module Datadog
     module Transport
       module Api
         class EvpProxy < Base
+          def initialize(http:, path_prefix: Ext::Transport::EVP_PROXY_V2_PATH_PREFIX)
+            super(http: http)
+
+            path_prefix = "#{path_prefix}/" unless path_prefix.end_with?("/")
+            @path_prefix = path_prefix
+          end
+
           def request(path:, payload:, verb: "post")
-            path = "#{Ext::Transport::EVP_PROXY_PATH_PREFIX}#{path.sub(/^\//, "")}"
+            path = "#{@path_prefix}#{path.sub(/^\//, "")}"
 
             super(
               path: path,

--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -10,10 +10,10 @@ module Datadog
 
         def activate_ci!: (untyped settings) -> untyped
 
-        def build_agentless_transport: (untyped settings) -> Datadog::CI::TestVisibility::Transport?
-        def build_evp_proxy_transport: (untyped settings, untyped agent_settings) -> Datadog::CI::TestVisibility::Transport
-        def can_use_evp_proxy?: (untyped settings, untyped agent_settings) -> bool
+        def build_test_visibility_api: (untyped settings) -> Datadog::CI::Transport::Api::Base?
+
         def serializers_factory: (untyped settings) -> (singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel))
+
         def check_dd_site: (untyped settings) -> void
       end
     end

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -14,7 +14,13 @@ module Datadog
 
         HEADER_CONTAINER_ID: "Datadog-Container-ID"
 
-        EVP_PROXY_PATH_PREFIX: "/evp_proxy/v2/"
+        EVP_PROXY_V2_PATH_PREFIX: "/evp_proxy/v2/"
+
+        EVP_PROXY_V4_PATH_PREFIX: "/evp_proxy/v4/"
+
+        EVP_PROXY_PATH_PREFIXES: ::Array[String]
+
+        EVP_PROXY_COMPRESSION_SUPPORTED: ::Hash[String, bool]
 
         TEST_VISIBILITY_INTAKE_HOST_PREFIX: "citestcycle-intake"
 

--- a/sig/datadog/ci/transport/api/agentless.rbs
+++ b/sig/datadog/ci/transport/api/agentless.rbs
@@ -2,7 +2,7 @@ module Datadog
   module CI
     module Transport
       module Api
-        class CiTestCycle < Base
+        class Agentless < Base
           attr_reader api_key: String
 
           @api_key: String

--- a/sig/datadog/ci/transport/api/builder.rbs
+++ b/sig/datadog/ci/transport/api/builder.rbs
@@ -3,8 +3,8 @@ module Datadog
     module Transport
       module Api
         module Builder
-          def self.build_ci_test_cycle_api: (untyped settings) -> Datadog::CI::Transport::Api::CiTestCycle
-          def self.build_evp_proxy_api: (untyped agent_settings) -> Datadog::CI::Transport::Api::EvpProxy
+          def self.build_agentless_api: (untyped settings) -> Datadog::CI::Transport::Api::Agentless?
+          def self.build_evp_proxy_api: (untyped agent_settings) -> Datadog::CI::Transport::Api::EvpProxy?
         end
       end
     end

--- a/sig/datadog/ci/transport/api/evp_proxy.rbs
+++ b/sig/datadog/ci/transport/api/evp_proxy.rbs
@@ -4,6 +4,9 @@ module Datadog
       module Api
         class EvpProxy < Base
           @container_id: String?
+          @path_prefix: String
+
+          def initialize: (http: Datadog::CI::Transport::HTTP, ?path_prefix: String) -> void
 
           def request: (path: String, payload: String, ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
 

--- a/spec/datadog/ci/transport/api/agentless_spec.rb
+++ b/spec/datadog/ci/transport/api/agentless_spec.rb
@@ -1,6 +1,6 @@
-require_relative "../../../../../lib/datadog/ci/transport/api/ci_test_cycle"
+require_relative "../../../../../lib/datadog/ci/transport/api/agentless"
 
-RSpec.describe Datadog::CI::Transport::Api::CiTestCycle do
+RSpec.describe Datadog::CI::Transport::Api::Agentless do
   subject do
     described_class.new(
       api_key: api_key,

--- a/spec/datadog/ci/transport/api/evp_proxy_spec.rb
+++ b/spec/datadog/ci/transport/api/evp_proxy_spec.rb
@@ -2,50 +2,67 @@ require_relative "../../../../../lib/datadog/ci/transport/api/evp_proxy"
 
 RSpec.describe Datadog::CI::Transport::Api::EvpProxy do
   subject do
-    described_class.new(http: http)
+    described_class.new(http: http, path_prefix: path_prefix)
   end
 
   let(:http) { double(:http) }
+  let(:path_prefix) { "/evp_proxy/v2/" }
 
   describe "#request" do
+    let(:container_id) { nil }
+
     before do
       allow(Datadog::CI::Transport::HTTP).to receive(:new).and_return(http)
       expect(Datadog::Core::Environment::Container).to receive(:container_id).and_return(container_id)
     end
 
-    context "without container id" do
-      let(:container_id) { nil }
+    context "with path starting from / character" do
+      it "produces correct headers and forwards request to HTTP layer prepending path with evp_proxy" do
+        expect(http).to receive(:request).with(
+          path: "/evp_proxy/v2/path",
+          payload: "payload",
+          verb: "post",
+          headers: {
+            "Content-Type" => "application/msgpack",
+            "X-Datadog-EVP-Subdomain" => "citestcycle-intake"
+          }
+        )
 
-      context "with path starting from / character" do
-        it "produces correct headers and forwards request to HTTP layer prepending path with evp_proxy" do
-          expect(http).to receive(:request).with(
-            path: "/evp_proxy/v2/path",
-            payload: "payload",
-            verb: "post",
-            headers: {
-              "Content-Type" => "application/msgpack",
-              "X-Datadog-EVP-Subdomain" => "citestcycle-intake"
-            }
-          )
-
-          subject.request(path: "/path", payload: "payload")
-        end
+        subject.request(path: "/path", payload: "payload")
       end
+    end
 
-      context "with path without / in the beginning" do
-        it "constructs evp proxy path correctly" do
-          expect(http).to receive(:request).with(
-            path: "/evp_proxy/v2/path",
-            payload: "payload",
-            verb: "post",
-            headers: {
-              "Content-Type" => "application/msgpack",
-              "X-Datadog-EVP-Subdomain" => "citestcycle-intake"
-            }
-          )
+    context "with path without / in the beginning" do
+      it "constructs evp proxy path correctly" do
+        expect(http).to receive(:request).with(
+          path: "/evp_proxy/v2/path",
+          payload: "payload",
+          verb: "post",
+          headers: {
+            "Content-Type" => "application/msgpack",
+            "X-Datadog-EVP-Subdomain" => "citestcycle-intake"
+          }
+        )
 
-          subject.request(path: "path", payload: "payload")
-        end
+        subject.request(path: "path", payload: "payload")
+      end
+    end
+
+    context "with different path_prefix" do
+      let(:path_prefix) { "/evp_proxy/v4" }
+
+      it "constructs evp proxy path using this prefix" do
+        expect(http).to receive(:request).with(
+          path: "/evp_proxy/v4/path",
+          payload: "payload",
+          verb: "post",
+          headers: {
+            "Content-Type" => "application/msgpack",
+            "X-Datadog-EVP-Subdomain" => "citestcycle-intake"
+          }
+        )
+
+        subject.request(path: "path", payload: "payload")
       end
     end
 

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -18,7 +18,7 @@ RSpec.shared_context "CI mode activated" do
 
   before do
     allow_any_instance_of(Datadog::Core::Remote::Negotiation).to(
-      receive(:endpoint?).with("/evp_proxy/v2/").and_return(true)
+      receive(:endpoint?).with("/evp_proxy/v4/").and_return(true)
     )
 
     allow(Datadog::CI::Utils::TestRun).to receive(:command).and_return(test_command)


### PR DESCRIPTION
**What does this PR do?**
Enables compression of payloads that this library sends to Datadog Agent by using `/evp_proxy/v4/` endpoint when it is available.

**Motivation**
Datadog Agent v7.52.0 is going to support forwarding gzip headers to the backend. We leverage this new capability to make our network calls more efficient and reduce overhead for users when running tests.

**Additional Notes**
This change also contains some refactoring for Api clients:
- CiTestCycle is renamed to Agentless
- Client building logic moved from `Datadog::CI::Configuration::Components` to `Datadog::CI::Transport::Api::Builder` where it should have been

**How to test the change?**
Tested locally with dev build of Datadog Agent, unit tests are provided