### PR TITLE
[CIVIS-9349] assign the single running test suite for a test if none found by test suite name

### DIFF
--- a/lib/datadog/ci/test_visibility/context/global.rb
+++ b/lib/datadog/ci/test_visibility/context/global.rb
@@ -21,6 +21,14 @@ module Datadog
             end
           end
 
+          def fetch_single_test_suite
+            @mutex.synchronize do
+              return nil if @test_suites.empty? || @test_suites.size > 1
+
+              @test_suites.values.first
+            end
+          end
+
           def fetch_or_activate_test_module(&block)
             @mutex.synchronize do
               @test_module ||= block.call

--- a/sig/datadog/ci/test_visibility/context/global.rbs
+++ b/sig/datadog/ci/test_visibility/context/global.rbs
@@ -13,6 +13,8 @@ module Datadog
 
           def fetch_or_activate_test_suite: (String test_suite_name) {() -> Datadog::CI::TestSuite} -> Datadog::CI::TestSuite
 
+          def fetch_single_test_suite: () -> Datadog::CI::TestSuite?
+
           def fetch_or_activate_test_module: () {() -> Datadog::CI::TestModule} -> Datadog::CI::TestModule
 
           def fetch_or_activate_test_session: () {() -> Datadog::CI::TestSession} -> Datadog::CI::TestSession

--- a/sig/datadog/ci/test_visibility/recorder.rbs
+++ b/sig/datadog/ci/test_visibility/recorder.rbs
@@ -73,6 +73,8 @@ module Datadog
 
         def set_suite_context: (Hash[untyped, untyped] tags, ?span: Datadog::Tracing::SpanOperation, ?name: String) -> void
 
+        def fix_test_suite!: (Datadog::CI::Test test) -> void
+
         def set_module_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestModule | Datadog::Tracing::SpanOperation? test_module) -> void
 
         def set_codeowners: (Datadog::CI::Test test) -> void

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -310,6 +310,32 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
                   expect(subject).to have_test_tag(:suite, test_suite_name)
                 end
               end
+
+              context "when there is a running test suite but with a different name" do
+                let(:test_suite) do
+                  recorder.start_test_suite("other suite")
+                end
+
+                before do
+                  test_suite
+                end
+
+                it "connects the test span to the running test suite" do
+                  expect(subject).to have_test_tag(:test_suite_id, test_suite.id.to_s)
+                  expect(subject).to have_test_tag(:suite, "other suite")
+                end
+              end
+
+              context "when there are several running test suites with different names" do
+                before do
+                  recorder.start_test_suite("other suite")
+                  recorder.start_test_suite("other other suite")
+                end
+
+                it "does not connect test to test suite" do
+                  expect(subject).not_to have_test_tag(:test_suite_id)
+                end
+              end
             end
           end
         end


### PR DESCRIPTION
**What does this PR do?**
Makes test suite assignment more robust by assigning the single runinng test suite to a test when no test suite found by name.

**Motivation**
There are cases where minitest test suite names fluctuate from test to test because of using external libraries like shoulda-context and/or activesupport concerns. While https://github.com/DataDog/datadog-ci-rb/pull/134 fixed most of these cases there are still a very small chance of some test cases (inside anonymous classes?) that are skipped because of missing test suite id.

Thankfully, if minitest executes tests sequentially, there should be only one test suite running at a time: we can use it to assign "lost tests" to whichever test suite that is currently running.

**How to test the change?**
Unit tests are provided