### PR TITLE
Bump to version 1.0.0.beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 ## [Unreleased]
 
+## [1.0.0.beta2] - 2024-04-23
+
+### Added
+
+* Code coverage events writer ([#150])
+* Git tree upload - git command line integration ([#151])
+* Add Git::SearchCommits api client ([#152])
+* Upload packfiles API client ([#153])
+* Git tree uploader ([#154])
+* Git repository unshallowing logic ([#155])
+* Git upload async worker ([#156])
+* Reduce ITR-induced code coverage overhead for default branch ([#157])
+* Skippable tests api client ([#158])
+* Request skippable tests when configuring ITR ([#159])
+* Test skipping implementation ([#160])
+
 ## [1.0.0.beta1] - 2024-03-25
 
 ### Added
@@ -199,6 +215,7 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 * Ruby versions < 2.7 no longer supported ([#8][])
 
 [Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v0.8.3...main
+[1.0.0.beta2]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta1...v1.0.0.beta2
 [1.0.0.beta1]: https://github.com/DataDog/datadog-ci-rb/compare/v0.8.3...v1.0.0.beta1
 [0.8.3]: https://github.com/DataDog/datadog-ci-rb/compare/v0.8.2...v0.8.3
 [0.8.2]: https://github.com/DataDog/datadog-ci-rb/compare/v0.8.1...v0.8.2
@@ -276,3 +293,14 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#142]: https://github.com/DataDog/datadog-ci-rb/issues/142
 [#145]: https://github.com/DataDog/datadog-ci-rb/issues/145
 [#148]: https://github.com/DataDog/datadog-ci-rb/issues/148
+[#150]: https://github.com/DataDog/datadog-ci-rb/issues/150
+[#151]: https://github.com/DataDog/datadog-ci-rb/issues/151
+[#152]: https://github.com/DataDog/datadog-ci-rb/issues/152
+[#153]: https://github.com/DataDog/datadog-ci-rb/issues/153
+[#154]: https://github.com/DataDog/datadog-ci-rb/issues/154
+[#155]: https://github.com/DataDog/datadog-ci-rb/issues/155
+[#156]: https://github.com/DataDog/datadog-ci-rb/issues/156
+[#157]: https://github.com/DataDog/datadog-ci-rb/issues/157
+[#158]: https://github.com/DataDog/datadog-ci-rb/issues/158
+[#159]: https://github.com/DataDog/datadog-ci-rb/issues/159
+[#160]: https://github.com/DataDog/datadog-ci-rb/issues/160

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta1)
+    datadog-ci (1.0.0.beta2)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -6,7 +6,7 @@ module Datadog
       MAJOR = "1"
       MINOR = "0"
       PATCH = "0"
-      PRE = "beta1"
+      PRE = "beta2"
       BUILD = nil
       # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 


### PR DESCRIPTION
**What does this PR do?**
Releases 1.0.0.beta2 version ahead of upcoming 1.0.0 release

