### PR TITLE
[POC] per test code coverage using rb_thread_add_event_hook in C extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ Gemfile-*.lock
 .ruby-version
 .DS_Store
 /test.rb
+
+# Native extension binaries
+lib/**/*.bundle
+lib/**/*.so
+lib/**/*.o

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "pry"
 gem "rake"
 gem "os"
 
+# To compile native extensions
+gem "rake-compiler"
+
 gem "climate_control"
 
 gem "rspec"

--- a/Rakefile
+++ b/Rakefile
@@ -121,3 +121,9 @@ end
 
 desc "CI task; it runs all tests for current version of Ruby"
 task ci: "test:all"
+
+require "rake/extensiontask"
+
+Rake::ExtensionTask.new("ddcov") do |ext|
+  ext.lib_dir = "lib/ddcov"
+end

--- a/datadog-ci.gemspec
+++ b/datadog-ci.gemspec
@@ -35,7 +35,10 @@ Gem::Specification.new do |spec|
       NOTICE
       README.md
       lib/**/*
+      ext/**/*
     ]].select { |fn| File.file?(fn) } # We don't want directories, only files
+
+  spec.extensions << "ext/ddcov/extconf.rb"
 
   spec.require_paths = ["lib"]
 

--- a/ext/ddcov/ddcov.c
+++ b/ext/ddcov/ddcov.c
@@ -1,0 +1,83 @@
+#include <ruby.h>
+
+static ID id_puts, id_each;
+
+static void kernel_puts(VALUE val)
+{
+  rb_funcall(rb_mKernel, id_puts, 1, val);
+}
+
+static VALUE my_fixed_args_method(VALUE self, VALUE arg1, VALUE arg2)
+{
+  kernel_puts(self);
+  kernel_puts(arg1);
+  kernel_puts(arg2);
+
+  return Qnil;
+}
+
+static VALUE my_var_args_c_array_method(int argc, VALUE *argv, VALUE self)
+{
+  kernel_puts(self);
+
+  for (int i = 0; i < argc; i++)
+  {
+    kernel_puts(argv[i]);
+  }
+
+  return Qnil;
+}
+
+static VALUE my_var_args_rb_array_method(VALUE self, VALUE args)
+{
+  kernel_puts(self);
+  kernel_puts(args);
+
+  return Qnil;
+}
+
+static VALUE my_method_with_required_block(VALUE self)
+{
+  VALUE block_ret = rb_yield_values(0);
+  kernel_puts(block_ret);
+
+  return Qnil;
+}
+
+static VALUE array_puts_every_other_i(VALUE yielded_arg, VALUE data, int argc, const VALUE *argv, VALUE blockarg)
+{
+  int *puts_cur_ptr = (int *)data;
+  int puts_cur = *puts_cur_ptr;
+
+  if (puts_cur)
+  {
+    kernel_puts(yielded_arg);
+  }
+
+  *puts_cur_ptr = !puts_cur;
+
+  return Qnil;
+}
+
+static VALUE array_puts_every_other(VALUE self)
+{
+  int puts_cur = 1;
+
+  rb_block_call(self, id_each, 0, NULL, array_puts_every_other_i, (VALUE)&puts_cur);
+
+  return Qnil;
+}
+
+void Init_ddcov(void)
+{
+  id_puts = rb_intern("puts");
+
+  rb_define_method(rb_cObject, "my_fixed_args_method", my_fixed_args_method, 2);
+  rb_define_method(rb_cObject, "my_var_args_c_array_method", my_var_args_c_array_method, -1);
+  rb_define_method(rb_cObject, "my_var_args_rb_array_method", my_var_args_rb_array_method, -2);
+  rb_define_method(rb_cObject, "my_method_with_required_block", my_method_with_required_block, 0);
+
+  id_each = rb_intern("each");
+
+  rb_define_method(rb_cArray, "puts_every_other", array_puts_every_other, 0);
+}

--- a/ext/ddcov/ddcov.c
+++ b/ext/ddcov/ddcov.c
@@ -2,19 +2,80 @@
 #include <ruby/debug.h>
 #include <stdio.h>
 
-VALUE DDCovClass = Qnil;
-
-VALUE dd_cov_initialize(VALUE self)
+// Utils
+static bool prefix(const char *pre, const char *str)
 {
-  rb_iv_set(self, "@var", rb_hash_new());
-  return self;
+  return strncmp(pre, str, strlen(pre)) == 0;
 }
 
-void dd_cov_update_line_coverage(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
+// Data structure
+struct dd_cov_data
+{
+  char *root;
+  VALUE coverage;
+};
+
+static void dd_cov_mark(void *ptr)
+{
+  // printf("MARK\n");
+  struct dd_cov_data *dd_cov_data = ptr;
+  rb_gc_mark_movable(dd_cov_data->coverage);
+}
+
+static void dd_cov_free(void *ptr)
+{
+  // printf("FREE\n");
+  struct dd_cov_data *dd_cov_data = ptr;
+
+  xfree(dd_cov_data);
+}
+
+static void dd_cov_compact(void *ptr)
+{
+  // printf("COMPACT\n");
+  struct dd_cov_data *dd_cov_data = ptr;
+  dd_cov_data->coverage = rb_gc_location(dd_cov_data->coverage);
+}
+
+const rb_data_type_t dd_cov_data_type = {
+    .wrap_struct_name = "dd_cov",
+    .function = {
+        .dmark = dd_cov_mark,
+        .dfree = dd_cov_free,
+        .dsize = NULL,
+        .dcompact = dd_cov_compact},
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY};
+
+static VALUE dd_cov_allocate(VALUE klass)
+{
+  // printf("ALLOCATE\n");
+  struct dd_cov_data *dd_cov_data;
+  VALUE obj = TypedData_Make_Struct(klass, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
+  dd_cov_data->coverage = rb_hash_new();
+  return obj;
+}
+
+// DDCov methods
+static VALUE dd_cov_initialize(VALUE self, VALUE rb_root)
+{
+  // printf("INITIALIZE\n");
+  struct dd_cov_data *dd_cov_data;
+  TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
+
+  // printf("struct got\n");
+  dd_cov_data->root = StringValueCStr(rb_root);
+  // printf("root set\n");
+
+  return Qnil;
+}
+
+static void dd_cov_update_line_coverage(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
 {
   // printf("EVENT HOOK FIRED\n");
   // printf("FILE: %s\n", rb_sourcefile());
   // printf("LINE: %d\n", rb_sourceline());
+  struct dd_cov_data *dd_cov_data;
+  TypedData_Get_Struct(data, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
 
   const char *filename = rb_sourcefile();
   if (filename == 0)
@@ -22,13 +83,18 @@ void dd_cov_update_line_coverage(rb_event_flag_t event, VALUE data, VALUE self, 
     return;
   }
 
-  unsigned long filename_length = strlen(filename);
+  if (!prefix(dd_cov_data->root, filename))
+  {
+    return;
+  }
 
-  VALUE rb_str_source_file = rb_str_new(filename, filename_length);
-  rb_hash_aset(rb_iv_get(data, "@var"), rb_str_source_file, Qtrue);
+  unsigned long len_filename = strlen(filename);
+
+  VALUE rb_str_source_file = rb_str_new(filename, len_filename);
+  rb_hash_aset(dd_cov_data->coverage, rb_str_source_file, Qtrue);
 }
 
-VALUE dd_cov_start(VALUE self)
+static VALUE dd_cov_start(VALUE self)
 {
   // get current thread
   VALUE thval = rb_thread_current();
@@ -39,23 +105,30 @@ VALUE dd_cov_start(VALUE self)
   return self;
 }
 
-VALUE dd_cov_stop(VALUE self)
+static VALUE dd_cov_stop(VALUE self)
 {
   // get current thread
   VALUE thval = rb_thread_current();
-
   // remove event hook
   rb_thread_remove_event_hook(thval, dd_cov_update_line_coverage);
 
-  return rb_iv_get(self, "@var");
+  struct dd_cov_data *dd_cov_data;
+  TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
+
+  VALUE cov = dd_cov_data->coverage;
+
+  dd_cov_data->coverage = rb_hash_new();
+
+  return cov;
 }
 
 void Init_ddcov(void)
 {
-  id_puts = rb_intern("puts");
+  VALUE cDDCov = rb_define_class("DDCov", rb_cObject);
 
-  DDCovClass = rb_define_class("DDCov", rb_cObject);
-  rb_define_method(DDCovClass, "initialize", dd_cov_initialize, 0);
-  rb_define_method(DDCovClass, "start", dd_cov_start, 0);
-  rb_define_method(DDCovClass, "stop", dd_cov_stop, 0);
+  rb_define_alloc_func(cDDCov, dd_cov_allocate);
+
+  rb_define_method(cDDCov, "initialize", dd_cov_initialize, 1);
+  rb_define_method(cDDCov, "start", dd_cov_start, 0);
+  rb_define_method(cDDCov, "stop", dd_cov_stop, 0);
 }

--- a/ext/ddcov/extconf.rb
+++ b/ext/ddcov/extconf.rb
@@ -1,0 +1,5 @@
+require "mkmf"
+
+extension_name = "ddcov"
+dir_config(extension_name)
+create_makefile(extension_name)

--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require "coverage"
-
-require_relative "filter"
+require_relative "../../utils/git"
 require_relative "../../../../ddcov/ddcov"
 
 module Datadog
@@ -11,7 +9,7 @@ module Datadog
       module Coverage
         class Collector
           def initialize
-            @ddcov = DDCov.new
+            # TODO: make this thread local
           end
 
           def setup
@@ -19,14 +17,14 @@ module Datadog
           end
 
           def start
+            @ddcov = DDCov.new(Utils::Git.root)
             @ddcov.start
           end
 
           def stop
-            result = @ddcov.stop
-            @ddcov.instance_variable_set(:@var, {})
-
-            Filter.call(result)
+            @ddcov.stop
+            # p "RAW"
+            # p result.count
           end
         end
       end

--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "coverage"
+
+require_relative "filter"
+
+module Datadog
+  module CI
+    module Itr
+      module Coverage
+        class Collector
+          def initialize
+            # Do not run code coverage if someone else is already running it.
+            # It means that user is running the test with coverage and ITR would mess it up.
+            @coverage_supported = !::Coverage.running?
+            # @coverage_supported = false
+          end
+
+          def setup
+            if @coverage_supported
+              p "RUNNING WITH CODE COVERAGE ENABLED!"
+              ::Coverage.setup(lines: true)
+            else
+              p "RUNNING WITH CODE COVERAGE DISABLED!"
+            end
+          end
+
+          def start
+            return unless @coverage_supported
+
+            # if execution is threaded then coverage might already be running
+            ::Coverage.resume unless ::Coverage.running?
+          end
+
+          def stop
+            return nil unless @coverage_supported
+
+            result = ::Coverage.result(stop: false, clear: true)
+            ::Coverage.suspend if ::Coverage.running?
+
+            Filter.call(result)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "coverage"
+
 require_relative "../../utils/git"
 require_relative "../../../../ddcov/ddcov"
 
@@ -8,23 +10,31 @@ module Datadog
     module Itr
       module Coverage
         class Collector
-          def initialize
+          def initialize(mode: :files, enabled: true)
             # TODO: make this thread local
+            # modes available: :files, :lines
+            @mode = mode
+            @enabled = enabled
+
+            if @enabled
+              @ddcov = DDCov.new(root: Utils::Git.root, mode: mode)
+            end
           end
 
           def setup
-            p "RUNNING WITH CODE COVERAGE ENABLED"
+            if @enabled
+              p "RUNNING WITH CODE COVERAGE ENABLED"
+            else
+              p "RUNNING WITH CODE COVERAGE DISABLED"
+            end
           end
 
           def start
-            @ddcov = DDCov.new(Utils::Git.root)
-            @ddcov.start
+            @ddcov.start if @enabled
           end
 
           def stop
-            @ddcov.stop
-            # p "RAW"
-            # p result.count
+            @ddcov.stop if @enabled
           end
         end
       end

--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -23,7 +23,7 @@ module Datadog
 
           def setup
             if @enabled
-              p "RUNNING WITH CODE COVERAGE ENABLED"
+              p "RUNNING WITH CODE COVERAGE ENABLED AND MODE #{@mode}"
             else
               p "RUNNING WITH CODE COVERAGE DISABLED"
             end

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "../../utils/git"
+
+module Datadog
+  module CI
+    module Itr
+      module Coverage
+        class Filter
+          def self.call(raw_result)
+            new.call(raw_result)
+          end
+
+          def initialize(root: Utils::Git.root)
+            @regex = /\A#{Regexp.escape(root + File::SEPARATOR)}/i.freeze
+          end
+
+          def call(raw_result)
+            return nil if raw_result.nil?
+
+            raw_result.select do |path, coverage|
+              path =~ @regex && coverage[:lines].any? { |count| count && count > 0 }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -24,9 +24,8 @@ module Datadog
 
             raw_result.filter_map do |path, coverage|
               next unless path =~ @regex
-              next unless coverage[:lines].any? { |line| !line.nil? && line > 0 }
 
-              [path, convert_lines_to_bitmap(coverage[:lines])]
+              [path, coverage]
             end
           end
 

--- a/lib/datadog/ci/itr/coverage/filter.rb
+++ b/lib/datadog/ci/itr/coverage/filter.rb
@@ -6,6 +6,7 @@ module Datadog
   module CI
     module Itr
       module Coverage
+        # not filter, but rather filter and transformer
         class Filter
           def self.call(raw_result)
             new.call(raw_result)
@@ -17,6 +18,9 @@ module Datadog
 
           def call(raw_result)
             return nil if raw_result.nil?
+
+            # p "RAW"
+            # p raw_result.count
 
             raw_result.filter_map do |path, coverage|
               next unless path =~ @regex

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -333,10 +333,9 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
-            files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
-            test.set_tag("_test.coverage", files_covered)
-
-            # p test.get_tag("_test.coverage")
+            # move this to the code coverage transport
+            # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
+            test.set_tag("_test.coverage", coverage)
           end
         end
       end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -41,7 +41,7 @@ module Datadog
           @global_context = Context::Global.new
           @codeowners = codeowners
 
-          @coverage_collector = Itr::Coverage::Collector.new
+          @coverage_collector = Itr::Coverage::Collector.new(mode: :lines, enabled: true)
           begin
             @coverage_collector.setup
           rescue => e
@@ -333,6 +333,20 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
+            if ENV["DD_COV_REPORT"]
+              # append to report.log file
+              File.open("report.log", "a") do |f|
+                f.write("#{test.name}\n")
+                f.write("---------------------------------------------------\n")
+
+                coverage.each do |filename, lines|
+                  f.write("#{filename}\n")
+                  sorted_lines = lines.uniq.sort
+                  f.write("#{sorted_lines}\n")
+                end
+                f.write("---------------------------------------------------\n")
+              end
+            end
             # p "FILTERED"
             # p coverage.count
             # p coverage

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -333,6 +333,8 @@ module Datadog
         def on_test_end(test)
           coverage = @coverage_collector.stop
           if coverage
+            # p "FILTERED"
+            # p coverage.count
             # move this to the code coverage transport
             # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
             test.set_tag("_test.coverage", coverage)

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -335,6 +335,7 @@ module Datadog
           if coverage
             # p "FILTERED"
             # p coverage.count
+            # p coverage
             # move this to the code coverage transport
             # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
             test.set_tag("_test.coverage", coverage)

--- a/spec/datadog/ci/span_spec.rb
+++ b/spec/datadog/ci/span_spec.rb
@@ -1,6 +1,35 @@
+require_relative "../../../lib/ddcov/ddcov"
+
 RSpec.describe Datadog::CI::Span do
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, name: "span_name", type: "test") }
   subject(:span) { described_class.new(tracer_span) }
+
+  describe "ddcov" do
+    puts "----- Testing Object#my_fixed_args_method -----"
+
+    "I am self".my_fixed_args_method("Hi from argument 1", "Hi from argument 2")
+
+    puts
+    puts "----- Testing Object#my_var_args_c_array_method -----"
+
+    "Hi from self".my_var_args_c_array_method("1", "2", "3", "4")
+
+    puts
+    puts "----- Testing Object#my_var_args_rb_array_method -----"
+
+    "Hi from self".my_var_args_rb_array_method("1", "2")
+
+    puts
+    puts "----- Testing Object#my_method_with_required_block -----"
+
+    my_method_with_required_block do
+      "foo"
+    end
+
+    puts "---- Test Array#puts_every_other ----"
+
+    [1, 2, 3, 4, 5, 6, 7].puts_every_other
+  end
 
   describe "#name" do
     it "returns the span name" do

--- a/spec/datadog/ci/span_spec.rb
+++ b/spec/datadog/ci/span_spec.rb
@@ -4,33 +4,6 @@ RSpec.describe Datadog::CI::Span do
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, name: "span_name", type: "test") }
   subject(:span) { described_class.new(tracer_span) }
 
-  describe "ddcov" do
-    puts "----- Testing Object#my_fixed_args_method -----"
-
-    "I am self".my_fixed_args_method("Hi from argument 1", "Hi from argument 2")
-
-    puts
-    puts "----- Testing Object#my_var_args_c_array_method -----"
-
-    "Hi from self".my_var_args_c_array_method("1", "2", "3", "4")
-
-    puts
-    puts "----- Testing Object#my_var_args_rb_array_method -----"
-
-    "Hi from self".my_var_args_rb_array_method("1", "2")
-
-    puts
-    puts "----- Testing Object#my_method_with_required_block -----"
-
-    my_method_with_required_block do
-      "foo"
-    end
-
-    puts "---- Test Array#puts_every_other ----"
-
-    [1, 2, 3, 4, 5, 6, 7].puts_every_other
-  end
-
   describe "#name" do
     it "returns the span name" do
       expect(span.name).to eq("span_name")

--- a/spec/datadog/ci/span_spec.rb
+++ b/spec/datadog/ci/span_spec.rb
@@ -1,5 +1,3 @@
-require_relative "../../../lib/ddcov/ddcov"
-
 RSpec.describe Datadog::CI::Span do
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, name: "span_name", type: "test") }
   subject(:span) { described_class.new(tracer_span) }


### PR DESCRIPTION
Proof of concept of the approach proposed by @mame in https://bugs.ruby-lang.org/issues/20282. 

It uses native C function `rb_thread_add_event_hook` to add an event hook for `RUBY_EVENT_LINE` event and track executed lines independently from Ruby's built-in `Coverage` module. Additionally, it is optimized by tracking only files that are located under the git repository root.

### Performance evaluation

Projects used to evaluate performance:
- sidekiq: very small and fast test suite
- rubocop: very big but quite fast test suite (20 000 tests under 2 minutes)
- vagrant: very big and slow test suite (5 000 tests in about 14 minutes)

In the following table are durations of the whole test session in seconds, in brackets overhead percentage compared to run with datadog-ci.

| Coverage type | Sidekiq | Rubocop | Vagrant |
|--------|--------|--------|--------|
| No coverage | ~6,8 | 111 | 827 |
| Simplecov (total coverage) | ~7 | 137 | 864 |
| Per test coverage, files | 7,5 (10%) | 178 (60%)  | 869 (5%)  |
| Per test coverage, lines | 8,5 (25%) | 187 (68%) | 886 (7%) |
| Per test coverage, lines AND total coverage with simplecov`*` | 8,7 (24%) |  210 (53%)  |  928 (7%) |

`*` overhead here is compared to "Simplecov (total coverage)"

### Relevant code

#### Native extension
```c
static void dd_cov_update_line_coverage(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
{
  struct dd_cov_data *dd_cov_data;
  TypedData_Get_Struct(data, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);

  const char *filename = rb_sourcefile();
  if (filename == 0)
  {
    return;
  }

  if (!prefix(dd_cov_data->root, filename))
  {
    return;
  }

  unsigned long len_filename = strlen(filename);

  VALUE rb_str_source_file = rb_str_new(filename, len_filename);

  if (dd_cov_data->mode == DD_COVERAGE_TARGET_FILES)
  {
    rb_hash_aset(dd_cov_data->coverage, rb_str_source_file, Qtrue);
    return;
  }

  if (dd_cov_data->mode == DD_COVERAGE_TARGET_LINES)
  {
    VALUE rb_lines = rb_hash_aref(dd_cov_data->coverage, rb_str_source_file);
    if (rb_lines == Qnil)
    {
      rb_lines = rb_ary_new();
      rb_hash_aset(dd_cov_data->coverage, rb_str_source_file, rb_lines);
    }

    VALUE line_number = INT2FIX(rb_sourceline());
    if (rb_ary_includes(rb_lines, line_number) == Qfalse)
    {
      rb_ary_push(rb_lines, line_number);
    }
  }
}

static VALUE dd_cov_start(VALUE self)
{
  // get current thread
  VALUE thval = rb_thread_current();

  // add event hook
  rb_thread_add_event_hook(thval, dd_cov_update_line_coverage, RUBY_EVENT_LINE, self);

  return self;
}

static VALUE dd_cov_stop(VALUE self)
{
  // get current thread
  VALUE thval = rb_thread_current();
  // remove event hook for the current thread
  rb_thread_remove_event_hook(thval, dd_cov_update_line_coverage);

  struct dd_cov_data *dd_cov_data;
  TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);

  VALUE cov = dd_cov_data->coverage;

  dd_cov_data->coverage = rb_hash_new();

  return cov;
}
```

#### Usage in Ruby

```ruby
mode = :files # or :lines
@ddcov = DDCov.new(root: Utils::Git.root, mode: mode)

# when test starts
@ddcov.start

# when test ends
@ddcov.stop # returns coverage hash
```
