### PR TITLE
[CIVIS-2863] Git repository unshallowing logic

### DIFF
--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -186,11 +186,7 @@ module Datadog
           private
 
           def filter_invalid_commits(commits)
-            commits.filter_map do |commit|
-              next unless Utils::Git.valid_commit_sha?(commit)
-
-              commit
-            end
+            commits.filter { |commit| Utils::Git.valid_commit_sha?(commit) }
           end
 
           def exec_git_command(cmd, stdin: nil)

--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -166,6 +166,20 @@ module Datadog
           false
         end
 
+        def self.git_unshallow
+          exec_git_command(
+            "git fetch " \
+            "--shallow-since=\"1 month ago\" " \
+            "--update-shallow " \
+            "--filter=\"blob:none\" " \
+            "--recurse-submodules=no " \
+            "$(git config --default origin --get clone.defaultRemoteName) $(git rev-parse HEAD)"
+          )
+        rescue => e
+          log_failure(e, "git unshallow")
+          nil
+        end
+
         # makes .exec_git_command private to make sure that this method
         # is not called from outside of this module with insecure parameters
         class << self

--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -159,6 +159,13 @@ module Datadog
           nil
         end
 
+        def self.git_shallow_clone?
+          exec_git_command("git rev-parse --is-shallow-repository") == "true"
+        rescue => e
+          log_failure(e, "git shallow clone")
+          false
+        end
+
         # makes .exec_git_command private to make sure that this method
         # is not called from outside of this module with insecure parameters
         class << self

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -33,6 +33,8 @@ module Datadog
 
         def self.git_generate_packfiles: (included_commits: Enumerable[String], excluded_commits: Enumerable[String], path: String) -> String?
 
+        def self.git_shallow_clone?: () -> bool
+
         private
 
         def self.filter_invalid_commits: (Enumerable[String] commits) -> Array[String]

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -35,6 +35,8 @@ module Datadog
 
         def self.git_shallow_clone?: () -> bool
 
+        def self.git_unshallow: () -> String?
+
         private
 
         def self.filter_invalid_commits: (Enumerable[String] commits) -> Array[String]

--- a/sig/datadog/ci/git/tree_uploader.rbs
+++ b/sig/datadog/ci/git/tree_uploader.rbs
@@ -11,7 +11,7 @@ module Datadog
 
         private
 
-        def split_known_commits: (String repository_url, Array[String] latest_commits) -> [Array[String], Array[String]]
+        def fetch_known_commits_and_split: (String repository_url, Array[String] latest_commits) -> [Array[String], Array[String]]
       end
     end
   end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -182,12 +182,6 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     end
   end
 
-  describe ".git_shallow_clone?" do
-    subject { described_class.git_shallow_clone? }
-
-    it { is_expected.to be_falsey }
-  end
-
   context "with git folder" do
     include_context "with git fixture", "gitdir_with_commit"
 
@@ -351,6 +345,30 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
         expect(subject).to be_truthy
         expect(commits.size).to be > 1
       end
+    end
+  end
+
+  context "with full clone" do
+    let(:tmpdir) { Dir.mktmpdir }
+    after { FileUtils.remove_entry(tmpdir) }
+
+    before do
+      # shallow clone datadog-ci-rb repository
+      `cd #{tmpdir} && git clone https://github.com/DataDog/datadog-ci-rb`
+    end
+
+    def with_full_clone_git_dir
+      ClimateControl.modify("GIT_DIR" => File.join(tmpdir, "datadog-ci-rb/.git")) do
+        yield
+      end
+    end
+
+    describe ".git_shallow_clone?" do
+      subject do
+        with_full_clone_git_dir { described_class.git_shallow_clone? }
+      end
+
+      it { is_expected.to be_falsey }
     end
   end
 end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -182,6 +182,12 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     end
   end
 
+  describe ".git_shallow_clone?" do
+    subject { described_class.git_shallow_clone? }
+
+    it { is_expected.to be_falsey }
+  end
+
   context "with git folder" do
     include_context "with git fixture", "gitdir_with_commit"
 

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -322,5 +322,18 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
 
       it { is_expected.to be_truthy }
     end
+
+    describe ".git_commits" do
+      subject do
+        with_shallow_clone_git_dir { described_class.git_commits }
+      end
+
+      it "returns a list of single git commit sha" do
+        expect(subject).to be_kind_of(Array)
+        expect(subject).not_to be_empty
+        expect(subject).to have(1).item
+        expect(subject.first).to match(/^\h{40}$/)
+      end
+    end
   end
 end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -335,5 +335,22 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
         expect(subject.first).to match(/^\h{40}$/)
       end
     end
+
+    describe ".git_unshallow" do
+      subject do
+        with_shallow_clone_git_dir { described_class.git_unshallow }
+      end
+      let(:commits0) do
+        with_shallow_clone_git_dir { described_class.git_commits }
+      end
+      let(:commits) do
+        with_shallow_clone_git_dir { described_class.git_commits }
+      end
+
+      it "unshallows the repository" do
+        expect(subject).to be_truthy
+        expect(commits.size).to be > 1
+      end
+    end
   end
 end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -337,6 +337,9 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     end
 
     describe ".git_unshallow" do
+      # skip for jruby for now - old git version DD docker image
+      before { skip if PlatformHelpers.jruby? }
+
       subject do
         with_shallow_clone_git_dir { described_class.git_unshallow }
       end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -343,9 +343,6 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       subject do
         with_shallow_clone_git_dir { described_class.git_unshallow }
       end
-      let(:commits0) do
-        with_shallow_clone_git_dir { described_class.git_commits }
-      end
       let(:commits) do
         with_shallow_clone_git_dir { described_class.git_commits }
       end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -299,4 +299,28 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       it { is_expected.to eq("first-tag") }
     end
   end
+
+  context "with shallow clone" do
+    let(:tmpdir) { Dir.mktmpdir }
+    after { FileUtils.remove_entry(tmpdir) }
+
+    before do
+      # shallow clone datadog-ci-rb repository
+      `cd #{tmpdir} && git clone --depth 1 https://github.com/DataDog/datadog-ci-rb`
+    end
+
+    def with_shallow_clone_git_dir
+      ClimateControl.modify("GIT_DIR" => File.join(tmpdir, "datadog-ci-rb/.git")) do
+        yield
+      end
+    end
+
+    describe ".git_shallow_clone?" do
+      subject do
+        with_shallow_clone_git_dir { described_class.git_shallow_clone? }
+      end
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end

--- a/spec/datadog/ci/git/tree_uploader_spec.rb
+++ b/spec/datadog/ci/git/tree_uploader_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe Datadog::CI::Git::TreeUploader do
     let(:search_commits) { double("search_commits", call: backend_commits) }
 
     before do
-      allow(Datadog::CI::Git::LocalRepository).to receive(:git_commits).and_return(latest_commits)
       allow(Datadog::CI::Git::SearchCommits).to receive(:new).with(api: api).and_return(search_commits)
     end
 
@@ -33,71 +32,136 @@ RSpec.describe Datadog::CI::Git::TreeUploader do
       end
     end
 
-    context "when the latest commits list is empty" do
-      let(:latest_commits) { [] }
-
-      it "logs a debug message and aborts the git upload" do
-        expect(Datadog.logger).to receive(:debug).with("Got empty latest commits list, aborting git upload")
-
-        tree_uploader.call(repository_url)
-      end
-    end
-
-    context "when the backend commits search fails" do
+    context "when API is configured" do
       before do
-        expect(search_commits).to receive(:call).and_raise(Datadog::CI::Git::SearchCommits::ApiError, "test error")
+        expect(Datadog::CI::Git::LocalRepository).to receive(:git_commits).and_return(latest_commits)
       end
 
-      it "logs a debug message and aborts the git upload" do
-        expect(Datadog.logger).to receive(:debug).with("SearchCommits failed with test error, aborting git upload")
+      context "when the latest commits list is empty" do
+        let(:latest_commits) { [] }
 
-        tree_uploader.call(repository_url)
-      end
-    end
+        it "logs a debug message and aborts the git upload" do
+          expect(Datadog.logger).to receive(:debug).with("Got empty latest commits list, aborting git upload")
 
-    context "when all commits are known to the backend" do
-      let(:backend_commits) { latest_commits }
-
-      it "logs a debug message and aborts the git upload" do
-        expect(Datadog.logger).to receive(:debug).with("No new commits to upload")
-
-        tree_uploader.call(repository_url)
-      end
-    end
-
-    context "when some commits are new" do
-      let(:upload_packfile) { double("upload_packfile", call: nil) }
-
-      before do
-        expect(Datadog::CI::Git::Packfiles).to receive(:generate).with(
-          included_commits: latest_commits - backend_commits.to_a,
-          excluded_commits: backend_commits
-        ).and_yield("packfile_path")
-
-        expect(Datadog::CI::Git::UploadPackfile).to receive(:new).with(
-          api: api,
-          head_commit_sha: head_commit,
-          repository_url: repository_url
-        ).and_return(upload_packfile)
+          tree_uploader.call(repository_url)
+        end
       end
 
-      context "when the packfile upload fails" do
+      context "when the backend commits search fails" do
         before do
-          expect(upload_packfile).to receive(:call).and_raise(Datadog::CI::Git::UploadPackfile::ApiError, "test error")
+          expect(search_commits).to receive(:call).and_raise(Datadog::CI::Git::SearchCommits::ApiError, "test error")
         end
 
         it "logs a debug message and aborts the git upload" do
-          expect(Datadog.logger).to receive(:debug).with("Packfile upload failed with test error")
+          expect(Datadog.logger).to receive(:debug).with("SearchCommits failed with test error, aborting git upload")
 
           tree_uploader.call(repository_url)
         end
       end
 
-      context "when the packfile upload succeeds" do
-        it "uploads the new commits" do
-          expect(upload_packfile).to receive(:call).with(filepath: "packfile_path").and_return(nil)
+      context "when all commits are known to the backend" do
+        let(:backend_commits) { latest_commits }
+
+        it "logs a debug message and aborts the git upload" do
+          expect(Datadog.logger).to receive(:debug).with("No new commits to upload")
 
           tree_uploader.call(repository_url)
+        end
+
+        context "when the repository is shallow cloned" do
+          before do
+            expect(Datadog::CI::Git::LocalRepository).to receive(:git_shallow_clone?).and_return(true)
+          end
+
+          context "when the unshallowing fails" do
+            before do
+              expect(Datadog::CI::Git::LocalRepository).to receive(:git_unshallow).and_return(nil)
+            end
+
+            it "logs a debug message and aborts the git upload" do
+              expect(Datadog.logger).to receive(:debug).with("Failed to unshallow the git repository, aborting git upload")
+
+              tree_uploader.call(repository_url)
+            end
+          end
+
+          context "when the unshallowing succeeds" do
+            before do
+              expect(Datadog::CI::Git::LocalRepository).to receive(:git_unshallow).and_return("unshallow_result")
+            end
+
+            context "when there are new commits after unshallowing" do
+              before do
+                expect(Datadog::CI::Git::LocalRepository).to receive(:git_commits).and_return(
+                  latest_commits + %w[782d09e3fbfd8cf1b5c13f3eb9621362f9089ed5]
+                )
+              end
+
+              it "uploads the new commits" do
+                expect(Datadog::CI::Git::Packfiles).to receive(:generate).with(
+                  included_commits: %w[782d09e3fbfd8cf1b5c13f3eb9621362f9089ed5],
+                  excluded_commits: backend_commits
+                ).and_yield("packfile_path")
+
+                expect(Datadog::CI::Git::UploadPackfile).to receive(:new).with(
+                  api: api,
+                  head_commit_sha: head_commit,
+                  repository_url: repository_url
+                ).and_return(double("upload_packfile", call: nil))
+
+                tree_uploader.call(repository_url)
+              end
+            end
+
+            context "when there are no new commits" do
+              before do
+                expect(Datadog::CI::Git::LocalRepository).to receive(:git_commits).and_return(latest_commits)
+              end
+
+              it "logs a debug message and aborts the git upload" do
+                expect(Datadog.logger).to receive(:debug).with("No new commits to upload after unshallowing")
+
+                tree_uploader.call(repository_url)
+              end
+            end
+          end
+        end
+      end
+
+      context "when some commits are new" do
+        let(:upload_packfile) { double("upload_packfile", call: nil) }
+
+        before do
+          expect(Datadog::CI::Git::Packfiles).to receive(:generate).with(
+            included_commits: latest_commits - backend_commits.to_a,
+            excluded_commits: backend_commits
+          ).and_yield("packfile_path")
+
+          expect(Datadog::CI::Git::UploadPackfile).to receive(:new).with(
+            api: api,
+            head_commit_sha: head_commit,
+            repository_url: repository_url
+          ).and_return(upload_packfile)
+        end
+
+        context "when the packfile upload fails" do
+          before do
+            expect(upload_packfile).to receive(:call).and_raise(Datadog::CI::Git::UploadPackfile::ApiError, "test error")
+          end
+
+          it "logs a debug message and aborts the git upload" do
+            expect(Datadog.logger).to receive(:debug).with("Packfile upload failed with test error")
+
+            tree_uploader.call(repository_url)
+          end
+        end
+
+        context "when the packfile upload succeeds" do
+          it "uploads the new commits" do
+            expect(upload_packfile).to receive(:call).with(filepath: "packfile_path").and_return(nil)
+
+            tree_uploader.call(repository_url)
+          end
         end
       end
     end


### PR DESCRIPTION
**What does this PR do?**
Adds the following git unshallowing logic to this library:

<img width="400" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/f3341b24-6990-4ee6-ac08-44d31778f2d1">

Also implements unshallowing optimization: if all commits from the shallow repo are present in the backend, we skip the git upload alltogether.

**How to test the change?**
Unit tests are provided