### PR TITLE
[CIVIS-2938] Git tree uploader

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -13,6 +13,7 @@ target :lib do
   library "net-http"
   library "zlib"
   library "securerandom"
+  library "tmpdir"
 
   repo_path "vendor/rbs"
   library "ddtrace"

--- a/Steepfile
+++ b/Steepfile
@@ -14,6 +14,7 @@ target :lib do
   library "zlib"
   library "securerandom"
   library "tmpdir"
+  library "fileutils"
 
   repo_path "vendor/rbs"
   library "ddtrace"

--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -152,6 +152,8 @@ module Datadog
             "git pack-objects --compression=9 --max-pack-size=3m #{path}/#{basename}",
             stdin: commit_tree
           )
+
+          basename
         rescue => e
           log_failure(e, "git generate packfiles")
           nil

--- a/lib/datadog/ci/git/packfiles.rb
+++ b/lib/datadog/ci/git/packfiles.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+require "fileutils"
+
+require_relative "local_repository"
+
+module Datadog
+  module CI
+    module Git
+      module Packfiles
+        def self.generate(included_commits:, excluded_commits:)
+          # @type var current_process_tmp_folder: String?
+          current_process_tmp_folder = nil
+
+          Dir.mktmpdir do |tmpdir|
+            prefix = LocalRepository.git_generate_packfiles(
+              included_commits: included_commits,
+              excluded_commits: excluded_commits,
+              path: tmpdir
+            )
+
+            if prefix.nil?
+              # git pack-files command fails if tmpdir is mounted on
+              # a different device from the current process directory
+              #
+              # @type var current_process_tmp_folder: String
+              current_process_tmp_folder = File.join(Dir.pwd, "tmp", "packfiles")
+              FileUtils.mkdir_p(current_process_tmp_folder)
+
+              prefix = LocalRepository.git_generate_packfiles(
+                included_commits: included_commits,
+                excluded_commits: excluded_commits,
+                path: current_process_tmp_folder
+              )
+
+              if prefix.nil?
+                Datadog.logger.debug("Packfiles generation failed twice, aborting")
+                break
+              end
+
+              tmpdir = current_process_tmp_folder
+            end
+
+            packfiles = Dir.entries(tmpdir) - %w[. ..]
+            if packfiles.empty?
+              Datadog.logger.debug("Empty packfiles list, aborting process")
+              break
+            end
+
+            packfiles.each do |packfile_name|
+              next unless packfile_name.start_with?(prefix)
+              next unless packfile_name.end_with?(".pack")
+
+              packfile_path = File.join(tmpdir, packfile_name)
+
+              yield packfile_path
+            end
+          end
+        rescue => e
+          Datadog.logger.debug("Packfiles could not be generated, error: #{e}")
+        ensure
+          FileUtils.remove_entry(current_process_tmp_folder) unless current_process_tmp_folder.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -18,11 +18,14 @@ module Datadog
           @api = api
         end
 
-        # 1. Get repository URL
         def call(repository_url)
+          if api.nil?
+            Datadog.logger.debug("API is not configured, aborting git upload")
+            return
+          end
+
           # 2. Check if the repository clone is shallow and unshallow if appropriate
           # TO BE ADDED IN CIVIS-2863
-          # 3. Get a maximum of 1000 latest commits in the last month with git log
           latest_commits = LocalRepository.git_commits
           head_commit = latest_commits&.first
           if head_commit.nil?
@@ -30,23 +33,14 @@ module Datadog
             return
           end
 
-          # 4. Search which commits are present on backend
-          backend_commits = nil
           begin
-            backend_commits = SearchCommits.new(api: api).call(repository_url, latest_commits)
+            excluded_commits, included_commits = split_known_commits(repository_url, latest_commits)
+            if included_commits.empty?
+              Datadog.logger.debug("No new commits to upload")
+              return
+            end
           rescue SearchCommits::ApiError => e
             Datadog.logger.debug("SearchCommits failed with #{e}, aborting git upload")
-            return
-          end
-
-          # 5. Get commits and trees excluding the backend commits
-          # 6. Generate pack files
-          included_commits = latest_commits.filter do |commit|
-            !backend_commits.include?(commit)
-          end
-
-          if included_commits.empty?
-            Datadog.logger.debug("No new commits to upload")
             return
           end
 
@@ -55,12 +49,20 @@ module Datadog
             head_commit_sha: head_commit,
             repository_url: repository_url
           )
-
-          Packfiles.generate(included_commits: included_commits, excluded_commits: backend_commits) do |filepath|
+          Packfiles.generate(included_commits: included_commits, excluded_commits: excluded_commits) do |filepath|
             uploader.call(filepath: filepath)
           rescue UploadPackfile::ApiError => e
             Datadog.logger.debug("Packfile upload failed with #{e}")
             break
+          end
+        end
+
+        private
+
+        def split_known_commits(repository_url, latest_commits)
+          backend_commits = SearchCommits.new(api: api).call(repository_url, latest_commits)
+          latest_commits.partition do |commit|
+            backend_commits.include?(commit)
           end
         end
       end

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -42,7 +42,7 @@ module Datadog
               return
             end
           rescue SearchCommits::ApiError => e
-            Datadog.logger.debug { "SearchCommits failed with #{e}, aborting git upload" }
+            Datadog.logger.debug("SearchCommits failed with #{e}, aborting git upload")
             return
           end
 

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require_relative "local_repository"
+require_relative "search_commits"
+require_relative "upload_packfile"
+
+module Datadog
+  module CI
+    module Git
+      class TreeUploader
+        attr_reader :api
+
+        def initialize(api:)
+          @api = api
+        end
+
+        # 1. Get repository URL
+        def call(repository_url)
+          # 2. Check if the repository clone is shallow and unshallow if appropriate
+          # TO BE ADDED IN CIVIS-2863
+          # 3. Get a maximum of 1000 latest commits in the last month with git log
+          latest_commits = LocalRepository.git_commits
+          if latest_commits.empty?
+            Datadog.logger.debug("Got empty latest commits list, aborting git upload")
+            return
+          end
+
+          # 4. Search which commits are present on backend
+          backend_commits = nil
+          begin
+            backend_commits = SearchCommits.new(api: api).call(repository_url, latest_commits)
+          rescue SearchCommits::ApiError => e
+            Datadog.logger.debug("SearchCommits failed with #{e}, aborting git upload")
+            return
+          end
+
+          # 5. Get commits and trees excluding the backend commits
+          # 6. Generate pack files
+          included_commits = latest_commits.filter do |commit|
+            # check that backend_commits has this commit
+            !backend_commits.include?(commit)
+          end
+
+          Dir.mktmpdir do |tmpdir|
+            res = LocalRepository.git_generate_packfiles(
+              included_commits: included_commits,
+              excluded_commits: backend_commits.to_a,
+              path: tmpdir
+            )
+
+            if res.nil?
+              Datadog.logger.debug("packfiles generation failed, retrying with different folder")
+
+              # TODO: retry with tmp folder under current process directory
+            end
+
+            packfiles = Dir.entries(tmpdir) - [".", ".."]
+            if packfiles.empty?
+              Datadog.logger.debug("Empty packfiles, nothing to upload")
+              break
+            end
+
+            head_commit = latest_commits.first
+            if head_commit.nil?
+              Datadog.logger.debug("Got empty latest commits list, aborting git upload")
+              break
+            end
+
+            # 7. Upload packfiles via an HTTP multipart POST to /api/v2/git/repository/packfile for each generated packfile
+            uploader = UploadPackfile.new(
+              api: api,
+              head_commit_sha: head_commit,
+              repository_url: repository_url
+            )
+
+            packfiles.each do |packfile|
+              # TODO: skip packfiles that do not have the same prefix (return prefix from git_generate_packfiles)
+              # TODO: upload only .pack files
+              uploader.call(filepath: packfile)
+            rescue UploadPackfile::ApiError => e
+              Datadog.logger.debug("Packfile upload failed with #{e}")
+              break
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -22,7 +22,8 @@ module Datadog
           # TO BE ADDED IN CIVIS-2863
           # 3. Get a maximum of 1000 latest commits in the last month with git log
           latest_commits = LocalRepository.git_commits
-          if latest_commits.empty?
+          head_commit = latest_commits.first
+          if head_commit.nil?
             Datadog.logger.debug("Got empty latest commits list, aborting git upload")
             return
           end
@@ -58,13 +59,7 @@ module Datadog
 
             packfiles = Dir.entries(tmpdir) - [".", ".."]
             if packfiles.empty?
-              Datadog.logger.debug("Empty packfiles, nothing to upload")
-              break
-            end
-
-            head_commit = latest_commits.first
-            if head_commit.nil?
-              Datadog.logger.debug("Got empty latest commits list, aborting git upload")
+              Datadog.logger.debug("Empty packfiles list, nothing to upload")
               break
             end
 

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -6,6 +6,7 @@ require "fileutils"
 require_relative "local_repository"
 require_relative "search_commits"
 require_relative "upload_packfile"
+require_relative "packfiles"
 
 module Datadog
   module CI
@@ -23,7 +24,7 @@ module Datadog
           # TO BE ADDED IN CIVIS-2863
           # 3. Get a maximum of 1000 latest commits in the last month with git log
           latest_commits = LocalRepository.git_commits
-          head_commit = latest_commits.first
+          head_commit = latest_commits&.first
           if head_commit.nil?
             Datadog.logger.debug("Got empty latest commits list, aborting git upload")
             return
@@ -55,52 +56,11 @@ module Datadog
             repository_url: repository_url
           )
 
-          # TODO: extract packfile generation to a separate class that yields files one by one
-          # hopefully it'll make it easier to test
-          Dir.mktmpdir do |tmpdir|
-            packfiles_folder = tmpdir
-            prefix = LocalRepository.git_generate_packfiles(
-              included_commits: included_commits,
-              excluded_commits: backend_commits.to_a,
-              path: packfiles_folder
-            )
-
-            if prefix.nil?
-              Datadog.logger.debug("packfiles generation failed, retrying with different folder")
-
-              packfiles_folder = File.join(Dir.pwd, "tmp", "packfiles")
-              FileUtils.mkdir_p(packfiles_folder)
-
-              prefix = LocalRepository.git_generate_packfiles(
-                included_commits: included_commits,
-                excluded_commits: backend_commits.to_a,
-                path: packfiles_folder
-              )
-
-              if prefix.nil?
-                Datadog.logger.debug("packfiles generation failed, aborting git upload")
-                break
-              end
-            end
-
-            packfiles = Dir.entries(packfiles_folder) - %w[. ..]
-            if packfiles.empty?
-              Datadog.logger.debug("Empty packfiles list, nothing to upload")
-              break
-            end
-
-            # 7. Upload packfiles via an HTTP multipart POST to /api/v2/git/repository/packfile for each generated packfile
-            packfiles.each do |packfile|
-              filename = File.basename(packfile)
-
-              next unless filename.start_with?(prefix)
-              next unless filename.end_with?(".pack")
-
-              uploader.call(filepath: packfile)
-            rescue UploadPackfile::ApiError => e
-              Datadog.logger.debug("Packfile upload failed with #{e}")
-              break
-            end
+          Packfiles.generate(included_commits: included_commits, excluded_commits: backend_commits) do |filepath|
+            uploader.call(filepath: filepath)
+          rescue UploadPackfile::ApiError => e
+            Datadog.logger.debug("Packfile upload failed with #{e}")
+            break
           end
         end
       end

--- a/lib/datadog/ci/git/tree_uploader.rb
+++ b/lib/datadog/ci/git/tree_uploader.rb
@@ -24,6 +24,8 @@ module Datadog
             return
           end
 
+          Datadog.logger.debug { "Uploading git tree for repository #{repository_url}" }
+
           # 2. Check if the repository clone is shallow and unshallow if appropriate
           # TO BE ADDED IN CIVIS-2863
           latest_commits = LocalRepository.git_commits
@@ -40,10 +42,11 @@ module Datadog
               return
             end
           rescue SearchCommits::ApiError => e
-            Datadog.logger.debug("SearchCommits failed with #{e}, aborting git upload")
+            Datadog.logger.debug { "SearchCommits failed with #{e}, aborting git upload" }
             return
           end
 
+          Datadog.logger.debug { "Uploading packfiles for commits: #{included_commits}" }
           uploader = UploadPackfile.new(
             api: api,
             head_commit_sha: head_commit,
@@ -60,6 +63,7 @@ module Datadog
         private
 
         def split_known_commits(repository_url, latest_commits)
+          Datadog.logger.debug { "Checking the latest commits list with backend: #{latest_commits}" }
           backend_commits = SearchCommits.new(api: api).call(repository_url, latest_commits)
           latest_commits.partition do |commit|
             backend_commits.include?(commit)

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -29,13 +29,13 @@ module Datadog
 
         def self.git_commits: () -> Array[String]
 
-        def self.git_commits_rev_list: (included_commits: Array[String], excluded_commits: Array[String]) -> String?
+        def self.git_commits_rev_list: (included_commits: Enumerable[String], excluded_commits: Enumerable[String]) -> String?
 
-        def self.git_generate_packfiles: (included_commits: Array[String], excluded_commits: Array[String], path: String) -> String?
+        def self.git_generate_packfiles: (included_commits: Enumerable[String], excluded_commits: Enumerable[String], path: String) -> String?
 
         private
 
-        def self.filter_invalid_commits: (Array[String] commits) -> Array[String]
+        def self.filter_invalid_commits: (Enumerable[String] commits) -> Array[String]
 
         def self.exec_git_command: (String ref, ?stdin: String?) -> String?
 

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -31,6 +31,8 @@ module Datadog
 
         def self.git_commits_rev_list: (included_commits: Array[String], excluded_commits: Array[String]) -> String?
 
+        def self.git_generate_packfiles: (included_commits: Array[String], excluded_commits: Array[String], path: String) -> String?
+
         private
 
         def self.filter_invalid_commits: (Array[String] commits) -> Array[String]

--- a/sig/datadog/ci/git/packfiles.rbs
+++ b/sig/datadog/ci/git/packfiles.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module CI
+    module Git
+      module Packfiles
+        def self.generate: (included_commits: Enumerable[String], excluded_commits: Enumerable[String]) { (String) -> untyped } -> void
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/git/tree_uploader.rbs
+++ b/sig/datadog/ci/git/tree_uploader.rbs
@@ -8,6 +8,10 @@ module Datadog
 
         def initialize: (api: Datadog::CI::Transport::Api::Base?) -> void
         def call: (String repository_url) -> void
+
+        private
+
+        def split_known_commits: (String repository_url, Array[String] latest_commits) -> [Array[String], Array[String]]
       end
     end
   end

--- a/sig/datadog/ci/git/tree_uploader.rbs
+++ b/sig/datadog/ci/git/tree_uploader.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module CI
+    module Git
+      class TreeUploader
+        @api: Datadog::CI::Transport::Api::Base?
+
+        attr_reader api: Datadog::CI::Transport::Api::Base?
+
+        def initialize: (api: Datadog::CI::Transport::Api::Base?) -> void
+        def call: (String repository_url) -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       end
 
       it "generates packfiles in temp directory" do
-        expect(subject).not_to be_nil
+        expect(subject).to match(/^\h{8}$/)
         packfiles = Dir.entries(tmpdir) - %w[. ..]
         expect(packfiles).not_to be_empty
         expect(packfiles).to all(match(/^\h{8}-\h{40}\.(pack|idx|rev)$/))

--- a/spec/datadog/ci/git/packfiles_spec.rb
+++ b/spec/datadog/ci/git/packfiles_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/git/packfiles"
+
+RSpec.describe ::Datadog::CI::Git::Packfiles do
+  # skip for jruby for now - old git version DD docker image
+  before { skip if PlatformHelpers.jruby? }
+
+  let(:commits) { Datadog::CI::Git::LocalRepository.git_commits }
+  let(:included_commits) { commits[0..1] }
+  let(:excluded_commits) { commits[2..] }
+
+  describe ".generate" do
+    it "yields packfile" do
+      expect do |b|
+        described_class.generate(included_commits: included_commits, excluded_commits: excluded_commits, &b)
+      end.to yield_with_args(/\/.+\h{8}-\h{40}\.pack$/)
+    end
+
+    context "empty packfiles folder" do
+      before do
+        expect(Datadog::CI::Git::LocalRepository).to receive(:git_generate_packfiles).with(
+          included_commits: included_commits,
+          excluded_commits: excluded_commits,
+          path: String
+        ) do
+          "pref"
+        end
+      end
+
+      it "does not yield anything" do
+        expect do |b|
+          described_class.generate(included_commits: included_commits, excluded_commits: excluded_commits, &b)
+        end.not_to yield_control
+      end
+    end
+
+    context "something goes wrong" do
+      before do
+        expect(Dir).to receive(:mktmpdir).and_raise("error")
+      end
+
+      it "does not yield anything" do
+        expect do |b|
+          described_class.generate(included_commits: included_commits, excluded_commits: excluded_commits, &b)
+        end.not_to yield_control
+      end
+    end
+
+    context "tmp folder fails" do
+      let(:current_process_tmp_folder) { File.join(Dir.pwd, "tmp", "packfiles") }
+      let(:prefix) { "pref" }
+
+      before do
+        expect(Datadog::CI::Git::LocalRepository).to receive(:git_generate_packfiles).with(
+          included_commits: included_commits,
+          excluded_commits: excluded_commits,
+          path: String
+        ).and_return(nil)
+
+        expect(Datadog::CI::Git::LocalRepository).to receive(:git_generate_packfiles).with(
+          included_commits: included_commits,
+          excluded_commits: excluded_commits,
+          path: current_process_tmp_folder
+        ) do
+          File.write(File.join(current_process_tmp_folder, "#{prefix}-sha.idx"), "hello world")
+          File.write(File.join(current_process_tmp_folder, "other-sha.pack"), "hello world")
+          File.write(File.join(current_process_tmp_folder, "#{prefix}-sha.pack"), "hello world")
+
+          prefix
+        end
+      end
+
+      it "creates temporary folder in the current directory" do
+        expect do |b|
+          described_class.generate(included_commits: included_commits, excluded_commits: excluded_commits, &b)
+        end.to yield_with_args(/^#{current_process_tmp_folder}\/pref-sha.pack$/)
+
+        expect(File.exist?(current_process_tmp_folder)).to be_falsey
+      end
+    end
+
+    context "packfile generation fails" do
+      before do
+        allow(Datadog::CI::Git::LocalRepository).to receive(:git_generate_packfiles).and_return(nil)
+      end
+
+      it "does not yield anything" do
+        expect do |b|
+          described_class.generate(included_commits: included_commits, excluded_commits: excluded_commits, &b)
+        end.not_to yield_control
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/git/tree_uploader_spec.rb
+++ b/spec/datadog/ci/git/tree_uploader_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Datadog::CI::Git::TreeUploader do
   let(:api) { double("api") }
   subject(:tree_uploader) { described_class.new(api: api) }
 
+  before do
+    allow(Datadog.logger).to receive(:debug)
+  end
+
   describe "#call" do
     let(:repository_url) { "https://datadoghq.com/git/test.git" }
     let(:latest_commits) { %w[c7f893648f656339f62fb7b4d8a6ecdf7d063835 13c988d4f15e06bcdd0b0af290086a3079cdadb0] }

--- a/spec/datadog/ci/git/tree_uploader_spec.rb
+++ b/spec/datadog/ci/git/tree_uploader_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/git/tree_uploader"
+
+RSpec.describe Datadog::CI::Git::TreeUploader do
+  let(:api) { double("api") }
+  subject(:tree_uploader) { described_class.new(api: api) }
+
+  describe "#call" do
+    let(:repository_url) { "https://datadoghq.com/git/test.git" }
+    let(:latest_commits) { %w[c7f893648f656339f62fb7b4d8a6ecdf7d063835 13c988d4f15e06bcdd0b0af290086a3079cdadb0] }
+    let(:head_commit) { "c7f893648f656339f62fb7b4d8a6ecdf7d063835" }
+    let(:backend_commits) { %w[c7f893648f656339f62fb7b4d8a6ecdf7d063835] }
+
+    let(:search_commits) { double("search_commits", call: backend_commits) }
+
+    before do
+      allow(Datadog::CI::Git::LocalRepository).to receive(:git_commits).and_return(latest_commits)
+      allow(Datadog::CI::Git::SearchCommits).to receive(:new).with(api: api).and_return(search_commits)
+    end
+
+    context "when the API is not configured" do
+      let(:api) { nil }
+
+      it "logs a debug message and aborts the git upload" do
+        expect(Datadog.logger).to receive(:debug).with("API is not configured, aborting git upload")
+
+        tree_uploader.call(repository_url)
+      end
+    end
+
+    context "when the latest commits list is empty" do
+      let(:latest_commits) { [] }
+
+      it "logs a debug message and aborts the git upload" do
+        expect(Datadog.logger).to receive(:debug).with("Got empty latest commits list, aborting git upload")
+
+        tree_uploader.call(repository_url)
+      end
+    end
+
+    context "when the backend commits search fails" do
+      before do
+        expect(search_commits).to receive(:call).and_raise(Datadog::CI::Git::SearchCommits::ApiError, "test error")
+      end
+
+      it "logs a debug message and aborts the git upload" do
+        expect(Datadog.logger).to receive(:debug).with("SearchCommits failed with test error, aborting git upload")
+
+        tree_uploader.call(repository_url)
+      end
+    end
+
+    context "when all commits are known to the backend" do
+      let(:backend_commits) { latest_commits }
+
+      it "logs a debug message and aborts the git upload" do
+        expect(Datadog.logger).to receive(:debug).with("No new commits to upload")
+
+        tree_uploader.call(repository_url)
+      end
+    end
+
+    context "when some commits are new" do
+      let(:upload_packfile) { double("upload_packfile", call: nil) }
+
+      before do
+        expect(Datadog::CI::Git::Packfiles).to receive(:generate).with(
+          included_commits: latest_commits - backend_commits.to_a,
+          excluded_commits: backend_commits
+        ).and_yield("packfile_path")
+
+        expect(Datadog::CI::Git::UploadPackfile).to receive(:new).with(
+          api: api,
+          head_commit_sha: head_commit,
+          repository_url: repository_url
+        ).and_return(upload_packfile)
+      end
+
+      context "when the packfile upload fails" do
+        before do
+          expect(upload_packfile).to receive(:call).and_raise(Datadog::CI::Git::UploadPackfile::ApiError, "test error")
+        end
+
+        it "logs a debug message and aborts the git upload" do
+          expect(Datadog.logger).to receive(:debug).with("Packfile upload failed with test error")
+
+          tree_uploader.call(repository_url)
+        end
+      end
+
+      context "when the packfile upload succeeds" do
+        it "uploads the new commits" do
+          expect(upload_packfile).to receive(:call).with(filepath: "packfile_path").and_return(nil)
+
+          tree_uploader.call(repository_url)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Adds `Datadog::CI::Git::TreeUploader` class that performs git metadata upload

**Additional Notes**
This is not done yet, there are several features coming in the next PRs:
- [add unshallowing logic](https://github.com/DataDog/datadog-ci-rb/pull/155)
- wrap TreeUploader in background worker
- start git upload process when starting test session (behind configuration flag)
- change library configuration logic to wait for git upload if `require_git` is true

**How to test the change?**
Tested on https://github.com/anmarchenko/sidekiq/tree/anmarchenko/datadog-ci-visibility with the following result in debug logs:

```
D, [2024-04-09T13:06:00.880158 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/git/tree_uploader.rb:27:in `call') Uploading git tree for repository git@github.com:anmarchenko/sidekiq.git
D, [2024-04-09T13:06:00.895630 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/git/tree_uploader.rb:66:in `split_known_commits') Checking the latest commits list with backend: ["192916705f15731ffd0154d338654faa25808faf", "eee691c84185dca1ac9f28f30b5d167ed5f62aa8", "e82b8884cb1763eef9a47a3548635c30dceaa710", "c83bde1bb54375f0f853f3680536403ea3c0b84d", "0778417584ffac06d4eafcae0ae3b0f5be3de8ef"]
D, [2024-04-09T13:06:00.895774 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/transport/http.rb:38:in `request') Sending post request: host=api.datad0g.com; port=443; ssl_enabled=true; compression_enabled=false; path=/api/v2/git/repository/search_commits; payload_size=407
D, [2024-04-09T13:06:01.437905 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/transport/http.rb:49:in `request') Received server response: Datadog::Core::Transport::HTTP::Adapters::Net::Response ok?:true unsupported?:false, not_found?:false, client_error?:false, server_error?:false, internal_error?:, payload:{"data":[{"id":"eee691c84185dca1ac9f28f30b5d167ed5f62aa8","type":"commit"},{"id":"e82b8884cb1763eef9a47a3548635c30dceaa710","type":"commit"},{"id":"c83bde1bb54375f0f853f3680536403ea3c0b84d","type":"commit"},{"id":"0778417584ffac06d4eafcae0ae3b0f5be3de8ef","type":"commit"}]}, http_response:#<Net::HTTPOK:0x000000011fab21e0>
D, [2024-04-09T13:06:01.438376 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/git/tree_uploader.rb:49:in `call') Uploading packfiles for commits: ["192916705f15731ffd0154d338654faa25808faf"]
D, [2024-04-09T13:06:01.490725 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/transport/http.rb:38:in `request') Sending post request: host=api.datad0g.com; port=443; ssl_enabled=true; compression_enabled=false; path=/api/v2/git/repository/packfile; payload_size=2968
D, [2024-04-09T13:06:02.193948 #11671] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/transport/http.rb:49:in `request') Received server response: Datadog::Core::Transport::HTTP::Adapters::Net::Response ok?:true unsupported?:false, not_found?:false, client_error?:false, server_error?:false, internal_error?:, payload:, http_response:#<Net::HTTPNoContent:0x0000000128414118>

```