### PR TITLE
[POC] per test code coverage using TracePoint.new(:line)

### DIFF
--- a/lib/datadog/ci/itr/coverage/collector.rb
+++ b/lib/datadog/ci/itr/coverage/collector.rb
@@ -33,7 +33,7 @@ module Datadog
 
           def setup
             if @enabled
-              p "RUNNING WITH CODE COVERAGE ENABLED"
+              p "RUNNING WITH CODE COVERAGE ENABLED AND MODE #{@mode}"
             else
               p "RUNNING WITH CODE COVERAGE DISABLED"
             end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -347,9 +347,9 @@ module Datadog
                 f.write("---------------------------------------------------\n")
               end
             end
-            p "FILTERED"
-            p coverage.count
-            p coverage
+            # p "FILTERED"
+            # p coverage.count
+            # p coverage
             # move this to the code coverage transport
             # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
             test.set_tag("_test.coverage", coverage)

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -41,7 +41,7 @@ module Datadog
           @global_context = Context::Global.new
           @codeowners = codeowners
 
-          @coverage_collector = Itr::Coverage::Collector.new(mode: :lines, enabled: true)
+          @coverage_collector = Itr::Coverage::Collector.new(mode: :files, enabled: true)
           begin
             @coverage_collector.setup
           rescue => e

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -341,15 +341,15 @@ module Datadog
 
                 coverage.each do |filename, lines|
                   f.write("#{filename}\n")
-                  sorted_lines = lines.uniq.sort
+                  sorted_lines = lines.to_a.sort
                   f.write("#{sorted_lines}\n")
                 end
                 f.write("---------------------------------------------------\n")
               end
             end
-            # p "FILTERED"
-            # p coverage.count
-            # p coverage
+            p "FILTERED"
+            p coverage.count
+            p coverage
             # move this to the code coverage transport
             # files_covered = coverage.keys.map { |filename| Utils::Git.relative_to_root(filename) }
             test.set_tag("_test.coverage", coverage)


### PR DESCRIPTION
Proof of concept for per test code coverage using TracePoint class to attach to `line` events. Works in **files** mode (tracking only source files executed) and **lines** mode (tracking files together with executed lines).

### Performance evaluation

Projects used to evaluate performance:
- sidekiq: very small and fast test suite
- rubocop: very big but quite fast test suite (20 000 tests under 2 minutes)
- vagrant: very big and slow test suite (5 000 tests in about 14 minutes)

In the following table are durations of the whole test session in seconds, in brackets overhead percentage compared to run with datadog-ci.

| Coverage type | Sidekiq | Rubocop | Vagrant |
|--------|--------|--------|--------|
| No coverage | ~6,8 | 111 | 827 |
| Simplecov (total coverage) | ~7 | 137 | 864 |
| Per test coverage, files | ~11 (61%) | 617 (455%)  | 1044 (20%) |
| Per test coverage, lines | ~11 (61%) | 617 (455%) | 1094 (26%) |
| Per test coverage, lines AND total coverage with simplecov`*` | ~11 (57%) | 660 (380%)  |  1122 (29%) |

`*` overhead here is compared to "Simplecov (total coverage)"


### Relevant code

```ruby
mode = :files # or :lines
regex = /\A#{Regexp.escape(Utils::Git.root + File::SEPARATOR)}/i.freeze
coverage = {}

@tracepoint = TracePoint.new(:line) do |tp|
  # filter only files that are under the git repository root
  next unless tp.path =~ regex

  if mode == :files
    coverage[tp.path] = true
  elsif mode == :lines
    coverage[tp.path] ||= Set.new
    coverage[tp.path] << tp.lineno
  end
end

# when starting test
@tracepoint.enable

# when ending test
@tracepoint.disable
```

