### PR TITLE
[CIVIS-2985] upgrade guide for 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ end
 
 Startup logs produce a report of tracing state when the application is initially configured.
 These logs are activated by default in test mode, if you don't want them you can disable this
-via `DD_TRACE_STARTUP_LOGS=0` or in the configure block:
+via `DD_TRACE_STARTUP_LOGS=0` or in the `Datadog.configure` block:
 
 ```ruby
 Datadog.configure { |c| c.diagnostics.startup_logs.enabled = false }

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ or other external calls like here:
 
 ![Test trace with redis instrumented](./docs/screenshots/test-trace-with-redis.png)
 
-In order to achieve this you can configure Datadog tracing instrumentations in your configure block:
+To achieve this, add Datadog tracing instrumentations in your `Datadog.configure` block:
 
 ```ruby
 Datadog.configure do |c|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ end
 
 ## Upgrade from ddtrace v1.x
 
-If you used test visibility for Ruby with ddtrace gem, check out our [upgrade guide](/docs/UpgradeGuide.md).
+If you used [test visibility for Ruby](https://docs.datadoghq.com/tests/setup/ruby/) with [ddtrace](https://github.com/datadog/dd-trace-rb) gem, check out our [upgrade guide](/docs/UpgradeGuide.md).
 
 ## Usage
 
@@ -108,7 +108,7 @@ end
 Configuration `ci.instrument` accepts the following optional parameters:
 
 - `enabled` (default: `true`) - defines whether tests should be traced (useful for temporarily disabling tracing)
-- `service_name` - service name used for this instrumentation (when you want it to be different for given test framework)
+- `service_name` - name of the service or library under test (when you want it to be different for a test framework)
 
 Example usage:
 
@@ -219,7 +219,7 @@ Datadog.configure { |c| c.diagnostics.startup_logs.enabled = false }
 
 Switching the library into debug mode will produce verbose, detailed logs about tracing activity, including any suppressed errors. This output can be helpful in identifying errors, confirming trace output, or catching HTTP transport issues.
 
-You can enable this via `DD_TRACE_DEBUG=1` or in the configure block:
+You can enable this via `DD_TRACE_DEBUG=1` or in the `Datadog.configure` block:
 
 ```ruby
 Datadog.configure { |c| c.diagnostics.debug = true }

--- a/README.md
+++ b/README.md
@@ -200,8 +200,10 @@ VCR.configure do |config|
   config.ignore_hosts "127.0.0.1", "localhost"
 
   # when using agentless mode
-  # note to use the correct datadog site (e.g. datadoghq.eu, etc)
-  config.ignore_hosts "citestcycle-intake.datadoghq.com", "api.datadoghq.com", "citestcov-intake.datadoghq.com"
+  config.ignore_request do |request|
+    # ignore all requests to datadoghq hosts
+    request.uri =~ /datadoghq/
+  end
 end
 ```
 

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -1,0 +1,50 @@
+# Upgrading from ddtrace 1.x to datadog-ci
+
+Test visibility for Ruby is no longer part of `datadog` gem and fully migrated to
+`datadog-ci` gem. To continue using it after gem `datadog` v2.0 is released, only a
+couple of changes needed.
+
+## Add datadog-ci to your gemfile
+
+Before:
+
+```ruby
+gem "ddtrace", "~> 1.0"
+```
+
+After:
+
+```ruby
+group :test do
+  gem "datadog-ci", "~> 1.0"
+end
+```
+
+Or if you use other Datadog products:
+
+```ruby
+gem "datadog", "~> 2.0"
+
+group :test do
+  gem "datadog-ci", "~> 1.0"
+end
+```
+
+## Change WebMock or VCR configuration
+
+We work on adding new features to the test visibility product in Ruby (intelligent test runner, git metadata upload, code coverage support) that require new endpoints being allowlisted by WebMock/VCR tools when using agentless mode.
+
+For WebMock allow all requests that match datadoghq:
+
+```ruby
+WebMock.disable_net_connect!(:allow => /datadoghq/)
+```
+
+For VCR provide a list of Datadog backend hosts as ignored hosts:
+
+```ruby
+VCR.configure do |config|
+  # note to use the correct datadog site (e.g. datadoghq.eu, etc)
+  config.ignore_hosts "citestcycle-intake.datadoghq.com", "api.datadoghq.com", "citestcov-intake.datadoghq.com"
+end
+```

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -1,8 +1,7 @@
 # Upgrading from ddtrace 1.x to datadog-ci
 
 Test visibility for Ruby is no longer part of `datadog` gem and fully migrated to
-`datadog-ci` gem. To continue using it after gem `datadog` v2.0 is released, only a
-couple of changes needed.
+`datadog-ci` gem. To continue using it after gem `datadog` v2.0 is released, do these changes.
 
 ## Add datadog-ci to your gemfile
 

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -31,7 +31,7 @@ end
 
 ## Change WebMock or VCR configuration
 
-We work on adding new features to the test visibility product in Ruby (intelligent test runner, git metadata upload, code coverage support) that require new endpoints being allowlisted by WebMock/VCR tools when using agentless mode.
+Test visibility features (such as intelligent test runner, git metadata upload, code coverage support) require some DataDog endpoints to be allowlisted by WebMock/VCR tools when using agentless mode.
 
 For WebMock allow all requests that match datadoghq:
 

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -39,11 +39,13 @@ For WebMock allow all requests that match datadoghq:
 WebMock.disable_net_connect!(:allow => /datadoghq/)
 ```
 
-For VCR provide a list of Datadog backend hosts as ignored hosts:
+For VCR provide `ignore_request` configuration:
 
 ```ruby
 VCR.configure do |config|
-  # note to use the correct datadog site (e.g. datadoghq.eu, etc)
-  config.ignore_hosts "citestcycle-intake.datadoghq.com", "api.datadoghq.com", "citestcov-intake.datadoghq.com"
+  config.ignore_request do |request|
+    # ignore all requests to datadoghq hosts
+    request.uri =~ /datadoghq/
+  end
 end
 ```

--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -1,6 +1,6 @@
 # Upgrading from ddtrace 1.x to datadog-ci
 
-Test visibility for Ruby is no longer part of `datadog` gem and fully migrated to
+[Test visibility for Ruby](https://docs.datadoghq.com/tests/setup/ruby/) is no longer part of `datadog` gem and fully migrated to
 `datadog-ci` gem. To continue using it after gem `datadog` v2.0 is released, do these changes.
 
 ## Add datadog-ci to your gemfile
@@ -31,7 +31,7 @@ end
 
 ## Change WebMock or VCR configuration
 
-Test visibility features (such as intelligent test runner, git metadata upload, code coverage support) require some DataDog endpoints to be allowlisted by WebMock/VCR tools when using agentless mode.
+New test visibility features (such as [intelligent test runner](https://docs.datadoghq.com/intelligent_test_runner/), git metadata upload, [code coverage support](https://docs.datadoghq.com/tests/code_coverage)) require some DataDog endpoints to be allowlisted by WebMock/VCR tools when using agentless mode.
 
 For WebMock allow all requests that match datadoghq:
 


### PR DESCRIPTION
**What does this PR do?**
Adds upgrade guide for users upgrading from ddtrace gem and updates readme.

**Motivation**
Next major release for Datadog ruby libraries is coming

