### PR TITLE
[CIVIS-2938] Add Git::SearchCommits api client

### DIFF
--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -27,6 +27,7 @@ module Datadog
         TEST_COVERAGE_INTAKE_PATH = "/api/v2/citestcov"
 
         DD_API_HOST_PREFIX = "api"
+
         DD_API_SETTINGS_PATH = "/api/v2/libraries/tests/services/setting"
         DD_API_SETTINGS_TYPE = "ci_app_test_service_libraries_settings"
         DD_API_SETTINGS_RESPONSE_DIG_KEYS = %w[data attributes].freeze
@@ -35,6 +36,8 @@ module Datadog
         DD_API_SETTINGS_RESPONSE_TESTS_SKIPPING_KEY = "tests_skipping"
         DD_API_SETTINGS_RESPONSE_REQUIRE_GIT_KEY = "require_git"
         DD_API_SETTINGS_RESPONSE_DEFAULT = {DD_API_SETTINGS_RESPONSE_ITR_ENABLED_KEY => false}.freeze
+
+        DD_API_GIT_SEARCH_COMMITS_PATH = "/api/v2/git/repository/search_commits"
 
         CONTENT_TYPE_MESSAGEPACK = "application/msgpack"
         CONTENT_TYPE_JSON = "application/json"

--- a/lib/datadog/ci/git/search_commits.rb
+++ b/lib/datadog/ci/git/search_commits.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "json"
+require "set"
+
+require_relative "../ext/transport"
+require_relative "../utils/git"
+
+module Datadog
+  module CI
+    module Git
+      class SearchCommits
+        class ApiError < StandardError; end
+
+        attr_reader :api
+
+        def initialize(api:)
+          @api = api
+        end
+
+        def call(repository_url, commits)
+          raise ApiError, "test visibility API is not configured" if api.nil?
+
+          http_response = api.api_request(
+            path: Ext::Transport::DD_API_GIT_SEARCH_COMMITS_PATH,
+            payload: request_payload(repository_url, commits)
+          )
+          raise ApiError, "Failed to search commits: #{http_response.body}" unless http_response.ok?
+
+          response_payload = parse_json_response(http_response)
+          extract_commits(response_payload)
+        end
+
+        private
+
+        def request_payload(repository_url, commits)
+          {
+            meta: {
+              repository_url: repository_url
+            },
+            data: commits.filter_map do |commit|
+              next unless Utils::Git.valid_commit_sha?(commit)
+
+              {
+                id: commit,
+                type: "commit"
+              }
+            end
+          }.to_json
+        end
+
+        def parse_json_response(http_response)
+          JSON.parse(http_response.payload)
+        rescue JSON::ParserError => e
+          raise ApiError, "Failed to parse search commits response: #{e}. Payload was: #{http_response.payload}"
+        end
+
+        def extract_commits(response_payload)
+          result = Set.new
+
+          response_payload.fetch("data").each do |commit_json|
+            raise ApiError, "Invalid commit type response #{commit_json}" unless commit_json["type"] == "commit"
+
+            commit_sha = commit_json["id"]
+            raise ApiError, "Invalid commit SHA response #{commit_sha}" unless Utils::Git.valid_commit_sha?(commit_sha)
+
+            result.add(commit_sha)
+          end
+
+          result
+        rescue KeyError => e
+          raise ApiError, "Malformed search commits response: #{e}. Payload was: #{response_payload}"
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/utils/git.rb
+++ b/lib/datadog/ci/utils/git.rb
@@ -7,6 +7,12 @@ module Datadog
   module CI
     module Utils
       module Git
+        def self.valid_commit_sha?(sha)
+          return false if sha.nil?
+
+          sha.match?(/\A[0-9a-f]{40}\Z/) || sha.match?(/\A[0-9a-f]{64}\Z/)
+        end
+
         def self.normalize_ref(ref)
           return nil if ref.nil?
 

--- a/sig/datadog/ci/ext/environment.rbs
+++ b/sig/datadog/ci/ext/environment.rbs
@@ -27,8 +27,6 @@ module Datadog
 
         TAG_CI_ENV_VARS: String
 
-        HEX_NUMBER_REGEXP: Regexp
-
         PROVIDERS: ::Array[Array[String | Symbol]]
 
         def self?.tags: (untyped env) -> Hash[String, String]

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -32,7 +32,7 @@ module Datadog
 
         DD_API_HOST_PREFIX: "api"
 
-        DD_API_SETTINGS_PATH: "/api/v2/ci/libraries/tests/services/setting"
+        DD_API_SETTINGS_PATH: "/api/v2/libraries/tests/services/setting"
 
         DD_API_SETTINGS_TYPE: "ci_app_test_service_libraries_settings"
 
@@ -47,6 +47,8 @@ module Datadog
         DD_API_SETTINGS_RESPONSE_REQUIRE_GIT_KEY: "require_git"
 
         DD_API_SETTINGS_RESPONSE_DEFAULT: Hash[String, untyped]
+
+        DD_API_GIT_SEARCH_COMMITS_PATH: "/api/v2/git/repository/search_commits"
 
         CONTENT_TYPE_MESSAGEPACK: "application/msgpack"
 

--- a/sig/datadog/ci/git/search_commits.rbs
+++ b/sig/datadog/ci/git/search_commits.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module CI
+    module Git
+      class SearchCommits
+        @api: Datadog::CI::Transport::Api::Base?
+
+        attr_reader api: Datadog::CI::Transport::Api::Base?
+
+        class ApiError < StandardError
+        end
+
+        def initialize: (api: Datadog::CI::Transport::Api::Base?) -> void
+
+        def call: (String repository_url, Array[String] commits) -> Set[String]
+
+        private
+
+        def request_payload: (String repository_url, Array[String] commits) -> String
+
+        def parse_json_response: (Datadog::Core::Transport::Response response) -> Hash[String, untyped]
+
+        def extract_commits: (Hash[String, untyped] response) -> Set[String]
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/utils/git.rbs
+++ b/sig/datadog/ci/utils/git.rbs
@@ -2,6 +2,8 @@ module Datadog
   module CI
     module Utils
       module Git
+        def self.valid_commit_sha?: (String? sha) -> bool
+
         def self.normalize_ref: (String? name) -> String?
 
         def self.is_git_tag?: (String? ref) -> bool

--- a/spec/datadog/ci/git/search_commits_spec.rb
+++ b/spec/datadog/ci/git/search_commits_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/git/search_commits"
+
+RSpec.describe Datadog::CI::Git::SearchCommits do
+  let(:api) { double("api") }
+  subject(:search_commits) { described_class.new(api: api) }
+
+  describe "#call" do
+    let(:repository_url) { "https://datadoghq.com/git/test.git" }
+    let(:commits) { ["c7f893648f656339f62fb7b4d8a6ecdf7d063835"] }
+
+    context "when the API is not configured" do
+      let(:api) { nil }
+
+      it "raises an error" do
+        expect { search_commits.call(repository_url, commits) }
+          .to raise_error(Datadog::CI::Git::SearchCommits::ApiError, "test visibility API is not configured")
+      end
+    end
+
+    context "when the API is configured" do
+      before do
+        allow(api).to receive(:api_request).and_return(http_response)
+      end
+
+      context "when the API request fails" do
+        let(:http_response) { double("http_response", ok?: false, body: "error message") }
+
+        it "raises an error" do
+          expect { search_commits.call(repository_url, commits) }
+            .to raise_error(Datadog::CI::Git::SearchCommits::ApiError, "Failed to search commits: error message")
+        end
+      end
+
+      context "when the API request is successful" do
+        let(:http_response) { double("http_response", ok?: true, payload: response_payload) }
+        let(:response_payload) do
+          {
+            "data" => [
+              {
+                "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
+                "type" => "commit"
+              }
+            ]
+          }.to_json
+        end
+
+        it "returns the list of commit SHAs" do
+          expect(api).to receive(:api_request).with(
+            path: Datadog::CI::Ext::Transport::DD_API_GIT_SEARCH_COMMITS_PATH,
+            payload: "{\"meta\":{\"repository_url\":\"https://datadoghq.com/git/test.git\"},\"data\":[{\"id\":\"c7f893648f656339f62fb7b4d8a6ecdf7d063835\",\"type\":\"commit\"}]}"
+          ).and_return(http_response)
+
+          expect(search_commits.call(repository_url, commits)).to eq(Set.new(["c7f893648f656339f62fb7b4d8a6ecdf7d063835"]))
+        end
+
+        context "when the request contains an invalid commit SHA" do
+          let(:commits) { ["INVALID_SHA", "c7f893648f656339f62fb7b4d8a6ecdf7d063835"] }
+
+          it "does not include the invalid commit SHA in the request" do
+            expect(api).to receive(:api_request).with(
+              path: Datadog::CI::Ext::Transport::DD_API_GIT_SEARCH_COMMITS_PATH,
+              payload: "{\"meta\":{\"repository_url\":\"https://datadoghq.com/git/test.git\"},\"data\":[{\"id\":\"c7f893648f656339f62fb7b4d8a6ecdf7d063835\",\"type\":\"commit\"}]}"
+            ).and_return(http_response)
+
+            expect(search_commits.call(repository_url, commits)).to eq(Set.new(["c7f893648f656339f62fb7b4d8a6ecdf7d063835"]))
+          end
+        end
+
+        context "when the response contains an invalid commit type" do
+          let(:response_payload) do
+            {
+              "data" => [
+                {
+                  "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
+                  "type" => "invalid"
+                }
+              ]
+            }.to_json
+          end
+
+          it "raises an error" do
+            expect { search_commits.call(repository_url, commits) }
+              .to raise_error(
+                Datadog::CI::Git::SearchCommits::ApiError,
+                "Invalid commit type response {\"id\"=>\"c7f893648f656339f62fb7b4d8a6ecdf7d063835\", \"type\"=>\"invalid\"}"
+              )
+          end
+        end
+
+        context "when the response contains an invalid commit SHA" do
+          let(:response_payload) do
+            {
+              "data" => [
+                {
+                  "id" => "INVALID_SHA",
+                  "type" => "commit"
+                }
+              ]
+            }.to_json
+          end
+
+          it "raises an error" do
+            expect { search_commits.call(repository_url, commits) }
+              .to raise_error(Datadog::CI::Git::SearchCommits::ApiError, "Invalid commit SHA response INVALID_SHA")
+          end
+        end
+
+        context "when the response is not a valid JSON" do
+          let(:response_payload) { "invalid json" }
+
+          it "raises an error" do
+            expect { search_commits.call(repository_url, commits) }
+              .to raise_error(
+                Datadog::CI::Git::SearchCommits::ApiError,
+                "Failed to parse search commits response: unexpected token at 'invalid json'. Payload was: invalid json"
+              )
+          end
+        end
+
+        context "when the response is missing the data key" do
+          let(:response_payload) { {}.to_json }
+
+          it "raises an error" do
+            expect { search_commits.call(repository_url, commits) }
+              .to raise_error(
+                Datadog::CI::Git::SearchCommits::ApiError,
+                "Malformed search commits response: key not found: \"data\". Payload was: {}"
+              )
+          end
+        end
+
+        context "when the response is missing the commit type" do
+          let(:response_payload) do
+            {
+              "data" => [
+                {
+                  "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835"
+                }
+              ]
+            }.to_json
+          end
+
+          it "raises an error" do
+            expect { search_commits.call(repository_url, commits) }
+              .to raise_error(
+                Datadog::CI::Git::SearchCommits::ApiError,
+                "Invalid commit type response {\"id\"=>\"c7f893648f656339f62fb7b4d8a6ecdf7d063835\"}"
+              )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/utils/git_spec.rb
+++ b/spec/datadog/ci/utils/git_spec.rb
@@ -1,4 +1,44 @@
 RSpec.describe ::Datadog::CI::Utils::Git do
+  describe ".valid_commit_sha?" do
+    subject { described_class.valid_commit_sha?(sha) }
+
+    context "when input is nil" do
+      let(:sha) { nil }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when input is a valid sha" do
+      let(:sha) { "c7f893648f656339f62fb7b4d8a6ecdf7d063835" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when input is a valid sha256" do
+      let(:sha) { "1b9affbba072ba2e923797d3b2050b9b9c8baacf696f84ac9940282b5568c547" }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when input is a several valid shas separated by newline" do
+      let(:sha) { "c7f893648f656339f62fb7b4d8a6ecdf7d063835\nc7f893648f656339f62fb7b4d8a6ecdf7d063835" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when input is a an invalid sha" do
+      let(:sha) { "c7f893648g656339f62fb7b4d8a6ecdf7d063835" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when input is too short to be valid" do
+      let(:sha) { "c7f893648f656339f62fb7b4d8a6ecdf7d06383" }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe ".normalize_ref" do
     subject { described_class.normalize_ref(ref) }
 

--- a/vendor/rbs/ddtrace/0/datadog/core/transport/response.rbs
+++ b/vendor/rbs/ddtrace/0/datadog/core/transport/response.rbs
@@ -2,7 +2,7 @@ module Datadog
   module Core
     module Transport
       module Response
-        def payload: () -> nil
+        def payload: () -> String
 
         def ok?: () -> nil
 


### PR DESCRIPTION
**What does this PR do?**
Adds `Datadog::CI::Git::SearchCommits` class that sends backen API request to `/api/v2/git/repository/search_commits` endpoint and gets a list of commits that are already known to the backend DB.

**How to test the change?**
For now unit tests only, this class is not used yet