### PR TITLE
[POC] per test code coverage using built-in Coverage.resume/suspend

### DIFF
--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -9,15 +9,16 @@ module Datadog
     module Itr
       module Coverage
         class Collector
-          def initialize
+          def initialize(enabled: true)
             # Do not run code coverage if someone else is already running it.
             # It means that user is running the test with coverage and ITR would mess it up.
+            @enabled = enabled
             @coverage_supported = !::Coverage.running?
             # @coverage_supported = false
           end
 
           def setup
-            if @coverage_supported
+            if @coverage_supported && @enabled
               p "RUNNING WITH CODE COVERAGE ENABLED!"
               ::Coverage.setup(lines: true)
             else
@@ -26,14 +27,14 @@ module Datadog
           end
 
           def start
-            return unless @coverage_supported
+            return if !@coverage_supported || !@enabled
 
             # if execution is threaded then coverage might already be running
             ::Coverage.resume unless ::Coverage.running?
           end
 
           def stop
-            return nil unless @coverage_supported
+            return if !@coverage_supported || !@enabled
 
             result = ::Coverage.result(stop: false, clear: true)
             ::Coverage.suspend if ::Coverage.running?

--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "coverage"
+
+require_relative "filter"
+
+module Datadog
+  module CI
+    module Itr
+      module Coverage
+        class Collector
+          def initialize
+            # Do not run code coverage if someone else is already running it.
+            # It means that user is running the test with coverage and ITR would mess it up.
+            @coverage_supported = !::Coverage.running?
+            # @coverage_supported = false
+          end
+
+          def setup
+            if @coverage_supported
+              p "RUNNING WITH CODE COVERAGE ENABLED!"
+              ::Coverage.setup(lines: true)
+            else
+              p "RUNNING WITH CODE COVERAGE DISABLED!"
+            end
+          end
+
+          def start
+            return unless @coverage_supported
+
+            # if execution is threaded then coverage might already be running
+            ::Coverage.resume unless ::Coverage.running?
+          end
+
+          def stop
+            return nil unless @coverage_supported
+
+            result = ::Coverage.result(stop: false, clear: true)
+            ::Coverage.suspend if ::Coverage.running?
+
+            Filter.call(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "../../utils/git"
+
+module Datadog
+  module CI
+    module Itr
+      module Coverage
+        class Filter
+          def self.call(raw_result)
+            new.call(raw_result)
+          end
+
+          def initialize(root: Utils::Git.root)
+            @regex = /\A#{Regexp.escape(root + File::SEPARATOR)}/i.freeze
+          end
+
+          def call(raw_result)
+            return nil if raw_result.nil?
+
+            raw_result.select do |path, coverage|
+              path =~ @regex && coverage[:lines].any? { |count| count && count > 0 }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -6,6 +6,7 @@ module Datadog
   module CI
     module Itr
       module Coverage
+        # not filter, but rather filter and transformer
         class Filter
           def self.call(raw_result)
             new.call(raw_result)
@@ -17,6 +18,9 @@ module Datadog
 
           def call(raw_result)
             return nil if raw_result.nil?
+
+            # p "RAW"
+            # p raw_result.count
 
             raw_result.filter_map do |path, coverage|
               next unless path =~ @regex

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -19,36 +19,9 @@ module Datadog
           def call(raw_result)
             return nil if raw_result.nil?
 
-            # p "RAW"
-            # p raw_result.count
-
-            raw_result.filter_map do |path, coverage|
-              next unless path =~ @regex
-              next unless coverage[:lines].any? { |line| !line.nil? && line > 0 }
-
-              [path, convert_lines_to_bitmap(coverage[:lines])]
+            raw_result.select do |path, coverage|
+              path =~ @regex && coverage[:lines].any? { |line| !line.nil? && line > 0 }
             end
-          end
-
-          private
-
-          def convert_lines_to_bitmap(lines)
-            bitmap = []
-            current = 0
-            bit = 1 << 63
-            lines.each do |line|
-              if !line.nil? && line > 0
-                current |= bit
-              end
-              bit >>= 1
-              if bit == 0
-                bitmap << current
-                current = 0
-                bit = 1 << 63
-              end
-            end
-            bitmap << current
-            lines
           end
         end
       end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -333,10 +333,9 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
-            files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
-            test.set_tag("_test.coverage", files_covered)
-
-            # p test.get_tag("_test.coverage")
+            # move this to the code coverage transport
+            # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
+            test.set_tag("_test.coverage", coverage)
           end
         end
       end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -333,6 +333,8 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
+            # p "FILTERED"
+            # p coverage.count
             # move this to the code coverage transport
             # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
             test.set_tag("_test.coverage", coverage)

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -333,10 +333,27 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
-            # p "FILTERED"
-            # p coverage.count
-            # move this to the code coverage transport
-            # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
+            if ENV["DD_COV_REPORT"]
+              # append to report.log file
+              File.open("report.log", "a") do |f|
+                f.write("#{test.name}\n")
+                f.write("---------------------------------------------------\n")
+
+                coverage.each do |filename, cov|
+                  f.write("#{filename}\n")
+                  sorted_lines = []
+
+                  cov[:lines].each_with_index do |count, line_number|
+                    next if count.nil? || count.zero?
+
+                    sorted_lines << line_number + 1
+                  end
+                  f.write("#{sorted_lines.sort}\n")
+                end
+                f.write("---------------------------------------------------\n")
+              end
+            end
+
             test.set_tag("_test.coverage", coverage)
           end
         end


### PR DESCRIPTION
Ruby has built-in `Coverage` class to track code coverage. It is used by all major code coverage libraries in Ruby right now. This object provides a way to track total code coverage per process. There is some trick to use it for per test code coverage: use `Coverage.resume` and `Coverage.suspend` to start/stop coverage tracing and `Coverage.results(stop: false, clear: true)` to get intermediate results.

This approach is not suitable for us because of the following disadvantages:
- It interferes with existing code coverage setup our users might have
- It does not work with multithreaded test execution
- On every step it returns not only files interesting to us but all of the Ruby files loaded and we have to do expensive filtering to get only the files that were actually covered by the current test
- resume and suspend are only available for Ruby 3.1+ (we need to support 2.7+)

Nevertheless, this PR explores performance of this approach to have a baseline for comparisons.
### Performance evaluation

Projects used to evaluate performance:
- sidekiq: very small and fast test suite
- rubocop: very big but quite fast test suite (20 000 tests under 2 minutes)
- vagrant: very big and slow test suite (5 000 tests in about 14 minutes)

In the following table are durations of the whole test session in seconds, in brackets overhead percentage compared to run with datadog-ci.

| Coverage type | Sidekiq | Rubocop | Vagrant |
|--------|--------|--------|--------|
| No coverage | ~6,8 | 111 | 827 |
| Simplecov (total coverage) | ~7 | 137 | 864 |
| Per test coverage, lines | 7,8 (14%) | 460 (314%) | 915 (10%) |

`*` overhead here is compared to "Simplecov (total coverage)"
### Relevant code

```ruby
# to filter results only taking the the files in git repository's root
@regex = /\A#{Regexp.escape(Utils::Git.root + File::SEPARATOR)}/i.freeze

::Coverage.setup(lines: true)

# when starting test
::Coverage.resume

# when stopping test
result = ::Coverage.result(stop: false, clear: true)
::Coverage.suspend if ::Coverage.running?

result.select do |path, coverage|
  path =~ @regex && coverage[:lines].any? { |line| !line.nil? && line > 0 }
end
```