### PR TITLE
add a section on correctly using tracer with minitest/autorun

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ if ENV["DD_ENV"] == "ci"
 end
 ```
 
+> [!IMPORTANT]
+> When using `minitest/autorun` the order of requires matters: `datadog/ci` must be
+> always required before `minitest/autorun`.
+
+Example using `minitest/autorun`
+
+```ruby
+require 'datadog/ci'
+require 'minitest/autorun'
+
+if ENV["DD_ENV"] == "ci"
+  Datadog.configure do |c|
+    c.ci.enabled = true
+    c.service = 'my-ruby-app'
+    c.ci.instrument :minitest
+  end
+end
+```
+
 `options` are the following keyword arguments:
 
 | Key | Description | Default |


### PR DESCRIPTION
**What does this PR do?**
Adds a note to README about possible issues when using minitest/autorun

**Motivation**
minitest/autorun registers at_exit hook that runs the test suite. Datadog::Core also registers at_exit hook that stops Tracing worker. As hooks are executed in LIFO order, Datadog must be required first: that way test suite is being run and then Tracing is stopped. Otherwise, tests are being run without tracing enabled.

