### PR TITLE
remove temporary hack and use Core::Remote::Negotiation's new constructor param

### DIFF
--- a/lib/datadog/ci/transport/api/builder.rb
+++ b/lib/datadog/ci/transport/api/builder.rb
@@ -29,10 +29,11 @@ module Datadog
 
           def self.build_evp_proxy_api(settings)
             agent_settings = Datadog::Core::Configuration::AgentSettingsResolver.call(settings)
-            negotiation = Datadog::Core::Remote::Negotiation.new(settings, agent_settings)
-
-            # temporary, remove this when patch will be accepted in Core to make logging configurable
-            negotiation.instance_variable_set(:@logged, {no_config_endpoint: true})
+            negotiation = Datadog::Core::Remote::Negotiation.new(
+              settings,
+              agent_settings,
+              suppress_logging: {no_config_endpoint: true}
+            )
 
             evp_proxy_path_prefix = Ext::Transport::EVP_PROXY_PATH_PREFIXES.find do |path_prefix|
               negotiation.endpoint?(path_prefix)

--- a/vendor/rbs/ddtrace/0/datadog/core/remote/negotiation.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/core/remote/negotiation.rbs
@@ -5,7 +5,7 @@ module Datadog
         @transport_root: Datadog::Core::Remote::Transport::Negotiation::Transport
         @logged: ::Hash[::Symbol, bool]
 
-        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings) -> void
+        def initialize: (Datadog::Core::Configuration::Settings _settings, Datadog::Core::Configuration::AgentSettingsResolver::AgentSettings agent_settings, ?suppress_logging: ::Hash[::Symbol, bool]) -> void
 
         def endpoint?: (::String path) -> bool
 


### PR DESCRIPTION
**What does this PR do?**
Removes temporary hack to suppress logging of Datadog::Core::Remote::Negotiation