### PR TITLE
[CIVIS-2892] citestcov transport to serialize and send code coverage events

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -12,6 +12,7 @@ target :lib do
   library "minitest"
   library "net-http"
   library "zlib"
+  library "securerandom"
 
   repo_path "vendor/rbs"
   library "ddtrace"

--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -23,6 +23,9 @@ module Datadog
         TEST_VISIBILITY_INTAKE_HOST_PREFIX = "citestcycle-intake"
         TEST_VISIBILITY_INTAKE_PATH = "/api/v2/citestcycle"
 
+        TEST_COVERAGE_INTAKE_HOST_PREFIX = "citestcov-intake"
+        TEST_COVERAGE_INTAKE_PATH = "/api/v2/citestcov"
+
         DD_API_HOST_PREFIX = "api"
         DD_API_SETTINGS_PATH = "/api/v2/libraries/tests/services/setting"
         DD_API_SETTINGS_TYPE = "ci_app_test_service_libraries_settings"
@@ -35,6 +38,7 @@ module Datadog
 
         CONTENT_TYPE_MESSAGEPACK = "application/msgpack"
         CONTENT_TYPE_JSON = "application/json"
+        CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data"
         CONTENT_ENCODING_GZIP = "gzip"
       end
     end

--- a/lib/datadog/ci/itr/coverage/event.rb
+++ b/lib/datadog/ci/itr/coverage/event.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "msgpack"
+
 module Datadog
   module CI
     module ITR
@@ -12,6 +14,48 @@ module Datadog
             @test_suite_id = test_suite_id
             @test_session_id = test_session_id
             @coverage = coverage
+          end
+
+          def valid?
+            valid = true
+
+            [:test_id, :test_suite_id, :test_session_id, :coverage].each do |key|
+              next unless send(key).nil?
+
+              Datadog.logger.warn("citestcov event is invalid: [#{key}] is nil. Event: #{self}")
+              valid = false
+            end
+
+            valid
+          end
+
+          def to_msgpack(packer = nil)
+            packer ||= MessagePack::Packer.new
+
+            packer.write_map_header(4)
+
+            packer.write("test_session_id")
+            packer.write(test_session_id.to_i)
+
+            packer.write("test_suite_id")
+            packer.write(test_suite_id.to_i)
+
+            packer.write("span_id")
+            packer.write(test_id.to_i)
+
+            files = coverage.keys
+            packer.write("files")
+            packer.write_array_header(files.size)
+
+            files.each do |filename|
+              packer.write_map_header(1)
+              packer.write("filename")
+              packer.write(filename)
+            end
+          end
+
+          def to_s
+            "Coverage::Event[test_id=#{test_id}, test_suite_id=#{test_suite_id}, test_session_id=#{test_session_id}]"
           end
         end
       end

--- a/lib/datadog/ci/itr/coverage/event.rb
+++ b/lib/datadog/ci/itr/coverage/event.rb
@@ -5,11 +5,11 @@ module Datadog
     module ITR
       module Coverage
         class Event
-          attr_reader :test_id, :test_module_id, :test_session_id, :coverage
+          attr_reader :test_id, :test_suite_id, :test_session_id, :coverage
 
-          def initialize(test_id:, test_module_id:, test_session_id:, coverage:)
+          def initialize(test_id:, test_suite_id:, test_session_id:, coverage:)
             @test_id = test_id
-            @test_module_id = test_module_id
+            @test_suite_id = test_suite_id
             @test_session_id = test_session_id
             @coverage = coverage
           end

--- a/lib/datadog/ci/itr/coverage/event.rb
+++ b/lib/datadog/ci/itr/coverage/event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module ITR
+      module Coverage
+        class Event
+          attr_reader :test_id, :test_module_id, :test_session_id, :coverage
+
+          def initialize(test_id:, test_module_id:, test_session_id:, coverage:)
+            @test_id = test_id
+            @test_module_id = test_module_id
+            @test_session_id = test_session_id
+            @coverage = coverage
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/event.rb
+++ b/lib/datadog/ci/itr/coverage/event.rb
@@ -55,7 +55,7 @@ module Datadog
           end
 
           def to_s
-            "Coverage::Event[test_id=#{test_id}, test_suite_id=#{test_suite_id}, test_session_id=#{test_session_id}]"
+            "Coverage::Event[test_id=#{test_id}, test_suite_id=#{test_suite_id}, test_session_id=#{test_session_id}, coverage=#{coverage}]"
           end
         end
       end

--- a/lib/datadog/ci/itr/coverage/transport.rb
+++ b/lib/datadog/ci/itr/coverage/transport.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+require "msgpack"
+
+require_relative "event"
+
 module Datadog
   module CI
     module ITR

--- a/lib/datadog/ci/itr/coverage/transport.rb
+++ b/lib/datadog/ci/itr/coverage/transport.rb
@@ -2,6 +2,9 @@
 
 require "msgpack"
 
+require "datadog/core/encoding"
+require "datadog/core/chunker"
+
 require_relative "event"
 
 module Datadog
@@ -20,6 +23,71 @@ module Datadog
           end
 
           def send_events(events)
+            return [] if events.nil? || events.empty?
+
+            Datadog.logger.debug { "Sending #{events.count} events..." }
+
+            encoded_events = encode_events(events)
+            if encoded_events.empty?
+              Datadog.logger.debug { "Empty encoded events list, skipping send" }
+              return []
+            end
+
+            responses = []
+
+            Datadog::Core::Chunker.chunk_by_size(encoded_events, max_payload_size).map do |chunk|
+              encoded_payload = pack_events(chunk)
+              Datadog.logger.debug do
+                "Send chunk of #{chunk.count} events; payload size #{encoded_payload.size}"
+              end
+
+              response = send_payload(encoded_payload)
+
+              responses << response
+            end
+          end
+
+          private
+
+          def send_payload(encoded_payload)
+            api.citestcov_request(
+              path: Ext::Transport::TEST_COVERAGE_INTAKE_PATH,
+              payload: encoded_payload
+            )
+          end
+
+          def encoder
+            Datadog::Core::Encoding::MsgpackEncoder
+          end
+
+          def encode_events(events)
+            events.filter_map do |event|
+              next unless event.valid?
+
+              encoded = encoder.encode(event)
+              if encoded.size > max_payload_size
+                # This single event is too large, we can't flush it
+                Datadog.logger.warn("Dropping coverage event. Payload too large: '#{event}'")
+                Datadog.logger.warn(encoded)
+
+                next
+              end
+
+              encoded
+            end
+          end
+
+          def pack_events(encoded_events)
+            packer = MessagePack::Packer.new
+
+            packer.write_map_header(2)
+            packer.write("version")
+            packer.write(2)
+
+            packer.write("coverages")
+            packer.write_array_header(encoded_events.count)
+
+            (packer.buffer.to_a + encoded_events).join
           end
         end
       end

--- a/lib/datadog/ci/itr/coverage/transport.rb
+++ b/lib/datadog/ci/itr/coverage/transport.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module ITR
+      module Coverage
+        class Transport
+          DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
+
+          attr_reader :api,
+            :max_payload_size
+
+          def initialize(api:, max_payload_size: DEFAULT_MAX_PAYLOAD_SIZE)
+            @api = api
+            @max_payload_size = max_payload_size
+          end
+
+          def send_events(events)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/itr/coverage/transport.rb
+++ b/lib/datadog/ci/itr/coverage/transport.rb
@@ -1,52 +1,13 @@
 # frozen_string_literal: true
 
-require "msgpack"
-
-require "datadog/core/encoding"
-require "datadog/core/chunker"
-
 require_relative "event"
+require_relative "../../transport/event_platform_transport"
 
 module Datadog
   module CI
     module ITR
       module Coverage
-        class Transport
-          DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
-
-          attr_reader :api,
-            :max_payload_size
-
-          def initialize(api:, max_payload_size: DEFAULT_MAX_PAYLOAD_SIZE)
-            @api = api
-            @max_payload_size = max_payload_size
-          end
-
-          def send_events(events)
-            return [] if events.nil? || events.empty?
-
-            Datadog.logger.debug { "Sending #{events.count} events..." }
-
-            encoded_events = encode_events(events)
-            if encoded_events.empty?
-              Datadog.logger.debug { "Empty encoded events list, skipping send" }
-              return []
-            end
-
-            responses = []
-
-            Datadog::Core::Chunker.chunk_by_size(encoded_events, max_payload_size).map do |chunk|
-              encoded_payload = pack_events(chunk)
-              Datadog.logger.debug do
-                "Send chunk of #{chunk.count} events; payload size #{encoded_payload.size}"
-              end
-
-              response = send_payload(encoded_payload)
-
-              responses << response
-            end
-          end
-
+        class Transport < Datadog::CI::Transport::EventPlatformTransport
           private
 
           def send_payload(encoded_payload)
@@ -56,38 +17,23 @@ module Datadog
             )
           end
 
-          def encoder
-            Datadog::Core::Encoding::MsgpackEncoder
-          end
-
           def encode_events(events)
             events.filter_map do |event|
               next unless event.valid?
 
               encoded = encoder.encode(event)
-              if encoded.size > max_payload_size
-                # This single event is too large, we can't flush it
-                Datadog.logger.warn("Dropping coverage event. Payload too large: '#{event}'")
-                Datadog.logger.warn(encoded)
-
-                next
-              end
+              next if event_too_large?(event, encoded)
 
               encoded
             end
           end
 
-          def pack_events(encoded_events)
-            packer = MessagePack::Packer.new
-
+          def write_payload_header(packer)
             packer.write_map_header(2)
             packer.write("version")
             packer.write(2)
 
             packer.write("coverages")
-            packer.write_array_header(encoded_events.count)
-
-            (packer.buffer.to_a + encoded_events).join
           end
         end
       end

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -66,7 +66,7 @@ module Datadog
           coverage_collector&.start
         end
 
-        def stop_coverage
+        def stop_coverage(_test)
           return if !enabled? || !code_coverage?
 
           coverage_collector&.stop

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -371,8 +371,8 @@ module Datadog
         end
 
         # TODO: use kind of event system to notify about test finished?
-        def on_test_finished(_test)
-          @itr.stop_coverage
+        def on_test_finished(test)
+          @itr.stop_coverage(test)
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_level.rb
@@ -8,7 +8,7 @@ module Datadog
     module TestVisibility
       module Serializers
         module Factories
-          # This factory takes care of creating citestcycle serializers when test-level visibility is enabled
+          # This factory takes care of creating msgpack serializers when test-level visibility is enabled
           # NOTE: citestcycle is a protocol Datadog uses to submit test execution tracing information to CI visibility
           # backend
           module TestLevel

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
@@ -11,7 +11,7 @@ module Datadog
     module TestVisibility
       module Serializers
         module Factories
-          # This factory takes care of creating citestcycle serializers when test-suite-level visibility is enabled
+          # This factory takes care of creating msgpack serializers when test-suite-level visibility is enabled
           module TestSuiteLevel
             module_function
 

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -1,27 +1,16 @@
 # frozen_string_literal: true
 
-require "msgpack"
-require "uri"
-
-require "datadog/core/encoding"
 require "datadog/core/environment/identity"
-require "datadog/core/chunker"
 
 require_relative "serializers/factories/test_level"
 require_relative "../ext/transport"
+require_relative "../transport/event_platform_transport"
 
 module Datadog
   module CI
     module TestVisibility
-      class Transport
-        # CI test cycle intake's limit is 5.1MB uncompressed
-        # We will use a bit more conservative value 5MB
-        DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
-
-        attr_reader :serializers_factory,
-          :api,
-          :max_payload_size,
-          :dd_env
+      class Transport < Datadog::CI::Transport::EventPlatformTransport
+        attr_reader :serializers_factory, :dd_env
 
         def initialize(
           api:,
@@ -29,36 +18,15 @@ module Datadog
           serializers_factory: Datadog::CI::TestVisibility::Serializers::Factories::TestLevel,
           max_payload_size: DEFAULT_MAX_PAYLOAD_SIZE
         )
+          super(api: api, max_payload_size: max_payload_size)
+
           @serializers_factory = serializers_factory
-          @max_payload_size = max_payload_size
           @dd_env = dd_env
-          @api = api
         end
 
+        # this method is needed for compatibility with Datadog::Tracing::Writer that uses this Transport
         def send_traces(traces)
-          return [] if traces.nil? || traces.empty?
-
-          Datadog.logger.debug { "Sending #{traces.count} traces..." }
-
-          encoded_events = encode_traces(traces)
-          if encoded_events.empty?
-            Datadog.logger.debug { "Empty encoded events list, skipping send" }
-            return []
-          end
-
-          responses = []
-          Datadog::Core::Chunker.chunk_by_size(encoded_events, max_payload_size).map do |chunk|
-            encoded_payload = pack_events(chunk)
-            Datadog.logger.debug do
-              "Send chunk of #{chunk.count} events; payload size #{encoded_payload.size}"
-            end
-
-            response = send_payload(encoded_payload)
-
-            responses << response
-          end
-
-          responses
+          send_events(traces)
         end
 
         private
@@ -70,7 +38,7 @@ module Datadog
           )
         end
 
-        def encode_traces(traces)
+        def encode_events(traces)
           traces.flat_map do |trace|
             trace.spans.filter_map { |span| encode_span(trace, span) }
           end
@@ -101,9 +69,7 @@ module Datadog
           Datadog::Core::Encoding::MsgpackEncoder
         end
 
-        def pack_events(encoded_events)
-          packer = MessagePack::Packer.new
-
+        def write_payload_header(packer)
           packer.write_map_header(3) # Set header with how many elements in the map
 
           packer.write("version")
@@ -131,9 +97,6 @@ module Datadog
           packer.write(Datadog::CI::VERSION::STRING)
 
           packer.write("events")
-          packer.write_array_header(encoded_events.size)
-
-          (packer.buffer.to_a + encoded_events).join
         end
       end
     end

--- a/lib/datadog/ci/transport/api/agentless.rb
+++ b/lib/datadog/ci/transport/api/agentless.rb
@@ -10,10 +10,11 @@ module Datadog
         class Agentless < Base
           attr_reader :api_key
 
-          def initialize(api_key:, citestcycle_url:, api_url:)
+          def initialize(api_key:, citestcycle_url:, api_url:, citestcov_url:)
             @api_key = api_key
             @citestcycle_http = build_http_client(citestcycle_url, compress: true)
             @api_http = build_http_client(api_url, compress: false)
+            @citestcov_http = build_http_client(citestcov_url, compress: true)
           end
 
           def citestcycle_request(path:, payload:, headers: {}, verb: "post")
@@ -26,6 +27,12 @@ module Datadog
             super
 
             perform_request(@api_http, path: path, payload: payload, headers: headers, verb: verb)
+          end
+
+          def citestcov_request(path:, payload:, headers: {}, verb: "post")
+            super(path: path, payload: payload, headers: headers, verb: verb)
+
+            perform_request(@citestcov_http, path: path, payload: @citestcov_payload, headers: headers, verb: verb)
           end
 
           private

--- a/lib/datadog/ci/transport/api/base.rb
+++ b/lib/datadog/ci/transport/api/base.rb
@@ -15,6 +15,27 @@ module Datadog
             headers[Ext::Transport::HEADER_CONTENT_TYPE] ||= Ext::Transport::CONTENT_TYPE_MESSAGEPACK
           end
 
+          def citestcov_request(path:, payload:, headers: {}, verb: "post")
+            citestcov_request_boundary = "1"
+
+            headers[Ext::Transport::HEADER_CONTENT_TYPE] ||=
+              "#{Ext::Transport::CONTENT_TYPE_MULTIPART_FORM_DATA}; boundary=#{citestcov_request_boundary}"
+
+            @citestcov_payload = <<~PAYLOAD
+              --#{citestcov_request_boundary}
+              Content-Disposition: form-data; name="event"; filename="event.json"
+              Content-Type: application/json
+
+              {"dummy":true}
+              --#{citestcov_request_boundary}
+              Content-Disposition: form-data; name="coverage1"; filename="coverage1.msgpack"
+              Content-Type: application/msgpack
+
+              #{payload}
+              --#{citestcov_request_boundary}--
+            PAYLOAD
+          end
+
           def headers_with_default(headers)
             request_headers = default_headers
             request_headers.merge!(headers)

--- a/lib/datadog/ci/transport/api/builder.rb
+++ b/lib/datadog/ci/transport/api/builder.rb
@@ -24,7 +24,15 @@ module Datadog
             api_url = settings.ci.agentless_url ||
               "https://#{Ext::Transport::DD_API_HOST_PREFIX}.#{dd_site}:443"
 
-            Agentless.new(api_key: settings.api_key, citestcycle_url: citestcycle_url, api_url: api_url)
+            citestcov_url = settings.ci.agentless_url ||
+              "https://#{Ext::Transport::TEST_COVERAGE_INTAKE_HOST_PREFIX}.#{dd_site}:443"
+
+            Agentless.new(
+              api_key: settings.api_key,
+              citestcycle_url: citestcycle_url,
+              api_url: api_url,
+              citestcov_url: citestcov_url
+            )
           end
 
           def self.build_evp_proxy_api(settings)

--- a/lib/datadog/ci/transport/api/evp_proxy.rb
+++ b/lib/datadog/ci/transport/api/evp_proxy.rb
@@ -38,6 +38,14 @@ module Datadog
             perform_request(@agent_api_http, path: path, payload: payload, headers: headers, verb: verb)
           end
 
+          def citestcov_request(path:, payload:, headers: {}, verb: "post")
+            super(path: path, payload: payload, headers: headers, verb: verb)
+
+            headers[Ext::Transport::HEADER_EVP_SUBDOMAIN] = Ext::Transport::TEST_COVERAGE_INTAKE_HOST_PREFIX
+
+            perform_request(@agent_intake_http, path: path, payload: @citestcov_payload, headers: headers, verb: verb)
+          end
+
           private
 
           def perform_request(http_client, path:, payload:, headers:, verb:)

--- a/lib/datadog/ci/transport/event_platform_transport.rb
+++ b/lib/datadog/ci/transport/event_platform_transport.rb
@@ -42,6 +42,8 @@ module Datadog
 
             responses << response
           end
+
+          responses
         end
 
         private

--- a/lib/datadog/ci/transport/event_platform_transport.rb
+++ b/lib/datadog/ci/transport/event_platform_transport.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "msgpack"
+
+require "datadog/core/encoding"
+require "datadog/core/chunker"
+
+module Datadog
+  module CI
+    module Transport
+      class EventPlatformTransport
+        DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
+
+        attr_reader :api,
+          :max_payload_size
+
+        def initialize(api:, max_payload_size: DEFAULT_MAX_PAYLOAD_SIZE)
+          @api = api
+          @max_payload_size = max_payload_size
+        end
+
+        def send_events(events)
+          return [] if events.nil? || events.empty?
+
+          Datadog.logger.debug { "[#{self.class.name}] Sending #{events.count} events..." }
+
+          encoded_events = encode_events(events)
+          if encoded_events.empty?
+            Datadog.logger.debug { "[#{self.class.name}] Empty encoded events list, skipping send" }
+            return []
+          end
+
+          responses = []
+
+          Datadog::Core::Chunker.chunk_by_size(encoded_events, max_payload_size).map do |chunk|
+            encoded_payload = pack_events(chunk)
+            Datadog.logger.debug do
+              "[#{self.class.name}] Send chunk of #{chunk.count} events; payload size #{encoded_payload.size}"
+            end
+
+            response = send_payload(encoded_payload)
+
+            responses << response
+          end
+        end
+
+        private
+
+        def encoder
+          Datadog::Core::Encoding::MsgpackEncoder
+        end
+
+        def pack_events(encoded_events)
+          packer = MessagePack::Packer.new
+
+          write_payload_header(packer)
+
+          packer.write_array_header(encoded_events.count)
+          (packer.buffer.to_a + encoded_events).join
+        end
+
+        def event_too_large?(event, encoded_event)
+          return false unless encoded_event.size > max_payload_size
+
+          # This single event is too large, we can't flush it
+          Datadog.logger.warn("[#{self.class.name}] Dropping coverage event. Payload too large: '#{event.inspect}'")
+          Datadog.logger.warn(encoded_event)
+
+          true
+        end
+
+        def send_payload(encoded_payload)
+          raise NotImplementedError
+        end
+
+        def encode_events(events)
+          raise NotImplementedError
+        end
+
+        def write_payload_header(packer)
+          raise NotImplementedError
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -67,7 +67,8 @@ module Datadog
         end
 
         def adapter
-          @adapter ||= Datadog::Core::Transport::HTTP::Adapters::Net.new(host, port, timeout: timeout, ssl: ssl)
+          settings = AdapterSettings.new(hostname: host, port: port, ssl: ssl, timeout_seconds: timeout)
+          @adapter ||= Datadog::Core::Transport::HTTP::Adapters::Net.new(settings)
         end
 
         # this is needed because Datadog::Tracing::Writer is not fully compatiple with Datadog::Core::Transport
@@ -75,6 +76,22 @@ module Datadog
         class ResponseDecorator < ::SimpleDelegator
           def trace_count
             0
+          end
+        end
+
+        class AdapterSettings
+          attr_reader :hostname, :port, :ssl, :timeout_seconds
+
+          def initialize(hostname:, port: nil, ssl: true, timeout_seconds: nil)
+            @hostname = hostname
+            @port = port
+            @ssl = ssl
+            @timeout_seconds = timeout_seconds
+          end
+
+          def ==(other)
+            hostname == other.hostname && port == other.port && ssl == other.ssl &&
+              timeout_seconds == other.timeout_seconds
           end
         end
       end

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -26,6 +26,10 @@ module Datadog
 
         TEST_VISIBILITY_INTAKE_PATH: "/api/v2/citestcycle"
 
+        TEST_COVERAGE_INTAKE_HOST_PREFIX: "citestcov-intake"
+
+        TEST_COVERAGE_INTAKE_PATH: "/api/v2/citestcov"
+
         DD_API_HOST_PREFIX: "api"
 
         DD_API_SETTINGS_PATH: "/api/v2/ci/libraries/tests/services/setting"
@@ -47,6 +51,8 @@ module Datadog
         CONTENT_TYPE_MESSAGEPACK: "application/msgpack"
 
         CONTENT_TYPE_JSON: "application/json"
+
+        CONTENT_TYPE_MULTIPART_FORM_DATA: "multipart/form-data"
 
         CONTENT_ENCODING_GZIP: "gzip"
       end

--- a/sig/datadog/ci/itr/coverage/event.rbs
+++ b/sig/datadog/ci/itr/coverage/event.rbs
@@ -1,0 +1,27 @@
+module Datadog
+  module CI
+    module ITR
+      module Coverage
+        class Event
+          @test_id: String
+
+          @test_module_id: String
+
+          @test_session_id: String
+
+          @coverage: Hash[String, untyped]
+
+          attr_reader test_id: String
+
+          attr_reader test_module_id: String
+
+          attr_reader test_session_id: String
+
+          attr_reader coverage: Hash[String, untyped]
+
+          def initialize: (test_id: String, test_module_id: String, test_session_id: String, coverage: Hash[String, untyped]) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/itr/coverage/event.rbs
+++ b/sig/datadog/ci/itr/coverage/event.rbs
@@ -7,7 +7,7 @@ module Datadog
 
           @test_module_id: String
 
-          @test_session_id: String
+          @test_suite_id: String
 
           @coverage: Hash[String, untyped]
 
@@ -15,7 +15,7 @@ module Datadog
 
           attr_reader test_module_id: String
 
-          attr_reader test_session_id: String
+          attr_reader test_suite_id: String
 
           attr_reader coverage: Hash[String, untyped]
 

--- a/sig/datadog/ci/itr/coverage/event.rbs
+++ b/sig/datadog/ci/itr/coverage/event.rbs
@@ -5,7 +5,7 @@ module Datadog
         class Event
           @test_id: String
 
-          @test_module_id: String
+          @test_session_id: String
 
           @test_suite_id: String
 
@@ -13,13 +13,13 @@ module Datadog
 
           attr_reader test_id: String
 
-          attr_reader test_module_id: String
+          attr_reader test_session_id: String
 
           attr_reader test_suite_id: String
 
           attr_reader coverage: Hash[String, untyped]
 
-          def initialize: (test_id: String, test_module_id: String, test_session_id: String, coverage: Hash[String, untyped]) -> void
+          def initialize: (test_id: String, test_suite_id: String, test_session_id: String, coverage: Hash[String, untyped]) -> void
         end
       end
     end

--- a/sig/datadog/ci/itr/coverage/event.rbs
+++ b/sig/datadog/ci/itr/coverage/event.rbs
@@ -20,6 +20,10 @@ module Datadog
           attr_reader coverage: Hash[String, untyped]
 
           def initialize: (test_id: String, test_suite_id: String, test_session_id: String, coverage: Hash[String, untyped]) -> void
+
+          def valid?: () -> bool
+
+          def to_msgpack: (?untyped? packer) -> untyped
         end
       end
     end

--- a/sig/datadog/ci/itr/coverage/transport.rbs
+++ b/sig/datadog/ci/itr/coverage/transport.rbs
@@ -3,7 +3,7 @@ module Datadog
     module ITR
       module Coverage
         class Transport
-          DEFAULT_MAX_PAYLOAD_SIZE: untyped
+          DEFAULT_MAX_PAYLOAD_SIZE: Integer
 
           attr_reader api: Datadog::CI::Transport::Api::Base
           attr_reader max_payload_size: Integer
@@ -24,6 +24,8 @@ module Datadog
           def pack_events: (Array[String] encoded_events) -> String
 
           def encoder: () -> singleton(Datadog::Core::Encoding::MsgpackEncoder)
+
+          def event_too_large?: (Datadog::CI::ITR::Coverage::Event event, String encoded_event) -> bool
         end
       end
     end

--- a/sig/datadog/ci/itr/coverage/transport.rbs
+++ b/sig/datadog/ci/itr/coverage/transport.rbs
@@ -13,7 +13,17 @@ module Datadog
 
           def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Integer) -> void
 
-          def send_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> nil
+          def send_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> ::Array[Datadog::CI::Transport::HTTP::ResponseDecorator]
+
+          private
+
+          def send_payload: (String payload) -> ::Datadog::CI::Transport::HTTP::ResponseDecorator
+
+          def encode_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> ::Array[String]
+
+          def pack_events: (Array[String] encoded_events) -> String
+
+          def encoder: () -> singleton(Datadog::Core::Encoding::MsgpackEncoder)
         end
       end
     end

--- a/sig/datadog/ci/itr/coverage/transport.rbs
+++ b/sig/datadog/ci/itr/coverage/transport.rbs
@@ -1,0 +1,21 @@
+module Datadog
+  module CI
+    module ITR
+      module Coverage
+        class Transport
+          DEFAULT_MAX_PAYLOAD_SIZE: untyped
+
+          attr_reader api: Datadog::CI::Transport::Api::Base
+          attr_reader max_payload_size: Integer
+
+          @api: Datadog::CI::Transport::Api::Base
+          @max_payload_size: Integer
+
+          def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Integer) -> void
+
+          def send_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> nil
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/itr/coverage/transport.rbs
+++ b/sig/datadog/ci/itr/coverage/transport.rbs
@@ -2,19 +2,7 @@ module Datadog
   module CI
     module ITR
       module Coverage
-        class Transport
-          DEFAULT_MAX_PAYLOAD_SIZE: Integer
-
-          attr_reader api: Datadog::CI::Transport::Api::Base
-          attr_reader max_payload_size: Integer
-
-          @api: Datadog::CI::Transport::Api::Base
-          @max_payload_size: Integer
-
-          def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Integer) -> void
-
-          def send_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> ::Array[Datadog::CI::Transport::HTTP::ResponseDecorator]
-
+        class Transport < Datadog::CI::Transport::EventPlatformTransport
           private
 
           def send_payload: (String payload) -> ::Datadog::CI::Transport::HTTP::ResponseDecorator
@@ -22,8 +10,6 @@ module Datadog
           def encode_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> ::Array[String]
 
           def pack_events: (Array[String] encoded_events) -> String
-
-          def encoder: () -> singleton(Datadog::Core::Encoding::MsgpackEncoder)
 
           def event_too_large?: (Datadog::CI::ITR::Coverage::Event event, String encoded_event) -> bool
         end

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -18,7 +18,7 @@ module Datadog
 
         def start_coverage: () -> void
 
-        def stop_coverage: () -> Hash[String, untyped]?
+        def stop_coverage: (Datadog::CI::Test test) -> Hash[String, untyped]?
 
         private
 

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -22,7 +22,7 @@ module Datadog
 
         private
 
-        def coverage_collector: () -> Datadog::CI::Cov?
+        def coverage_collector: () -> Datadog::CI::ITR::Coverage::DDCov?
 
         def convert_to_bool: (untyped value) -> bool
 

--- a/sig/datadog/ci/test_visibility/transport.rbs
+++ b/sig/datadog/ci/test_visibility/transport.rbs
@@ -1,17 +1,12 @@
 module Datadog
   module CI
     module TestVisibility
-      class Transport
-        DEFAULT_MAX_PAYLOAD_SIZE: Integer
-
+      class Transport < Datadog::CI::Transport::EventPlatformTransport
         attr_reader serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
         attr_reader dd_env: String?
-        attr_reader api: Datadog::CI::Transport::Api::Base
-        attr_reader max_payload_size: Integer
 
         @dd_env: String?
         @serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
-        @max_payload_size: Integer
 
         def initialize: (
           api: Datadog::CI::Transport::Api::Base,
@@ -20,15 +15,11 @@ module Datadog
           ?max_payload_size: Integer
         ) -> void
 
-        def send_traces: (Array[Datadog::Tracing::TraceSegment] traces) -> ::Array[Datadog::CI::Transport::HTTP::ResponseDecorator]
-
         private
 
         def send_payload: (String encoded_payload) -> Datadog::CI::Transport::HTTP::ResponseDecorator
-        def pack_events: (Array[String] encoded_events) -> String
-        def encode_traces: (Array[Datadog::Tracing::TraceSegment] traces) -> ::Array[String]
+        def encode_events: (Array[Datadog::Tracing::TraceSegment] traces) -> ::Array[String]
         def encode_span: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> String?
-        def encoder: () -> singleton(Datadog::Core::Encoding::MsgpackEncoder)
       end
     end
   end

--- a/sig/datadog/ci/transport/api/agentless.rbs
+++ b/sig/datadog/ci/transport/api/agentless.rbs
@@ -8,10 +8,17 @@ module Datadog
           @api_key: String
           @citestcycle_http: Datadog::CI::Transport::HTTP
           @api_http: Datadog::CI::Transport::HTTP
+          @citestcov_http: Datadog::CI::Transport::HTTP
 
-          def initialize: (api_key: String, citestcycle_url: String, api_url: String) -> void
+          def initialize: (api_key: String, citestcycle_url: String, api_url: String, citestcov_url: String) -> void
 
           def request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
+
+          def citestcycle_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
+
+          def api_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
+
+          def citestcov_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
 
           private
 

--- a/sig/datadog/ci/transport/api/base.rbs
+++ b/sig/datadog/ci/transport/api/base.rbs
@@ -3,9 +3,13 @@ module Datadog
     module Transport
       module Api
         class Base
+          @citestcov_payload: String
+
           def api_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> untyped
 
           def citestcycle_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> untyped
+
+          def citestcov_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> untyped
 
           private
 

--- a/sig/datadog/ci/transport/api/evp_proxy.rbs
+++ b/sig/datadog/ci/transport/api/evp_proxy.rbs
@@ -16,6 +16,8 @@ module Datadog
 
           def api_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
 
+          def citestcov_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> untyped
+
           private
 
           def perform_request: (Datadog::CI::Transport::HTTP client, path: String, payload: String, headers: Hash[String, String], verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator

--- a/sig/datadog/ci/transport/event_platform_transport.rbs
+++ b/sig/datadog/ci/transport/event_platform_transport.rbs
@@ -1,0 +1,33 @@
+module Datadog
+  module CI
+    module Transport
+      class EventPlatformTransport
+        DEFAULT_MAX_PAYLOAD_SIZE: Integer
+
+        attr_reader api: Datadog::CI::Transport::Api::Base
+        attr_reader max_payload_size: Integer
+
+        @api: Datadog::CI::Transport::Api::Base
+        @max_payload_size: Integer
+
+        def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Integer) -> void
+
+        def send_events: (Array[untyped] events) -> ::Array[Datadog::CI::Transport::HTTP::ResponseDecorator]
+
+        private
+
+        def send_payload: (String payload) -> ::Datadog::CI::Transport::HTTP::ResponseDecorator
+
+        def encoder: () -> singleton(Datadog::Core::Encoding::MsgpackEncoder)
+
+        def encode_events: (Array[untyped] events) -> ::Array[String]
+
+        def write_payload_header: (untyped packer) -> void
+
+        def pack_events: (Array[String] encoded_events) -> String
+
+        def event_too_large?: (untyped event, String encoded_event) -> bool
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/transport/http.rbs
+++ b/sig/datadog/ci/transport/http.rbs
@@ -25,6 +25,20 @@ module Datadog
 
         def build_env: (payload: String, headers: Hash[String, String], path: String, verb: String) -> Datadog::Core::Transport::HTTP::Env
 
+        class AdapterSettings
+          attr_reader hostname: String
+          attr_reader port: Integer?
+          attr_reader ssl: bool
+          attr_reader timeout_seconds: Integer
+
+          @hostname: String
+          @port: Integer?
+          @ssl: bool
+          @timeout_seconds: Integer
+
+          def initialize: (hostname: String, ?port: Integer?, ?ssl: bool, ?timeout_seconds: Integer) -> void
+        end
+
         class ResponseDecorator < ::SimpleDelegator
           def initialize: (untyped anything) -> void
           def trace_count: () -> Integer

--- a/spec/datadog/ci/itr/coverage/event_spec.rb
+++ b/spec/datadog/ci/itr/coverage/event_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require_relative "../../../../../lib/datadog/ci/itr/coverage/event"
+
+RSpec.describe Datadog::CI::ITR::Coverage::Event do
+  subject do
+    described_class.new(
+      test_id: test_id,
+      test_suite_id: test_suite_id,
+      test_session_id: test_session_id,
+      coverage: coverage
+    )
+  end
+  let(:test_id) { "1" }
+  let(:test_suite_id) { "2" }
+  let(:test_session_id) { "3" }
+  let(:coverage) { {"file.rb" => true} }
+
+  describe "#valid?" do
+    it { is_expected.to be_valid }
+
+    context "when test_id is nil" do
+      let(:test_id) { nil }
+      before do
+        expect(Datadog.logger).to receive(:warn).with(/citestcov event is invalid: \[test_id\] is nil. Event: .*/)
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when test_suite_id is nil" do
+      let(:test_suite_id) { nil }
+      before do
+        expect(Datadog.logger).to receive(:warn).with(/citestcov event is invalid: \[test_suite_id\] is nil. Event: .*/)
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when test_session_id is nil" do
+      let(:test_session_id) { nil }
+      before do
+        expect(Datadog.logger).to receive(:warn).with(/citestcov event is invalid: \[test_session_id\] is nil. Event: .*/)
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when coverage is nil" do
+      let(:coverage) { nil }
+      before do
+        expect(Datadog.logger).to receive(:warn).with(/citestcov event is invalid: \[coverage\] is nil. Event: .*/)
+      end
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe "#to_msgpack" do
+    include_context "msgpack serializer" do
+      subject do
+        described_class.new(
+          test_id: test_id,
+          test_suite_id: test_suite_id,
+          test_session_id: test_session_id,
+          coverage: coverage
+        )
+      end
+    end
+
+    it "returns a msgpack representation of the event" do
+      expect(msgpack_json).to eq(
+        {
+          "test_session_id" => 3,
+          "test_suite_id" => 2,
+          "span_id" => 1,
+          "files" => [
+            {"filename" => "file.rb"}
+          ]
+        }
+      )
+    end
+
+    context "coverage in lines format" do
+      let(:coverage) { {"file.rb" => {1 => true, 2 => true, 3 => true}} }
+
+      it "returns a msgpack representation of the event" do
+        expect(msgpack_json).to eq(
+          {
+            "test_session_id" => 3,
+            "test_suite_id" => 2,
+            "span_id" => 1,
+            "files" => [
+              {"filename" => "file.rb"}
+            ]
+          }
+        )
+      end
+    end
+
+    context "multiple files" do
+      let(:coverage) { {"file.rb" => true, "file2.rb" => true} }
+
+      it "returns a msgpack representation of the event" do
+        expect(msgpack_json).to eq(
+          {
+            "test_session_id" => 3,
+            "test_suite_id" => 2,
+            "span_id" => 1,
+            "files" => [
+              {"filename" => "file.rb"},
+              {"filename" => "file2.rb"}
+            ]
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/itr/coverage/event_spec.rb
+++ b/spec/datadog/ci/itr/coverage/event_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Datadog::CI::ITR::Coverage::Event do
     context "coverage in lines format" do
       let(:coverage) { {"file.rb" => {1 => true, 2 => true, 3 => true}} }
 
-      it "returns a msgpack representation of the event" do
+      it "returns a msgpack representation of the event without lines information" do
         expect(msgpack_json).to eq(
           {
             "test_session_id" => 3,

--- a/spec/datadog/ci/itr/coverage/transport_spec.rb
+++ b/spec/datadog/ci/itr/coverage/transport_spec.rb
@@ -1,0 +1,160 @@
+require_relative "../../../../../lib/datadog/ci/itr/coverage/transport"
+
+RSpec.describe Datadog::CI::ITR::Coverage::Transport do
+  subject do
+    described_class.new(
+      api: api,
+      max_payload_size: max_payload_size
+    )
+  end
+
+  before do
+    allow(Datadog.logger).to receive(:warn)
+  end
+
+  let(:max_payload_size) { 5 * 1024 * 1024 }
+  let(:api) { spy(:api) }
+
+  let(:event) do
+    Datadog::CI::ITR::Coverage::Event.new(
+      test_id: "1",
+      test_suite_id: "2",
+      test_session_id: "3",
+      coverage: {"file.rb" => true}
+    )
+  end
+
+  describe "#send_events" do
+    context "with a single event" do
+      it "sends correct payload" do
+        subject.send_events([event])
+
+        expect(api).to have_received(:citestcov_request) do |args|
+          expect(args[:path]).to eq("/api/v2/citestcov")
+
+          payload = MessagePack.unpack(args[:payload])
+          expect(payload["version"]).to eq(2)
+
+          events = payload["coverages"]
+          expect(events.count).to eq(1)
+          expect(events.first["span_id"]).to eq(event.test_id.to_i)
+          expect(events.first["test_suite_id"]).to eq(event.test_suite_id.to_i)
+          expect(events.first["test_session_id"]).to eq(event.test_session_id.to_i)
+          expect(events.first["files"]).to eq([{"filename" => "file.rb"}])
+        end
+      end
+    end
+
+    context "multiple events" do
+      let(:events) do
+        [
+          event,
+          Datadog::CI::ITR::Coverage::Event.new(
+            test_id: "4",
+            test_suite_id: "5",
+            test_session_id: "6",
+            coverage: {"file.rb" => true, "file2.rb" => true}
+          )
+        ]
+      end
+      it "sends all events" do
+        subject.send_events(events)
+
+        expect(api).to have_received(:citestcov_request) do |args|
+          payload = MessagePack.unpack(args[:payload])
+          payload_events = payload["coverages"]
+          expect(payload_events.count).to eq(events.count)
+          expect(payload_events.map { |e| e["span_id"] }).to eq(events.map(&:test_id).map(&:to_i))
+          expect(payload_events.map { |e| e["files"] }).to eq(
+            [
+              [{"filename" => "file.rb"}],
+              [{"filename" => "file.rb"}, {"filename" => "file2.rb"}]
+            ]
+          )
+        end
+      end
+
+      context "when some events are invalid" do
+        let(:events) do
+          [
+            event,
+            Datadog::CI::ITR::Coverage::Event.new(
+              test_id: "4",
+              test_suite_id: nil,
+              test_session_id: "6",
+              coverage: {"file.rb" => true, "file2.rb" => true}
+            )
+          ]
+        end
+
+        it "filters out invalid events" do
+          subject.send_events(events)
+
+          expect(api).to have_received(:citestcov_request) do |args|
+            payload = MessagePack.unpack(args[:payload])
+
+            events = payload["coverages"]
+            expect(events.count).to eq(1)
+          end
+        end
+
+        it "logs warning that events were filtered out" do
+          subject.send_events(events)
+
+          expect(Datadog.logger).to have_received(:warn).with(
+            "citestcov event is invalid: [test_suite_id] is nil. " \
+            "Event: Coverage::Event[test_id=4, test_suite_id=, test_session_id=6, " \
+            "coverage={\"file.rb\"=>true, \"file2.rb\"=>true}]"
+          )
+        end
+      end
+
+      context "when chunking is used" do
+        # one coverage event is approximately 75 bytes
+        let(:max_payload_size) { 100 }
+
+        it "filters out invalid events" do
+          responses = subject.send_events(events)
+
+          expect(api).to have_received(:citestcov_request).twice
+          expect(responses.count).to eq(2)
+        end
+      end
+
+      context "when max_payload-size is too small" do
+        let(:max_payload_size) { 1 }
+
+        it "does not send events that are larger than max size" do
+          subject.send_events(events)
+
+          expect(api).not_to have_received(:citestcov_request)
+        end
+      end
+    end
+
+    context "when all events are invalid" do
+      let(:events) do
+        [
+          Datadog::CI::ITR::Coverage::Event.new(
+            test_id: "4",
+            test_suite_id: "5",
+            test_session_id: nil,
+            coverage: {"file.rb" => true, "file2.rb" => true}
+          ),
+          Datadog::CI::ITR::Coverage::Event.new(
+            test_id: "8",
+            test_suite_id: nil,
+            test_session_id: "6",
+            coverage: {"file.rb" => true, "file2.rb" => true}
+          )
+        ]
+      end
+
+      it "does not send anything" do
+        subject.send_events(events)
+
+        expect(api).not_to have_received(:citestcov_request)
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/itr/runner_spec.rb
+++ b/spec/datadog/ci/itr/runner_spec.rb
@@ -64,9 +64,13 @@ RSpec.describe Datadog::CI::ITR::Runner do
   end
 
   describe "#start_coverage" do
+    let(:test_tracer_span) { Datadog::Tracing::SpanOperation.new("test") }
+    let(:test_span) { Datadog::CI::Test.new(tracer_span) }
+
     before do
       runner.configure(remote_configuration, test_session)
     end
+
     context "when code coverage is disabled" do
       let(:remote_configuration) { {"itr_enabled" => true, "code_coverage" => false, "tests_skipping" => false} }
 
@@ -74,7 +78,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
         expect(runner).not_to receive(:coverage_collector)
 
         runner.start_coverage
-        expect(runner.stop_coverage).to be_nil
+        expect(runner.stop_coverage(test_span)).to be_nil
       end
     end
 
@@ -85,7 +89,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
         expect(runner).not_to receive(:coverage_collector)
 
         runner.start_coverage
-        expect(runner.stop_coverage).to be_nil
+        expect(runner.stop_coverage(test_span)).to be_nil
       end
     end
 
@@ -101,7 +105,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
 
         runner.start_coverage
         expect(1 + 1).to eq(2)
-        coverage = runner.stop_coverage
+        coverage = runner.stop_coverage(test_span)
         expect(coverage.size).to be > 0
       end
     end
@@ -118,7 +122,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
         expect(runner.code_coverage?).to be(false)
 
         runner.start_coverage
-        expect(runner.stop_coverage).to be_nil
+        expect(runner.stop_coverage(test_span)).to be_nil
       end
     end
   end

--- a/spec/datadog/ci/test_visibility/serializers/span_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/span_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::Span do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(first_custom_span), first_custom_span) }
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(test_module_span), test_module_span) }
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(test_session_span), test_session_span) }
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSuite do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(first_test_suite_span), first_test_suite_span) }
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(span), span) }
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
     let(:integration_name) { :rspec }
   end
 
-  include_context "citestcycle serializer" do
+  include_context "msgpack serializer" do
     subject { described_class.new(trace_for_span(first_test_span), first_test_span) }
   end
 

--- a/spec/datadog/ci/transport/api/agentless_spec.rb
+++ b/spec/datadog/ci/transport/api/agentless_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
     described_class.new(
       api_key: api_key,
       citestcycle_url: citestcycle_url,
+      citestcov_url: citestcov_url,
       api_url: api_url
     )
   end
@@ -14,6 +15,7 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
   context "malformed urls" do
     let(:citestcycle_url) { "" }
     let(:api_url) { "api.datadoghq.com" }
+    let(:citestcov_url) { "citestcov.datadoghq.com" }
 
     it { expect { subject }.to raise_error(/Invalid agentless mode URL:/) }
   end
@@ -24,6 +26,9 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
 
     let(:api_url) { "http://localhost:5555" }
     let(:api_http) { double(:http) }
+
+    let(:citestcov_url) { "http://localhost:5555" }
+    let(:citestcov_http) { double(:http) }
 
     before do
       expect(Datadog::CI::Transport::HTTP).to receive(:new).with(
@@ -39,6 +44,13 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
         ssl: false,
         compress: false
       ).and_return(api_http)
+
+      expect(Datadog::CI::Transport::HTTP).to receive(:new).with(
+        host: "localhost",
+        port: 5555,
+        ssl: false,
+        compress: true
+      ).and_return(citestcov_http)
     end
 
     describe "#citestcycle_request" do
@@ -69,6 +81,9 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
     let(:api_url) { "https://api.datadoghq.com:443" }
     let(:api_http) { double(:http) }
 
+    let(:citestcov_url) { "https://citestcov-intake.datadoghq.com:443" }
+    let(:citestcov_http) { double(:http) }
+
     before do
       expect(Datadog::CI::Transport::HTTP).to receive(:new).with(
         host: "citestcycle-intake.datadoghq.com",
@@ -83,6 +98,13 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
         ssl: true,
         compress: false
       ).and_return(api_http)
+
+      expect(Datadog::CI::Transport::HTTP).to receive(:new).with(
+        host: "citestcov-intake.datadoghq.com",
+        port: 443,
+        ssl: true,
+        compress: true
+      ).and_return(citestcov_http)
     end
 
     describe "#citestcycle_request" do

--- a/spec/datadog/ci/transport/api/builder_spec.rb
+++ b/spec/datadog/ci/transport/api/builder_spec.rb
@@ -37,7 +37,10 @@ RSpec.describe Datadog::CI::Transport::Api::Builder do
 
     it "creates and configures http client and Agentless api" do
       expect(Datadog::CI::Transport::Api::Agentless).to receive(:new).with(
-        api_key: "api_key", citestcycle_url: "https://citestcycle-intake.datadoghq.com:443", api_url: "https://api.datadoghq.com:443"
+        api_key: "api_key",
+        citestcycle_url: "https://citestcycle-intake.datadoghq.com:443",
+        api_url: "https://api.datadoghq.com:443",
+        citestcov_url: "https://citestcov-intake.datadoghq.com:443"
       ).and_return(api)
 
       expect(subject).to eq(api)
@@ -48,7 +51,10 @@ RSpec.describe Datadog::CI::Transport::Api::Builder do
 
       it "configures transport to use intake URL from settings" do
         expect(Datadog::CI::Transport::Api::Agentless).to receive(:new).with(
-          api_key: "api_key", citestcycle_url: "http://localhost:5555", api_url: "http://localhost:5555"
+          api_key: "api_key",
+          citestcycle_url: "http://localhost:5555",
+          api_url: "http://localhost:5555",
+          citestcov_url: "http://localhost:5555"
         ).and_return(api)
 
         expect(subject).to eq(api)
@@ -60,7 +66,10 @@ RSpec.describe Datadog::CI::Transport::Api::Builder do
 
       it "construct intake url using provided host" do
         expect(Datadog::CI::Transport::Api::Agentless).to receive(:new).with(
-          api_key: "api_key", citestcycle_url: "https://citestcycle-intake.datadoghq.eu:443", api_url: "https://api.datadoghq.eu:443"
+          api_key: "api_key",
+          citestcycle_url: "https://citestcycle-intake.datadoghq.eu:443",
+          api_url: "https://api.datadoghq.eu:443",
+          citestcov_url: "https://citestcov-intake.datadoghq.eu:443"
         ).and_return(api)
 
         expect(subject).to eq(api)

--- a/spec/datadog/ci/transport/http_spec.rb
+++ b/spec/datadog/ci/transport/http_spec.rb
@@ -13,13 +13,14 @@ RSpec.describe Datadog::CI::Transport::HTTP do
     let(:adapter) { instance_double(::Datadog::Core::Transport::HTTP::Adapters::Net) }
 
     before do
+      settings = Datadog::CI::Transport::HTTP::AdapterSettings.new(
+        hostname: transport.host,
+        port: transport.port,
+        timeout_seconds: transport.timeout,
+        ssl: transport.ssl
+      )
       allow(::Datadog::Core::Transport::HTTP::Adapters::Net).to receive(:new)
-        .with(
-          transport.host,
-          transport.port,
-          timeout: transport.timeout,
-          ssl: transport.ssl
-        ).and_return(adapter)
+        .with(settings).and_return(adapter)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ require_relative "support/contexts/ci_mode"
 require_relative "support/contexts/concurrency_test"
 require_relative "support/contexts/git_fixture"
 require_relative "support/contexts/extract_environment_tags"
-require_relative "support/contexts/citestcycle_serializer"
+require_relative "support/contexts/msgpack_serializer"
 
 require "rspec/collection_matchers"
 require "climate_control"

--- a/spec/support/contexts/msgpack_serializer.rb
+++ b/spec/support/contexts/msgpack_serializer.rb
@@ -1,7 +1,7 @@
-# "citestcycle serializer" shared context uses serializer defined in `subject`
+# "msgpack serializer" shared context uses serializer defined in `subject`
 # to serialize the data and then unpacks it to JSON.
 
-RSpec.shared_context "citestcycle serializer" do
+RSpec.shared_context "msgpack serializer" do
   subject {}
 
   let(:msgpack_jsons) do

--- a/vendor/rbs/ddtrace/0/datadog/core/transport/http/adapters/net.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/core/transport/http/adapters/net.rbs
@@ -14,7 +14,7 @@ module Datadog
 
             DEFAULT_TIMEOUT: 30
 
-            def initialize: (?untyped? hostname, ?untyped? port, **untyped options) -> void
+            def initialize: (untyped agent_settings) -> void
 
             def self.build: (untyped agent_settings) -> untyped
 


### PR DESCRIPTION
**What does this PR do?**
- Adds citestcov_request method to Transport::Api::Base to send events to citestcov intake as multipart/form-data (via agent or agentless intake)
- Adds Coverage::Event class that serializes itself to msgpack
- Adds Coverage::Transport class that packages msgpack payload and sends it to the intake
- Deduplicated code in Coverage::Transport and TestVisibility::Transport by introducing common ancestor EventPlatformTransport
- Fixed regression caused by a breaking change in `datadog` gem v2.0 with `Datadog::Core::Transport::HTTP::Adapters::Net` initialization

**How to test the change?**
Unit tests are provided