### PR TITLE
[CIVIS-2934] ITR test skipping implementation

### DIFF
--- a/datadog-ci.gemspec
+++ b/datadog-ci.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "datadog", "~> 2.0.0.beta1"
+  spec.add_dependency "datadog", "~> 2.0.0.beta2"
   spec.add_dependency "msgpack"
 
   spec.extensions = ["ext/datadog_cov/extconf.rb"]

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,7 +29,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +27,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,7 +57,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +51,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7-java)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,7 +53,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.1-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
+    libdatadog (7.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,8 +34,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,14 +18,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,8 +34,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -19,14 +19,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -37,8 +35,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,8 +43,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,15 +14,13 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -31,8 +29,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,14 +13,12 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     ci-queue (0.47.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,8 +27,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -14,7 +14,6 @@ GEM
       thor (>= 0.14.0)
     ast (2.4.2)
     backports (3.25.0)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -34,10 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -47,8 +45,8 @@ GEM
     gherkin (5.1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -50,10 +49,9 @@ GEM
       cucumber-core (~> 7.0, >= 7.0.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.1, >= 12.1.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -64,8 +62,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -54,10 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -68,8 +66,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -18,7 +18,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -55,10 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -69,8 +67,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -47,10 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -59,8 +57,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     builder (3.2.4)
     climate_control (1.2.0)
     coderay (1.1.3)
@@ -41,10 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,8 +51,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,7 +13,6 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
     climate_control (1.2.0)
@@ -43,10 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -55,8 +53,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,8 +26,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -29,10 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -44,8 +43,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta1)
-      datadog (~> 2.0.0.beta1)
+      datadog (~> 2.0.0.beta2)
       msgpack
 
 GEM
@@ -13,13 +13,11 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    base64 (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta1)
-      base64
+    datadog (2.0.0.beta2)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 6.0.0.2.0)
+      libdatadog (~> 7.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,8 +26,8 @@ GEM
     ffi (1.16.3)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    libdatadog (6.0.0.2.0)
-    libdatadog (6.0.0.2.0-aarch64-linux)
+    libdatadog (7.0.0.1.0)
+    libdatadog (7.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/lib/datadog/ci/contrib/cucumber/formatter.rb
+++ b/lib/datadog/ci/contrib/cucumber/formatter.rb
@@ -54,16 +54,6 @@ module Datadog
           end
 
           def on_test_case_started(event)
-            ::Cucumber::Core::Test::Step.class_eval do
-              def execute(*args)
-                test_span = CI.active_test
-                if test_span&.skipped_by_itr?
-                  @action.skip(*args)
-                else
-                  @action.execute(*args)
-                end
-              end
-            end
             test_suite_name = test_suite_name(event.test_case)
 
             # @type var tags: Hash[String, String]

--- a/lib/datadog/ci/contrib/cucumber/patcher.rb
+++ b/lib/datadog/ci/contrib/cucumber/patcher.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "datadog/tracing/contrib/patcher"
+
 require_relative "instrumentation"
+require_relative "step"
 
 module Datadog
   module CI
@@ -19,6 +21,7 @@ module Datadog
 
           def patch
             ::Cucumber::Runtime.include(Instrumentation)
+            ::Cucumber::Core::Test::Step.include(Datadog::CI::Contrib::Cucumber::Step)
           end
         end
       end

--- a/lib/datadog/ci/contrib/cucumber/step.rb
+++ b/lib/datadog/ci/contrib/cucumber/step.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module Contrib
+      module Cucumber
+        # instruments Cucumber::Core::Test::Step from cucumber-ruby-core to change
+        module Step
+          def self.included(base)
+            base.prepend(InstanceMethods)
+          end
+
+          module InstanceMethods
+            def execute(*args)
+              test_span = CI.active_test
+              if test_span&.skipped_by_itr?
+                @action.skip(*args)
+              else
+                super
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -25,7 +25,7 @@ module Datadog
 
             source_file, line_number = method(name).source_location
 
-            CI.start_test(
+            test_span = CI.start_test(
               name,
               test_suite_name,
               tags: {
@@ -36,6 +36,7 @@ module Datadog
               },
               service: datadog_configuration[:service_name]
             )
+            skip("skipped by ITR") if test_span&.skipped_by_itr?
           end
 
           def after_teardown

--- a/lib/datadog/ci/contrib/minitest/hooks.rb
+++ b/lib/datadog/ci/contrib/minitest/hooks.rb
@@ -36,7 +36,7 @@ module Datadog
               },
               service: datadog_configuration[:service_name]
             )
-            skip("skipped by ITR") if test_span&.skipped_by_itr?
+            skip(CI::Ext::Test::ITR_TEST_SKIP_REASON) if test_span&.skipped_by_itr?
           end
 
           def after_teardown

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -46,9 +46,9 @@ module Datadog
                 },
                 service: datadog_configuration[:service_name]
               ) do |test_span|
-                result = super
-
                 test_span&.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
+
+                result = super
 
                 case execution_result.status
                 when :passed

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -2,6 +2,7 @@
 
 require_relative "../../ext/test"
 require_relative "../../git/local_repository"
+require_relative "../../utils/test_run"
 require_relative "ext"
 
 module Datadog
@@ -42,11 +43,14 @@ module Datadog
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s,
                   CI::Ext::Test::TAG_SOURCE_FILE => Git::LocalRepository.relative_to_root(metadata[:file_path]),
-                  CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s
+                  CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s,
+                  CI::Ext::Test::TAG_PARAMETERS => Utils::TestRun.test_parameters(
+                    metadata: {"scoped_id" => metadata[:scoped_id]}
+                  )
                 },
                 service: datadog_configuration[:service_name]
               ) do |test_span|
-                test_span&.set_parameters({}, {"scoped_id" => metadata[:scoped_id]})
+                metadata[:skip] = CI::Ext::Test::ITR_TEST_SKIP_REASON if test_span&.skipped_by_itr?
 
                 result = super
 

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -27,7 +27,7 @@ module Datadog
         TAG_ITR_TEST_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled"
         TAG_ITR_TEST_SKIPPING_TYPE = "test.itr.tests_skipping.type"
         TAG_ITR_TEST_SKIPPING_COUNT = "test.itr.tests_skipping.count"
-        TAG_ITR_SKIPPED_BY_ITR = "test.itr.skipped_by_itr"
+        TAG_ITR_SKIPPED_BY_ITR = "test.skipped_by_itr"
         TAG_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped"
 
         # Code coverage tags

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -26,7 +26,9 @@ module Datadog
         # ITR tags
         TAG_ITR_TEST_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled"
         TAG_ITR_TEST_SKIPPING_TYPE = "test.itr.tests_skipping.type"
+        TAG_ITR_TEST_SKIPPING_COUNT = "test.itr.tests_skipping.count"
         TAG_ITR_SKIPPED_BY_ITR = "test.itr.skipped_by_itr"
+        TAG_ITR_TESTS_SKIPPED = "_dd.ci.itr.tests_skipped"
 
         # Code coverage tags
         TAG_CODE_COVERAGE_ENABLED = "test.code_coverage.enabled"

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -26,6 +26,7 @@ module Datadog
         # ITR tags
         TAG_ITR_TEST_SKIPPING_ENABLED = "test.itr.tests_skipping.enabled"
         TAG_ITR_TEST_SKIPPING_TYPE = "test.itr.tests_skipping.type"
+        TAG_ITR_SKIPPED_BY_ITR = "test.itr.skipped_by_itr"
 
         # Code coverage tags
         TAG_CODE_COVERAGE_ENABLED = "test.code_coverage.enabled"

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -57,6 +57,7 @@ module Datadog
         # could be either "test" or "suite" depending on whether we skip individual tests or whole suites
         # we use test skipping for Ruby
         ITR_TEST_SKIPPING_MODE = "test"
+        ITR_TEST_SKIP_REASON = "Skipped by Datadog's intelligent test runner"
 
         # test status as recognized by Datadog
         module Status

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -125,7 +125,7 @@ module Datadog
         def mark_if_skippable(test)
           return if !enabled? || !skipping_tests?
 
-          skippable_test_id = Utils::TestRun.test_full_name(test.name, test.test_suite_name, test.parameters)
+          skippable_test_id = Utils::TestRun.skippable_test_id(test.name, test.test_suite_name, test.parameters)
           if @skippable_tests.include?(skippable_test_id)
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
 

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -91,7 +91,6 @@ module Datadog
 
         def start_coverage(test)
           return if !enabled? || !code_coverage?
-          return if test.skipped_by_itr?
 
           coverage_collector&.start
         end
@@ -102,7 +101,7 @@ module Datadog
           coverage = coverage_collector&.stop
           return if coverage.nil? || coverage.empty?
 
-          return if test.skipped? || test.skipped_by_itr?
+          return if test.skipped?
 
           test_source_file = test.source_file
 

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -149,6 +149,13 @@ module Datadog
           end
         end
 
+        def write_test_session_tags(test_session)
+          return if !enabled?
+
+          test_session.set_tag(Ext::Test::TAG_ITR_TESTS_SKIPPED, @skipped_tests_count.positive?.to_s)
+          test_session.set_tag(Ext::Test::TAG_ITR_TEST_SKIPPING_COUNT, @skipped_tests_count)
+        end
+
         def shutdown!
           @coverage_writer&.stop
         end

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -129,7 +129,6 @@ module Datadog
 
           if @skippable_tests.include?(test_full_name)
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
-            increment_skipped_tests_counter
 
             Datadog.logger.debug { "Marked test as skippable: #{test_full_name}" }
           else
@@ -137,11 +136,13 @@ module Datadog
           end
         end
 
-        def increment_skipped_tests_counter
+        def count_skipped_test(test)
           if forked?
             Datadog.logger.warn { "ITR is not supported for forking test runners yet" }
             return
           end
+
+          return if !test.skipped? || !test.skipped_by_itr?
 
           @mutex.synchronize do
             @skipped_tests_count += 1

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -125,14 +125,13 @@ module Datadog
         def mark_if_skippable(test)
           return if !enabled? || !skipping_tests?
 
-          test_full_name = Utils::TestRun.test_full_name(test.name, test.test_suite_name)
-
-          if @skippable_tests.include?(test_full_name)
+          skippable_test_id = Utils::TestRun.test_full_name(test.name, test.test_suite_name, test.parameters)
+          if @skippable_tests.include?(skippable_test_id)
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
 
-            Datadog.logger.debug { "Marked test as skippable: #{test_full_name}" }
+            Datadog.logger.debug { "Marked test as skippable: #{skippable_test_id}" }
           else
-            Datadog.logger.debug { "Test is not skippable: #{test_full_name}" }
+            Datadog.logger.debug { "Test is not skippable: #{skippable_test_id}" }
           end
         end
 

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -89,8 +89,9 @@ module Datadog
           @code_coverage_enabled
         end
 
-        def start_coverage
+        def start_coverage(test)
           return if !enabled? || !code_coverage?
+          return if test.skipped_by_itr?
 
           coverage_collector&.start
         end
@@ -99,7 +100,9 @@ module Datadog
           return if !enabled? || !code_coverage?
 
           coverage = coverage_collector&.stop
-          return if coverage.nil?
+          return if coverage.nil? || coverage.empty?
+
+          return if test.skipped? || test.skipped_by_itr?
 
           test_source_file = test.source_file
 
@@ -121,7 +124,7 @@ module Datadog
         end
 
         def mark_if_skippable(test)
-          return unless enabled? && skipping_tests?
+          return if !enabled? || !skipping_tests?
 
           test_full_name = Utils::TestRun.test_full_name(test.name, test.test_suite_name)
 

--- a/lib/datadog/ci/itr/skippable.rb
+++ b/lib/datadog/ci/itr/skippable.rb
@@ -33,7 +33,7 @@ module Datadog
                 next unless test_data["type"] == Ext::Test::ITR_TEST_SKIPPING_MODE
 
                 attrs = test_data["attributes"] || {}
-                res << Utils::TestRun.test_full_name(attrs["name"], attrs["suite"])
+                res << Utils::TestRun.test_full_name(attrs["name"], attrs["suite"], attrs["parameters"])
               end
 
             res

--- a/lib/datadog/ci/itr/skippable.rb
+++ b/lib/datadog/ci/itr/skippable.rb
@@ -33,7 +33,7 @@ module Datadog
                 next unless test_data["type"] == Ext::Test::ITR_TEST_SKIPPING_MODE
 
                 attrs = test_data["attributes"] || {}
-                res << Utils::TestRun.test_full_name(attrs["name"], attrs["suite"], attrs["parameters"])
+                res << Utils::TestRun.skippable_test_id(attrs["name"], attrs["suite"], attrs["parameters"])
               end
 
             res

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -95,7 +95,7 @@ module Datadog
         record_test_result(Ext::Test::Status::SKIP)
       end
 
-      # Sets the parameters for this test (e.g. Cucumber example or RSpec shared specs).
+      # Sets the parameters for this test (e.g. Cucumber example or RSpec specs).
       # Parameters are needed to compute test fingerprint to distinguish between different tests having same names.
       #
       # @param [Hash] arguments the arguments that test accepts as key-value hash
@@ -113,6 +113,14 @@ module Datadog
             }
           )
         )
+      end
+
+      # Gets the parameters for this test (e.g. Cucumber example or RSpec specs) as a serialized JSON.
+      #
+      # @return [String] the serialized JSON of the parameters
+      # @return [nil] if this test does not have parameters
+      def parameters
+        get_tag(Ext::Test::TAG_PARAMETERS)
       end
 
       private

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -62,6 +62,12 @@ module Datadog
         get_tag(Ext::Test::TAG_SOURCE_FILE)
       end
 
+      # Returns "true" if the test is skipped by the ITR.
+      # @return [Boolean] true if the test is skipped by the ITR, false otherwise.
+      def skipped_by_itr?
+        get_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR) == "true"
+      end
+
       # Sets the status of the span to "pass".
       # @return [void]
       def passed!

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -62,8 +62,8 @@ module Datadog
         get_tag(Ext::Test::TAG_SOURCE_FILE)
       end
 
-      # Returns "true" if the test is skipped by the ITR.
-      # @return [Boolean] true if the test is skipped by the ITR, false otherwise.
+      # Returns "true" if the test is skipped by the intelligent test runner.
+      # @return [Boolean] true if the test is skipped by the intelligent test runner, false otherwise.
       def skipped_by_itr?
         get_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR) == "true"
       end

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -3,6 +3,7 @@
 require "json"
 
 require_relative "span"
+require_relative "utils/test_run"
 
 module Datadog
   module CI
@@ -104,15 +105,7 @@ module Datadog
       def set_parameters(arguments, metadata = {})
         return if arguments.nil?
 
-        set_tag(
-          Ext::Test::TAG_PARAMETERS,
-          JSON.generate(
-            {
-              arguments: arguments,
-              metadata: metadata
-            }
-          )
-        )
+        set_tag(Ext::Test::TAG_PARAMETERS, Utils::TestRun.test_parameters(arguments: arguments, metadata: metadata))
       end
 
       # Gets the parameters for this test (e.g. Cucumber example or RSpec specs) as a serialized JSON.

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -18,9 +18,9 @@ module Datadog
       # Finishes the current test.
       # @return [void]
       def finish
-        super
-
         recorder.deactivate_test
+
+        super
       end
 
       # Running test suite that this test is part of (if any).

--- a/lib/datadog/ci/test_module.rb
+++ b/lib/datadog/ci/test_module.rb
@@ -14,9 +14,9 @@ module Datadog
       # Finishes this test module.
       # @return [void]
       def finish
-        super
-
         recorder.deactivate_test_module
+
+        super
       end
     end
   end

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -15,9 +15,9 @@ module Datadog
       # Finishes the current test session.
       # @return [void]
       def finish
-        super
-
         recorder.deactivate_test_session
+
+        super
       end
 
       # Return the test session's name which is equal to test command used

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -26,9 +26,9 @@ module Datadog
           # we try to derive test suite status from execution stats if no status was set explicitly
           set_status_from_stats! if undefined?
 
-          super
-
           recorder.deactivate_test_suite(name)
+
+          super
         end
       end
 

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -398,6 +398,7 @@ module Datadog
         # TODO: use kind of event system to notify about test finished?
         def on_test_finished(test)
           @itr.stop_coverage(test)
+          @itr.count_skipped_test(test)
         end
 
         def on_test_started(test)

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -191,6 +191,9 @@ module Datadog
         end
 
         def deactivate_test_session
+          test_session = active_test_session
+          on_test_session_finished(test_session) if test_session
+
           @global_context.deactivate_test_session!
         end
 
@@ -404,6 +407,10 @@ module Datadog
         def on_test_started(test)
           @itr.mark_if_skippable(test)
           @itr.start_coverage(test)
+        end
+
+        def on_test_session_finished(test_session)
+          @itr.write_test_session_tags(test_session)
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -127,21 +127,18 @@ module Datadog
               test = build_test(tracer_span, tags)
 
               @local_context.activate_test(test) do
-                @itr.start_coverage
-
+                on_test_started(test)
                 res = block.call(test)
                 on_test_finished(test)
-
                 res
               end
             end
           else
             tracer_span = start_datadog_tracer_span(test_name, span_options)
-
             test = build_test(tracer_span, tags)
 
             @local_context.activate_test(test)
-            @itr.start_coverage
+            on_test_started(test)
 
             test
           end
@@ -401,6 +398,11 @@ module Datadog
         # TODO: use kind of event system to notify about test finished?
         def on_test_finished(test)
           @itr.stop_coverage(test)
+        end
+
+        def on_test_started(test)
+          @itr.mark_if_skippable(test)
+          @itr.start_coverage
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/recorder.rb
+++ b/lib/datadog/ci/test_visibility/recorder.rb
@@ -402,7 +402,7 @@ module Datadog
 
         def on_test_started(test)
           @itr.mark_if_skippable(test)
-          @itr.start_coverage
+          @itr.start_coverage(test)
         end
       end
     end

--- a/lib/datadog/ci/utils/test_run.rb
+++ b/lib/datadog/ci/utils/test_run.rb
@@ -10,8 +10,8 @@ module Datadog
           @command = "#{$0} #{ARGV.join(" ")}"
         end
 
-        def self.test_full_name(test_name, suite)
-          "#{suite}.#{test_name}"
+        def self.test_full_name(test_name, suite, parameters = nil)
+          "#{suite}.#{test_name}.#{parameters}"
         end
       end
     end

--- a/lib/datadog/ci/utils/test_run.rb
+++ b/lib/datadog/ci/utils/test_run.rb
@@ -13,6 +13,15 @@ module Datadog
         def self.test_full_name(test_name, suite, parameters = nil)
           "#{suite}.#{test_name}.#{parameters}"
         end
+
+        def self.test_parameters(arguments: {}, metadata: {})
+          JSON.generate(
+            {
+              arguments: arguments,
+              metadata: metadata
+            }
+          )
+        end
       end
     end
   end

--- a/lib/datadog/ci/utils/test_run.rb
+++ b/lib/datadog/ci/utils/test_run.rb
@@ -10,7 +10,7 @@ module Datadog
           @command = "#{$0} #{ARGV.join(" ")}"
         end
 
-        def self.test_full_name(test_name, suite, parameters = nil)
+        def self.skippable_test_id(test_name, suite, parameters = nil)
           "#{suite}.#{test_name}.#{parameters}"
         end
 

--- a/sig/datadog/ci/contrib/cucumber/step.rbs
+++ b/sig/datadog/ci/contrib/cucumber/step.rbs
@@ -1,0 +1,16 @@
+module Datadog
+  module CI
+    module Contrib
+      module Cucumber
+        module Step
+          def self.included: (untyped base) -> untyped
+
+          module InstanceMethods
+            prepend ::Cucumber::Core::Test::Step
+            def execute: (*untyped args) -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -70,6 +70,8 @@ module Datadog
 
         ITR_TEST_SKIPPING_MODE: "test"
 
+        ITR_TEST_SKIP_REASON: String
+
         module Status
           PASS: "pass"
 

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -36,6 +36,8 @@ module Datadog
 
         TAG_ITR_TEST_SKIPPING_TYPE: "test.itr.tests_skipping.type"
 
+        TAG_ITR_SKIPPED_BY_ITR: "test.itr.skipped_by_itr"
+
         TAG_CODE_COVERAGE_ENABLED: "test.code_coverage.enabled"
 
         TAG_TEST_SESSION_ID: "_test.session_id"

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -36,7 +36,11 @@ module Datadog
 
         TAG_ITR_TEST_SKIPPING_TYPE: "test.itr.tests_skipping.type"
 
+        TAG_ITR_TEST_SKIPPING_COUNT: "test.itr.tests_skipping.count"
+
         TAG_ITR_SKIPPED_BY_ITR: "test.itr.skipped_by_itr"
+
+        TAG_ITR_TESTS_SKIPPED: "_dd.ci.itr.tests_skipped"
 
         TAG_CODE_COVERAGE_ENABLED: "test.code_coverage.enabled"
 

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -38,7 +38,7 @@ module Datadog
 
         TAG_ITR_TEST_SKIPPING_COUNT: "test.itr.tests_skipping.count"
 
-        TAG_ITR_SKIPPED_BY_ITR: "test.itr.skipped_by_itr"
+        TAG_ITR_SKIPPED_BY_ITR: "test.skipped_by_itr"
 
         TAG_ITR_TESTS_SKIPPED: "_dd.ci.itr.tests_skipped"
 

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -33,6 +33,8 @@ module Datadog
 
         def mark_if_skippable: (Datadog::CI::Test test) -> void
 
+        def count_skipped_test: (Datadog::CI::Test test) -> void
+
         def shutdown!: () -> void
 
         private

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -27,7 +27,7 @@ module Datadog
 
         def code_coverage?: () -> bool
 
-        def start_coverage: () -> void
+        def start_coverage: (Datadog::CI::Test test) -> void
 
         def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::ITR::Coverage::Event?
 

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -2,15 +2,20 @@ module Datadog
   module CI
     module ITR
       class Runner
+        include Datadog::Core::Utils::Forking
+
         @enabled: bool
         @test_skipping_enabled: bool
         @code_coverage_enabled: bool
         @correlation_id: String
-        @skippable_tests: Array[Datadog::CI::ITR::Skippable::Test]
+        @skippable_tests: Array[String]
         @coverage_writer: Datadog::CI::ITR::Coverage::Writer?
 
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?
+
+        @skipped_tests_count: Integer
+        @mutex: Thread::Mutex
 
         def initialize: (dd_env: String?, ?enabled: bool, coverage_writer: Datadog::CI::ITR::Coverage::Writer?, api: Datadog::CI::Transport::Api::Base?) -> void
 
@@ -26,6 +31,8 @@ module Datadog
 
         def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::ITR::Coverage::Event?
 
+        def mark_if_skippable: (Datadog::CI::Test test) -> void
+
         def shutdown!: () -> void
 
         private
@@ -39,6 +46,8 @@ module Datadog
         def ensure_test_source_covered: (String test_source_file, Hash[String, untyped] coverage) -> void
 
         def fetch_skippable_tests: (test_session: Datadog::CI::TestSession, git_tree_upload_worker: Datadog::CI::Worker) -> void
+
+        def increment_skipped_tests_counter: () -> void
       end
     end
   end

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -35,6 +35,8 @@ module Datadog
 
         def count_skipped_test: (Datadog::CI::Test test) -> void
 
+        def write_test_session_tags: (Datadog::CI::TestSession test_session) -> void
+
         def shutdown!: () -> void
 
         private

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -7,6 +7,7 @@ module Datadog
       def test_suite_name: () -> String?
       def test_module_id: () -> String?
       def test_session_id: () -> String?
+      def skipped_by_itr?: () -> bool
       def source_file: () -> String?
 
       private

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -9,6 +9,7 @@ module Datadog
       def test_session_id: () -> String?
       def skipped_by_itr?: () -> bool
       def source_file: () -> String?
+      def parameters: () -> String?
 
       private
 

--- a/sig/datadog/ci/test_visibility/recorder.rbs
+++ b/sig/datadog/ci/test_visibility/recorder.rbs
@@ -93,6 +93,8 @@ module Datadog
         def validate_test_suite_level_visibility_correctness: (Datadog::CI::Test test) -> void
 
         def on_test_finished: (Datadog::CI::Test test) -> void
+
+        def on_test_started: (Datadog::CI::Test test) -> void
       end
     end
   end

--- a/sig/datadog/ci/test_visibility/recorder.rbs
+++ b/sig/datadog/ci/test_visibility/recorder.rbs
@@ -95,6 +95,8 @@ module Datadog
         def on_test_finished: (Datadog::CI::Test test) -> void
 
         def on_test_started: (Datadog::CI::Test test) -> void
+
+        def on_test_session_finished: (Datadog::CI::TestSession test_session) -> void
       end
     end
   end

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         def self.command: () -> String
 
-        def self.test_full_name: (String test_name, String? test_suite, ?String? parameters) -> String
+        def self.skippable_test_id: (String test_name, String? test_suite, ?String? parameters) -> String
 
         def self.test_parameters: (?arguments: Hash[untyped, untyped], ?metadata: Hash[untyped, untyped]) -> String
       end

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         def self.command: () -> String
 
-        def self.test_full_name: (String test_name, String test_suite) -> String
+        def self.test_full_name: (String test_name, String? test_suite) -> String
       end
     end
   end

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -6,7 +6,7 @@ module Datadog
 
         def self.command: () -> String
 
-        def self.test_full_name: (String test_name, String? test_suite) -> String
+        def self.test_full_name: (String test_name, String? test_suite, ?String? parameters) -> String
       end
     end
   end

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -7,6 +7,8 @@ module Datadog
         def self.command: () -> String
 
         def self.test_full_name: (String test_name, String? test_suite, ?String? parameters) -> String
+
+        def self.test_parameters: (?arguments: Hash[untyped, untyped], ?metadata: Hash[untyped, untyped]) -> String
       end
     end
   end

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -29,8 +29,6 @@ RSpec.describe Datadog::CI::Configuration::Components do
     end
 
     after do
-      components.telemetry.worker.stop(true)
-      components.telemetry.worker.join
       components.shutdown!
     end
 

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Cucumber formatter" do
 
     let(:itr_enabled) { true }
     let(:code_coverage_enabled) { true }
+    let(:tests_skipping_enabled) { true }
   end
 
   let(:cucumber_8_or_above) { Gem::Version.new("8.0.0") <= Datadog::CI::Contrib::Cucumber::Integration.version }
@@ -204,6 +205,20 @@ RSpec.describe "Cucumber formatter" do
           match(%r{features/passing\.feature}),
           match(%r{features/step_definitions/steps_#{run_id}\.rb})
         )
+      end
+    end
+
+    context "skipping a test" do
+      let(:itr_skippable_tests) do
+        Set.new([
+          "Datadog integration at spec/datadog/ci/contrib/cucumber/features/passing.feature.cucumber scenario."
+        ])
+      end
+
+      it "skips the test" do
+        expect(test_spans).to have(4).items
+        p test_spans.map { |span| span.get_tag("test.status") }
+        # expect(test_spans).to all have_skip_status
       end
     end
   end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -217,8 +217,7 @@ RSpec.describe "Cucumber formatter" do
 
       it "skips the test" do
         expect(test_spans).to have(4).items
-        p test_spans.map { |span| span.get_tag("test.status") }
-        # expect(test_spans).to all have_skip_status
+        expect(test_spans).to all have_skip_status
       end
     end
   end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -189,12 +189,12 @@ RSpec.describe "Cucumber formatter" do
     context "collecting coverage with features dir as root" do
       before { skip if PlatformHelpers.jruby? }
 
-      it "creates coverage events for each test" do
-        expect(coverage_events).to have(4).items
+      it "creates coverage events for each non-skipped test" do
+        expect(coverage_events).to have(1).item
 
         expect_coverage_events_belong_to_session(test_session_span)
         expect_coverage_events_belong_to_suite(first_test_suite_span)
-        expect_coverage_events_belong_to_tests(test_spans)
+        expect_coverage_events_belong_to_tests([test_spans.first])
         expect_non_empty_coverages
 
         feature_coverage = coverage_events.first.coverage

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -738,7 +738,7 @@ RSpec.describe "Minitest instrumentation" do
             expect(skipped).to all have_test_tag(:itr_skipped_by_itr, "true")
           end
 
-          it "send test session level tags" do
+          it "sends test session level tags" do
             expect(test_session_span).to have_test_tag(:itr_test_skipping_enabled, "true")
             expect(test_session_span).to have_test_tag(:itr_test_skipping_type, "test")
             expect(test_session_span).to have_test_tag(:itr_tests_skipped, "true")

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -735,7 +735,7 @@ RSpec.describe "Minitest instrumentation" do
             expect(test_spans).to have_tag_values_no_order(:status, ["skip", "skip", "skip", "pass"])
 
             skipped = test_spans.select { |span| span.get_tag("status") == "skip" }
-            expect(skipped).to
+            expect(skipped).to all have_test_tag(:itr_skipped_by_itr, "true")
           end
 
           it "send test session level tags" do

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -499,7 +499,7 @@ RSpec.describe "Minitest instrumentation" do
         context "when ITR skips tests" do
           context "single skipped test" do
             let(:itr_skippable_tests) do
-              Set.new(["SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass"])
+              Set.new(["SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass."])
             end
 
             it "skips a single test" do
@@ -522,8 +522,8 @@ RSpec.describe "Minitest instrumentation" do
             let(:itr_skippable_tests) do
               Set.new(
                 [
-                  "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass",
-                  "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass_other"
+                  "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass.",
+                  "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass_other."
                 ]
               )
             end
@@ -723,9 +723,9 @@ RSpec.describe "Minitest instrumentation" do
           let(:itr_skippable_tests) do
             Set.new(
               [
-                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_1 concurrently).test_a_1",
-                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_2 concurrently).test_a_2",
-                "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_b_2 concurrently).test_b_2"
+                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_1 concurrently).test_a_1.",
+                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_2 concurrently).test_a_2.",
+                "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_b_2 concurrently).test_b_2."
               ]
             )
           end

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -295,6 +295,8 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
   end
 
   context "with shallow clone" do
+    before { skip("temporariliy skipped until development returns to main") }
+
     let(:tmpdir) { Dir.mktmpdir }
     after { FileUtils.remove_entry(tmpdir) }
 

--- a/spec/datadog/ci/itr/runner_spec.rb
+++ b/spec/datadog/ci/itr/runner_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
     context "test is skipped by ITR" do
       let(:test_span) do
         Datadog::CI::Test.new(
-          Datadog::Tracing::SpanOperation.new("test", tags: {"test.status" => "skip", "test.itr.skipped_by_itr" => "true"})
+          Datadog::Tracing::SpanOperation.new("test", tags: {"test.status" => "skip", "test.skipped_by_itr" => "true"})
         )
       end
 
@@ -370,7 +370,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
       context "when tests were skipped" do
         let(:test_span) do
           Datadog::CI::Test.new(
-            Datadog::Tracing::SpanOperation.new("test", tags: {"test.status" => "skip", "test.itr.skipped_by_itr" => "true"})
+            Datadog::Tracing::SpanOperation.new("test", tags: {"test.status" => "skip", "test.skipped_by_itr" => "true"})
           )
         end
 

--- a/spec/datadog/ci/itr/runner_spec.rb
+++ b/spec/datadog/ci/itr/runner_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
           fetch_skippable_tests: instance_double(
             Datadog::CI::ITR::Skippable::Response,
             correlation_id: "42",
-            tests: Set.new(["suite.test"])
+            tests: Set.new(["suite.test."])
           )
         )
       end
@@ -77,7 +77,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
         expect(runner.skipping_tests?).to be true
 
         expect(runner.correlation_id).to eq("42")
-        expect(runner.skippable_tests).to eq(Set.new(["suite.test"]))
+        expect(runner.skippable_tests).to eq(Set.new(["suite.test."]))
 
         expect(git_worker).to have_received(:wait_until_done)
       end
@@ -233,7 +233,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
           fetch_skippable_tests: instance_double(
             Datadog::CI::ITR::Skippable::Response,
             correlation_id: "42",
-            tests: Set.new(["suite.test", "suite2.test", "suite.test3"])
+            tests: Set.new(["suite.test.", "suite2.test.", "suite.test3."])
           )
         )
       end

--- a/spec/datadog/ci/itr/runner_spec.rb
+++ b/spec/datadog/ci/itr/runner_spec.rb
@@ -153,16 +153,6 @@ RSpec.describe Datadog::CI::ITR::Runner do
         coverage_event = runner.stop_coverage(test_span)
         expect(coverage_event.coverage.size).to be > 0
       end
-
-      context "when test is skipped by ITR" do
-        it "does not start coverage" do
-          test_span.set_tag(Datadog::CI::Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
-
-          expect(runner).not_to receive(:coverage_collector)
-
-          runner.start_coverage(test_span)
-        end
-      end
     end
 
     context "when JRuby and code coverage is enabled" do
@@ -212,17 +202,6 @@ RSpec.describe Datadog::CI::ITR::Runner do
     end
 
     context "when test is skipped" do
-      it "does not write coverage event" do
-        runner.start_coverage(test_span)
-        expect(1 + 1).to eq(2)
-        test_span.set_tag(Datadog::CI::Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
-
-        expect(runner.stop_coverage(test_span)).to be_nil
-        expect(writer).not_to have_received(:write)
-      end
-    end
-
-    context "when test is skipped by ITR" do
       it "does not write coverage event" do
         runner.start_coverage(test_span)
         expect(1 + 1).to eq(2)

--- a/spec/datadog/ci/itr/skippable_spec.rb
+++ b/spec/datadog/ci/itr/skippable_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe Datadog::CI::ITR::Skippable do
           it "parses the response" do
             expect(response.ok?).to be true
             expect(response.correlation_id).to eq("correlation_id_123")
-            expect(response.tests).to eq(Set.new(["test_suite_name.test_name"]))
+            expect(response.tests).to eq(Set.new(["test_suite_name.test_name.string"]))
           end
         end
 

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -99,6 +99,26 @@ RSpec.describe Datadog::CI::Test do
     it { is_expected.to eq("foo/bar.rb") }
   end
 
+  describe "#skipped_by_itr?" do
+    subject(:skipped_by_itr) { ci_test.skipped_by_itr? }
+
+    context "when tag is set" do
+      before do
+        allow(tracer_span).to(
+          receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_ITR_SKIPPED_BY_ITR).and_return("true")
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when tag is not set" do
+      before { allow(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_ITR_SKIPPED_BY_ITR).and_return(nil) }
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#set_parameters" do
     let(:parameters) { {"foo" => "bar", "baz" => "qux"} }
 

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -209,4 +209,16 @@ RSpec.describe Datadog::CI::Test do
       end
     end
   end
+
+  describe "#parameters" do
+    let(:parameters) { JSON.generate({arguments: {"foo" => "bar", "baz" => "qux"}, metadata: {}}) }
+
+    before do
+      allow(tracer_span).to receive(:get_tag).with("test.parameters").and_return(parameters)
+    end
+
+    it "returns the parameters" do
+      expect(ci_test.parameters).to eq(parameters)
+    end
+  end
 end

--- a/spec/datadog/ci/utils/test_run_spec.rb
+++ b/spec/datadog/ci/utils/test_run_spec.rb
@@ -6,4 +6,32 @@ RSpec.describe ::Datadog::CI::Utils::TestRun do
 
     it { is_expected.to eq("#{$0} #{ARGV.join(" ")}") }
   end
+
+  describe ".skippable_test_id" do
+    subject { described_class.skippable_test_id(test_name, suite, parameters) }
+
+    let(:test_name) { "test_name" }
+    let(:suite) { "suite" }
+    let(:parameters) { "parameters" }
+
+    it { is_expected.to eq("suite.test_name.parameters") }
+  end
+
+  describe ".test_parameters" do
+    subject { described_class.test_parameters(arguments: arguments, metadata: metadata) }
+
+    let(:arguments) { {} }
+    let(:metadata) { {} }
+
+    it "returns a JSON string" do
+      is_expected.to eq(
+        JSON.generate(
+          {
+            arguments: arguments,
+            metadata: metadata
+          }
+        )
+      )
+    end
+  end
 end

--- a/vendor/rbs/cucumber/0/cucumber.rbs
+++ b/vendor/rbs/cucumber/0/cucumber.rbs
@@ -25,6 +25,11 @@ class Cucumber::Core::Test::Result
   def exception: () -> untyped
 end
 
+module Cucumber::Core::Test::Step
+  @action: untyped
+  def execute: (untyped args) -> untyped
+end
+
 class Cucumber::Formatter::AstLookup
   def initialize: (untyped config) -> void
 


### PR DESCRIPTION
**What does this PR do?**
- Adds actual test skipping by ITR for minitest, rspec, cucumber with unit tests
- Adds test.parameters support to skippable tests logic
- Updates datadog dependency to 2.0.0.beta2 and solves test failures related to it

**How to test the change?**
Tested on DD staging.

**Results for Rubocop:**
<img width="1294" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/5d5c45a1-6f04-463f-9d48-14f389498fd3">


**Results for sidekiq:**
<img width="1303" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/aa933b9b-d50f-4861-b7f2-b4df315aa891">
