### PR TITLE
[CIVIS-2938] Upload packfiles API client

### DIFF
--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -39,6 +39,8 @@ module Datadog
 
         DD_API_GIT_SEARCH_COMMITS_PATH = "/api/v2/git/repository/search_commits"
 
+        DD_API_GIT_UPLOAD_PACKFILE_PATH = "/api/v2/git/repository/packfile"
+
         CONTENT_TYPE_MESSAGEPACK = "application/msgpack"
         CONTENT_TYPE_JSON = "application/json"
         CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data"

--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -141,6 +141,8 @@ module Datadog
         end
 
         def self.git_generate_packfiles(included_commits:, excluded_commits:, path:)
+          return nil unless File.exist?(path)
+
           commit_tree = git_commits_rev_list(included_commits: included_commits, excluded_commits: excluded_commits)
           return nil if commit_tree.nil?
 

--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -124,8 +124,8 @@ module Datadog
         end
 
         def self.git_commits_rev_list(included_commits:, excluded_commits:)
-          included_commits = included_commits.join(" ")
-          excluded_commits = excluded_commits.map! { |sha| "^#{sha}" }.join(" ")
+          included_commits = filter_invalid_commits(included_commits).join(" ")
+          excluded_commits = filter_invalid_commits(excluded_commits).map! { |sha| "^#{sha}" }.join(" ")
 
           exec_git_command(
             "git rev-list " \
@@ -161,6 +161,14 @@ module Datadog
         # is not called from outside of this module with insecure parameters
         class << self
           private
+
+          def filter_invalid_commits(commits)
+            commits.filter_map do |commit|
+              next unless Utils::Git.valid_commit_sha?(commit)
+
+              commit
+            end
+          end
 
           def exec_git_command(cmd, stdin: nil)
             # Shell injection is alleviated by making sure that no outside modules call this method.

--- a/lib/datadog/ci/git/search_commits.rb
+++ b/lib/datadog/ci/git/search_commits.rb
@@ -25,7 +25,7 @@ module Datadog
             path: Ext::Transport::DD_API_GIT_SEARCH_COMMITS_PATH,
             payload: request_payload(repository_url, commits)
           )
-          raise ApiError, "Failed to search commits: #{http_response.body}" unless http_response.ok?
+          raise ApiError, "Failed to search commits: #{http_response.inspect}" unless http_response.ok?
 
           response_payload = parse_json_response(http_response)
           extract_commits(response_payload)

--- a/lib/datadog/ci/git/upload_packfile.rb
+++ b/lib/datadog/ci/git/upload_packfile.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "json"
+require "securerandom"
+
+module Datadog
+  module CI
+    module Git
+      class UploadPackfile
+        class ApiError < StandardError; end
+
+        attr_reader :api, :head_commit_sha, :repository_url
+
+        def initialize(api:, head_commit_sha:, repository_url:)
+          @api = api
+          @head_commit_sha = head_commit_sha
+          @repository_url = repository_url
+        end
+
+        def call(filepath:)
+          raise ApiError, "test visibility API is not configured" if api.nil?
+
+          payload_boundary = SecureRandom.uuid
+
+          filename = File.basename(filepath)
+          packfile_contents = read_file(filepath)
+
+          payload = request_payload(payload_boundary, filename, packfile_contents)
+          content_type = "#{Ext::Transport::CONTENT_TYPE_MULTIPART_FORM_DATA}; boundary=#{payload_boundary}"
+
+          http_response = api.api_request(
+            path: Ext::Transport::DD_API_GIT_UPLOAD_PACKFILE_PATH,
+            payload: payload,
+            headers: {Ext::Transport::HEADER_CONTENT_TYPE => content_type}
+          )
+
+          raise ApiError, "Failed to upload packfile: #{http_response.inspect}" unless http_response.ok?
+        end
+
+        private
+
+        def request_payload(boundary, filename, packfile_contents)
+          [
+            "--#{boundary}",
+            'Content-Disposition: form-data; name="pushedSha"',
+            "Content-Type: application/json",
+            "",
+            {data: {id: head_commit_sha, type: "commit"}, meta: {repository_url: repository_url}}.to_json,
+            "--#{boundary}",
+            "Content-Disposition: form-data; name=\"packfile\"; filename=\"#{filename}\"",
+            "Content-Type: application/octet-stream",
+            "",
+            packfile_contents,
+            "--#{boundary}--"
+          ].join("\r\n")
+        end
+
+        def read_file(filepath)
+          File.read(filepath)
+        rescue => e
+          raise ApiError, "Failed to read packfile: #{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -50,6 +50,8 @@ module Datadog
 
         DD_API_GIT_SEARCH_COMMITS_PATH: "/api/v2/git/repository/search_commits"
 
+        DD_API_GIT_UPLOAD_PACKFILE_PATH: "/api/v2/git/repository/packfile"
+
         CONTENT_TYPE_MESSAGEPACK: "application/msgpack"
 
         CONTENT_TYPE_JSON: "application/json"

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -33,6 +33,8 @@ module Datadog
 
         private
 
+        def self.filter_invalid_commits: (Array[String] commits) -> Array[String]
+
         def self.exec_git_command: (String ref, ?stdin: String?) -> String?
 
         def self.log_failure: (StandardError e, String action) -> void

--- a/sig/datadog/ci/git/upload_packfile.rbs
+++ b/sig/datadog/ci/git/upload_packfile.rbs
@@ -1,0 +1,32 @@
+module Datadog
+  module CI
+    module Git
+      class UploadPackfile
+        @api: Datadog::CI::Transport::Api::Base?
+
+        @head_commit_sha: String
+
+        @repository_url: String
+
+        class ApiError < StandardError
+        end
+
+        attr_reader api: Datadog::CI::Transport::Api::Base?
+
+        attr_reader head_commit_sha: String
+
+        attr_reader repository_url: String
+
+        def initialize: (api: Datadog::CI::Transport::Api::Base?, head_commit_sha: String, repository_url: String) -> void
+
+        def call: (filepath: String) -> void
+
+        private
+
+        def request_payload: (String boundary, String filename, String packfile_contents) -> untyped
+
+        def read_file: (String filepath) -> untyped
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -130,6 +130,15 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     it "returns a list of commits that are reachable from included list but not reachable from excluded list" do
       expect(subject).to include(included_commits.join("\n"))
     end
+
+    context "invalid commits" do
+      let(:included_commits) { [" | echo \"boo\" "] }
+      let(:excluded_commits) { [" | echo \"boo\" "] }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
   end
 
   describe ".git_generate_packfiles" do

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     end
 
     context "no such directory" do
-      let(:tmpdir) { "./no/such/directory" }
+      let(:tmpdir) { " | echo \"boo\"" }
 
       it "returns nil" do
         expect(subject).to be_nil

--- a/spec/datadog/ci/git/search_commits_spec.rb
+++ b/spec/datadog/ci/git/search_commits_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Datadog::CI::Git::SearchCommits do
       end
 
       context "when the API request fails" do
-        let(:http_response) { double("http_response", ok?: false, body: "error message") }
+        let(:http_response) { double("http_response", ok?: false, inspect: "error message") }
 
         it "raises an error" do
           expect { search_commits.call(repository_url, commits) }
@@ -37,10 +37,10 @@ RSpec.describe Datadog::CI::Git::SearchCommits do
         let(:http_response) { double("http_response", ok?: true, payload: response_payload) }
         let(:response_payload) do
           {
-            "data" => [
+            data: [
               {
-                "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
-                "type" => "commit"
+                id: "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
+                type: "commit"
               }
             ]
           }.to_json
@@ -71,10 +71,10 @@ RSpec.describe Datadog::CI::Git::SearchCommits do
         context "when the response contains an invalid commit type" do
           let(:response_payload) do
             {
-              "data" => [
+              data: [
                 {
-                  "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
-                  "type" => "invalid"
+                  id: "c7f893648f656339f62fb7b4d8a6ecdf7d063835",
+                  type: "invalid"
                 }
               ]
             }.to_json
@@ -92,10 +92,10 @@ RSpec.describe Datadog::CI::Git::SearchCommits do
         context "when the response contains an invalid commit SHA" do
           let(:response_payload) do
             {
-              "data" => [
+              data: [
                 {
-                  "id" => "INVALID_SHA",
-                  "type" => "commit"
+                  id: "INVALID_SHA",
+                  type: "commit"
                 }
               ]
             }.to_json
@@ -134,9 +134,9 @@ RSpec.describe Datadog::CI::Git::SearchCommits do
         context "when the response is missing the commit type" do
           let(:response_payload) do
             {
-              "data" => [
+              data: [
                 {
-                  "id" => "c7f893648f656339f62fb7b4d8a6ecdf7d063835"
+                  id: "c7f893648f656339f62fb7b4d8a6ecdf7d063835"
                 }
               ]
             }.to_json

--- a/spec/datadog/ci/git/upload_packfile_spec.rb
+++ b/spec/datadog/ci/git/upload_packfile_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/git/upload_packfile"
+
+RSpec.describe Datadog::CI::Git::UploadPackfile do
+  let(:api) { double("api") }
+
+  subject(:upload_packfile) do
+    described_class.new(api: api, head_commit_sha: "HEAD", repository_url: "https://datadoghq.com/git/test.git")
+  end
+
+  describe "#call" do
+    let(:filepath) { "nonexistent" }
+
+    context "when the API is not configured" do
+      let(:api) { nil }
+
+      it "raises an error" do
+        expect { upload_packfile.call(filepath: filepath) }
+          .to raise_error(Datadog::CI::Git::UploadPackfile::ApiError, "test visibility API is not configured")
+      end
+    end
+
+    context "when the API is configured" do
+      before do
+        allow(api).to receive(:api_request).and_return(http_response)
+      end
+      let(:http_response) { double("http_response", ok?: true) }
+
+      context "when file does not exist" do
+        it "raises an error" do
+          expect { upload_packfile.call(filepath: filepath) }
+            .to raise_error(
+              Datadog::CI::Git::UploadPackfile::ApiError,
+              "Failed to read packfile: No such file or directory @ rb_sysopen - nonexistent"
+            )
+        end
+      end
+
+      context "when file exists" do
+        let(:tmpdir) { Dir.mktmpdir }
+        let(:filepath) { "#{tmpdir}/packfile.idx" }
+
+        before do
+          File.write(filepath, "packfile contents")
+        end
+
+        after do
+          FileUtils.remove_entry(tmpdir)
+        end
+
+        context "when the API request fails" do
+          let(:http_response) { double("http_response", ok?: false, inspect: "error message") }
+
+          it "raises an error" do
+            expect { upload_packfile.call(filepath: filepath) }
+              .to raise_error(Datadog::CI::Git::UploadPackfile::ApiError, "Failed to upload packfile: error message")
+          end
+        end
+
+        context "when the API request is successful" do
+          before do
+            allow(SecureRandom).to receive(:uuid).and_return("boundary")
+          end
+
+          it "uploads the packfile" do
+            expect(api).to receive(:api_request).with(
+              path: Datadog::CI::Ext::Transport::DD_API_GIT_UPLOAD_PACKFILE_PATH,
+              payload: [
+                "--boundary",
+                'Content-Disposition: form-data; name="pushedSha"',
+                "Content-Type: application/json",
+                "",
+                {data: {id: "HEAD", type: "commit"}, meta: {repository_url: "https://datadoghq.com/git/test.git"}}.to_json,
+                "--boundary",
+                'Content-Disposition: form-data; name="packfile"; filename="packfile.idx"',
+                "Content-Type: application/octet-stream",
+                "",
+                "packfile contents",
+                "--boundary--"
+              ].join("\r\n"),
+              headers: {Datadog::CI::Ext::Transport::HEADER_CONTENT_TYPE => "multipart/form-data; boundary=boundary"}
+            ).and_return(http_response)
+
+            upload_packfile.call(filepath: filepath)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/git/upload_packfile_spec.rb
+++ b/spec/datadog/ci/git/upload_packfile_spec.rb
@@ -28,11 +28,19 @@ RSpec.describe Datadog::CI::Git::UploadPackfile do
       let(:http_response) { double("http_response", ok?: true) }
 
       context "when file does not exist" do
+        let(:expected_error_message) do
+          if PlatformHelpers.jruby?
+            "Failed to read packfile: No such file or directory - nonexistent"
+          else
+            "Failed to read packfile: No such file or directory @ rb_sysopen - nonexistent"
+          end
+        end
+
         it "raises an error" do
           expect { upload_packfile.call(filepath: filepath) }
             .to raise_error(
               Datadog::CI::Git::UploadPackfile::ApiError,
-              "Failed to read packfile: No such file or directory @ rb_sysopen - nonexistent"
+              expected_error_message
             )
         end
       end


### PR DESCRIPTION
**What does this PR do?**
Adds `Git::UploadPackfile` class that is able to upload a single git packfile to Datadog's git API.

Makes minor changes to git_commits_rev_list and git_generate_packfiles methods to make them safer and prevent shell injections.

**How to test the change?**
Unit tests are provided, otherwise this functionality is not used yet