### PR TITLE
[CIVIS-9606] reduce ITR-induced code coverage overhead for default branch

### DIFF
--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -7,6 +7,8 @@ require_relative "../ext/transport"
 
 require_relative "../git/local_repository"
 
+require_relative "../utils/parsing"
+
 require_relative "coverage/event"
 
 module Datadog
@@ -32,13 +34,13 @@ module Datadog
         def configure(remote_configuration, test_session)
           Datadog.logger.debug("Configuring ITR Runner with remote configuration: #{remote_configuration}")
 
-          @enabled = convert_to_bool(
+          @enabled = Utils::Parsing.convert_to_bool(
             remote_configuration.fetch(Ext::Transport::DD_API_SETTINGS_RESPONSE_ITR_ENABLED_KEY, false)
           )
-          @test_skipping_enabled = @enabled && convert_to_bool(
+          @test_skipping_enabled = @enabled && Utils::Parsing.convert_to_bool(
             remote_configuration.fetch(Ext::Transport::DD_API_SETTINGS_RESPONSE_TESTS_SKIPPING_KEY, false)
           )
-          @code_coverage_enabled = @enabled && convert_to_bool(
+          @code_coverage_enabled = @enabled && Utils::Parsing.convert_to_bool(
             remote_configuration.fetch(Ext::Transport::DD_API_SETTINGS_RESPONSE_CODE_COVERAGE_KEY, false)
           )
 
@@ -119,10 +121,6 @@ module Datadog
           Datadog.logger.error("Failed to load coverage collector: #{e}. Code coverage will not be collected.")
 
           @code_coverage_enabled = false
-        end
-
-        def convert_to_bool(value)
-          value.to_s == "true"
         end
 
         def ensure_test_source_covered(test_source_file, coverage)

--- a/lib/datadog/ci/transport/remote_settings_api.rb
+++ b/lib/datadog/ci/transport/remote_settings_api.rb
@@ -5,6 +5,7 @@ require "json"
 require "datadog/core/environment/identity"
 
 require_relative "../ext/transport"
+require_relative "../utils/parsing"
 
 module Datadog
   module CI
@@ -37,6 +38,10 @@ module Datadog
               Datadog.logger.error("Failed to parse settings response payload: #{e}. Payload was: #{resp.payload}")
               @json = default_payload
             end
+          end
+
+          def require_git?
+            Utils::Parsing.convert_to_bool(payload[Ext::Transport::DD_API_SETTINGS_RESPONSE_REQUIRE_GIT_KEY])
           end
 
           private

--- a/lib/datadog/ci/utils/parsing.rb
+++ b/lib/datadog/ci/utils/parsing.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "open3"
+require "pathname"
+
+module Datadog
+  module CI
+    module Utils
+      module Parsing
+        def self.convert_to_bool(value)
+          value.to_s.downcase == "true"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -28,8 +28,6 @@ module Datadog
 
         def coverage_collector: () -> Datadog::CI::ITR::Coverage::DDCov?
 
-        def convert_to_bool: (untyped value) -> bool
-
         def load_datadog_cov!: () -> void
 
         def write: (Datadog::CI::ITR::Coverage::Event event) -> void

--- a/sig/datadog/ci/transport/remote_settings_api.rbs
+++ b/sig/datadog/ci/transport/remote_settings_api.rbs
@@ -12,6 +12,8 @@ module Datadog
 
           def payload: () -> Hash[String, untyped]
 
+          def require_git?: () -> bool
+
           private
 
           def default_payload: () -> Hash[String, untyped]

--- a/sig/datadog/ci/utils/parsing.rbs
+++ b/sig/datadog/ci/utils/parsing.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module CI
+    module Utils
+      module Parsing
+        def self.convert_to_bool: (untyped value) -> bool
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/test_visibility/recorder_spec.rb
+++ b/spec/datadog/ci/test_visibility/recorder_spec.rb
@@ -733,41 +733,44 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
     end
 
     context "with ITR" do
-      include_context "CI mode activated" do
-        let(:itr_enabled) { true }
+      context "without require_git in settings response" do
+        include_context "CI mode activated" do
+          let(:itr_enabled) { true }
+          let(:tests_skipping_enabled) { true }
+          let(:code_coverage_enabled) { true }
+        end
+
+        describe "#start_test_session" do
+          let(:service) { "my-service" }
+          let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
+
+          subject { recorder.start_test_session(service: service, tags: tags) }
+
+          it "returns a new CI test_session span with ITR tags" do
+            expect(subject).to be_kind_of(Datadog::CI::TestSession)
+            expect(subject.service).to eq(service)
+
+            expect(subject.skipping_tests?).to be true
+            expect(subject.code_coverage?).to be true
+          end
+        end
       end
 
-      before do
-        settings_http_response = double(
-          "http-response",
-          ok?: true,
-          payload: {
-            "data" => {
-              "attributes" => {
-                "itr_enabled" => true,
-                "tests_skipping" => true,
-                "code_coverage" => true
-              }
-            }
-          }.to_json
-        )
-        allow_any_instance_of(Datadog::CI::Transport::RemoteSettingsApi).to receive(:fetch_library_settings).and_return(
-          Datadog::CI::Transport::RemoteSettingsApi::Response.new(settings_http_response)
-        )
-      end
+      context "with require_git in settings response" do
+        include_context "CI mode activated" do
+          let(:itr_enabled) { true }
+          let(:tests_skipping_enabled) { true }
+          let(:code_coverage_enabled) { true }
+          let(:require_git) { true }
+        end
 
-      describe "#start_test_session" do
-        let(:service) { "my-service" }
-        let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
+        describe "#start_test_session" do
+          let(:service) { "my-service" }
+          let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-        subject { recorder.start_test_session(service: service, tags: tags) }
+          subject { recorder.start_test_session(service: service, tags: tags) }
 
-        it "returns a new CI test_session span with ITR tags" do
-          expect(subject).to be_kind_of(Datadog::CI::TestSession)
-          expect(subject.service).to eq(service)
-
-          expect(subject.skipping_tests?).to be true
-          expect(subject.code_coverage?).to be true
+          it { is_expected.not_to be_skipping_tests }
         end
       end
     end

--- a/spec/datadog/ci/transport/remote_settings_api_spec.rb
+++ b/spec/datadog/ci/transport/remote_settings_api_spec.rb
@@ -73,12 +73,13 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
                     "code_coverage" => true,
                     "tests_skipping" => false,
                     "itr_enabled" => true,
-                    "require_git" => false
+                    "require_git" => require_git
                   }
                 }
               }.to_json
             )
           end
+          let(:require_git) { false }
 
           it "parses the response" do
             expect(response.ok?).to be true
@@ -86,8 +87,17 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
               "code_coverage" => true,
               "tests_skipping" => false,
               "itr_enabled" => true,
-              "require_git" => false
+              "require_git" => require_git
             })
+            expect(response.require_git?).to be false
+          end
+
+          context "when git is required" do
+            let(:require_git) { "True" }
+
+            it "parses the response" do
+              expect(response.require_git?).to be true
+            end
           end
         end
 
@@ -103,6 +113,7 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
           it "parses the response" do
             expect(response.ok?).to be false
             expect(response.payload).to eq("itr_enabled" => false)
+            expect(response.require_git?).to be false
           end
         end
 
@@ -122,6 +133,7 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
           it "parses the response" do
             expect(response.ok?).to be true
             expect(response.payload).to eq("itr_enabled" => false)
+            expect(response.require_git?).to be false
           end
         end
 
@@ -144,6 +156,7 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
           it "parses the response" do
             expect(response.ok?).to be true
             expect(response.payload).to eq("itr_enabled" => false)
+            expect(response.require_git?).to be false
           end
         end
       end
@@ -154,6 +167,7 @@ RSpec.describe Datadog::CI::Transport::RemoteSettingsApi do
         it "returns an empty response" do
           expect(response.ok?).to be false
           expect(response.payload).to eq("itr_enabled" => false)
+          expect(response.require_git?).to be false
         end
       end
     end

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -21,6 +21,7 @@ RSpec.shared_context "CI mode activated" do
   let(:code_coverage_enabled) { false }
   let(:tests_skipping_enabled) { false }
   let(:git_metadata_upload_enabled) { false }
+  let(:require_git) { false }
 
   let(:recorder) { Datadog.send(:components).ci_recorder }
 
@@ -40,7 +41,18 @@ RSpec.shared_context "CI mode activated" do
           "itr_enabled" => itr_enabled,
           "code_coverage" => code_coverage_enabled,
           "tests_skipping" => tests_skipping_enabled
-        }
+        },
+        require_git?: require_git
+      ),
+      # This is for the second call to fetch_library_settings
+      double(
+        "remote_settings_api_response",
+        payload: {
+          "itr_enabled" => itr_enabled,
+          "code_coverage" => !code_coverage_enabled,
+          "tests_skipping" => !tests_skipping_enabled
+        },
+        require_git?: !require_git
       )
     )
 


### PR DESCRIPTION
**What does this PR do?**
Implements default branch code coverage overhead optimization: when server adds with `require_git: true` to the library settings payload, we wait for git upload to be done and then request settings again. The ITR Runner is configured with the second settings payload.

The reason for this is that if default branch does not have many relevant code changes, running per test code coverage won't give us a lot of new information and can be skipped: thus, tests in default branch will run faster without per test code coverage overhead.

**How to test the change?**
Unit tests are provided