### PR TITLE
use framework name as test module name to make test fingerprints stable

### DIFF
--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -34,14 +34,14 @@ module Datadog
           end
 
           def on_test_run_started(event)
-            test_session = CI.start_test_session(
+            CI.start_test_session(
               tags: {
                 CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                 CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Cucumber::Integration.version.to_s
               },
               service: configuration[:service_name]
             )
-            CI.start_test_module(test_session.name) if test_session
+            CI.start_test_module(Ext::FRAMEWORK)
           end
 
           def on_test_run_finished(event)

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -18,14 +18,14 @@ module Datadog
 
               return unless datadog_configuration[:enabled]
 
-              test_session = CI.start_test_session(
+              CI.start_test_session(
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s
                 },
                 service: datadog_configuration[:service_name]
               )
-              CI.start_test_module(test_session.name) if test_session
+              CI.start_test_module(Ext::FRAMEWORK)
             end
 
             private

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -25,7 +25,7 @@ module Datadog
                 service: datadog_configuration[:service_name]
               )
 
-              test_module = CI.start_test_module(test_session.name) if test_session
+              test_module = CI.start_test_module(Ext::FRAMEWORK)
 
               result = super
               return result unless test_module && test_session

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -31,7 +31,6 @@ module Datadog
               return result unless test_module && test_session
 
               if result != 0
-                # TODO: repeating this twice feels clunky, we need to remove test_module API before GA
                 test_module.failed!
                 test_session.failed!
               else

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Cucumber formatter" do
 
     it "creates test module span" do
       expect(test_module_span).not_to be_nil
-      expect(test_module_span.name).to eq(test_command)
+      expect(test_module_span.name).to eq("cucumber")
       expect(test_module_span.service).to eq("jalapenos")
       expect(test_module_span).to have_test_tag(:span_kind, "test")
       expect(test_module_span).to have_test_tag(:framework, "cucumber")
@@ -171,7 +171,7 @@ RSpec.describe "Cucumber formatter" do
 
     it "connects test span to test session, test module, and test suite" do
       expect(first_test_span).to have_test_tag(:test_module_id, test_module_span.id.to_s)
-      expect(first_test_span).to have_test_tag(:module, test_command)
+      expect(first_test_span).to have_test_tag(:module, "cucumber")
       expect(first_test_span).to have_test_tag(:test_session_id, test_session_span.id.to_s)
       expect(first_test_span).to have_test_tag(:test_suite_id, first_test_suite_span.id.to_s)
       expect(first_test_span).to have_test_tag(:suite, first_test_suite_span.name)

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -425,7 +425,7 @@ RSpec.describe "Minitest instrumentation" do
           expect(test_module_span).not_to be_nil
 
           expect(test_module_span.type).to eq("test_module_end")
-          expect(test_module_span.name).to eq(test_command)
+          expect(test_module_span.name).to eq("minitest")
 
           expect(test_module_span).to have_test_tag(:span_kind, "test")
           expect(test_module_span).to have_test_tag(:framework, "minitest")

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -469,7 +469,7 @@ RSpec.describe "RSpec hooks" do
       expect(test_module_span).not_to be_nil
 
       expect(test_module_span.type).to eq("test_module_end")
-      expect(test_module_span.name).to eq(test_command)
+      expect(test_module_span.name).to eq("rspec")
 
       expect(test_module_span).to have_test_tag(:span_kind, "test")
       expect(test_module_span).to have_test_tag(:framework, "rspec")


### PR DESCRIPTION
**What does this PR do?**

Fixes customer-reported issue with flaky test detection after test suite level visibility release.

**Bug description**

Currently `test_module_end` events have the same name as `test_session_end` which could be different between test runs: we use test command value this and test command could include variable data (like --seed param). The problem is that test module name is part of test fingerprint, and unstable fingerprints make flaky test detection impossible.

**How is it fixed?**

We change test module name to be just the test framework name (minitest, rspec, or cucumber). NOTE: This change will cause fingerprint updates for all current tests. 