### PR TITLE
[CIVIS-9014] implement "why this test was skipped" feature by adding ITR correlation to test events

### DIFF
--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -28,11 +28,12 @@ module Datadog
             "duration"
           ].freeze
 
-          attr_reader :trace, :span, :meta
+          attr_reader :trace, :span, :meta, :options
 
-          def initialize(trace, span)
+          def initialize(trace, span, options: {})
             @trace = trace
             @span = span
+            @options = options
 
             @meta = @span.meta.reject { |key, _| Ext::Test::TRANSIENT_TAGS.include?(key) }
 

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_level.rb
@@ -14,12 +14,12 @@ module Datadog
           module TestLevel
             module_function
 
-            def serializer(trace, span)
+            def serializer(trace, span, options: {})
               case span.type
               when Datadog::CI::Ext::AppTypes::TYPE_TEST
-                Serializers::TestV1.new(trace, span)
+                Serializers::TestV1.new(trace, span, options: options)
               else
-                Serializers::Span.new(trace, span)
+                Serializers::Span.new(trace, span, options: options)
               end
             end
           end

--- a/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
+++ b/lib/datadog/ci/test_visibility/serializers/factories/test_suite_level.rb
@@ -15,18 +15,18 @@ module Datadog
           module TestSuiteLevel
             module_function
 
-            def serializer(trace, span)
+            def serializer(trace, span, options: {})
               case span.type
               when Datadog::CI::Ext::AppTypes::TYPE_TEST
-                Serializers::TestV2.new(trace, span)
+                Serializers::TestV2.new(trace, span, options: options)
               when Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION
-                Serializers::TestSession.new(trace, span)
+                Serializers::TestSession.new(trace, span, options: options)
               when Datadog::CI::Ext::AppTypes::TYPE_TEST_MODULE
-                Serializers::TestModule.new(trace, span)
+                Serializers::TestModule.new(trace, span, options: options)
               when Datadog::CI::Ext::AppTypes::TYPE_TEST_SUITE
-                Serializers::TestSuite.new(trace, span)
+                Serializers::TestSuite.new(trace, span, options: options)
               else
-                Serializers::Span.new(trace, span)
+                Serializers::Span.new(trace, span, options: options)
               end
             end
           end

--- a/lib/datadog/ci/test_visibility/serializers/test_v2.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_v2.rb
@@ -10,20 +10,32 @@ module Datadog
         class TestV2 < TestV1
           CONTENT_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + TestV1::CONTENT_FIELDS).freeze
 
+          CONTENT_FIELDS_WITH_ITR_CORRELATION_ID = (CONTENT_FIELDS + ["itr_correlation_id"]).freeze
+
           CONTENT_MAP_SIZE = calculate_content_map_size(CONTENT_FIELDS)
+
+          CONTENT_MAP_SIZE_WITH_ITR_CORRELATION_ID = calculate_content_map_size(CONTENT_FIELDS_WITH_ITR_CORRELATION_ID)
 
           REQUIRED_FIELDS = (["test_session_id", "test_module_id", "test_suite_id"] + TestV1::REQUIRED_FIELDS).freeze
 
           def content_fields
-            CONTENT_FIELDS
+            return CONTENT_FIELDS if itr_correlation_id.nil?
+
+            CONTENT_FIELDS_WITH_ITR_CORRELATION_ID
           end
 
           def content_map_size
-            CONTENT_MAP_SIZE
+            return CONTENT_MAP_SIZE if itr_correlation_id.nil?
+
+            CONTENT_MAP_SIZE_WITH_ITR_CORRELATION_ID
           end
 
           def version
             2
+          end
+
+          def itr_correlation_id
+            options[:itr_correlation_id]
           end
 
           private

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -45,7 +45,7 @@ module Datadog
         end
 
         def encode_span(trace, span)
-          serializer = serializers_factory.serializer(trace, span)
+          serializer = serializers_factory.serializer(trace, span, options: {itr_correlation_id: itr&.correlation_id})
 
           if serializer.valid?
             encoded = encoder.encode(serializer)
@@ -97,6 +97,10 @@ module Datadog
           packer.write(Datadog::CI::VERSION::STRING)
 
           packer.write("events")
+        end
+
+        def itr
+          @itr ||= Datadog::CI.send(:itr_runner)
         end
       end
     end

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -7,8 +7,8 @@ module Datadog
         @enabled: bool
         @test_skipping_enabled: bool
         @code_coverage_enabled: bool
-        @correlation_id: String
-        @skippable_tests: Array[String]
+        @correlation_id: String?
+        @skippable_tests: Set[String]
         @coverage_writer: Datadog::CI::ITR::Coverage::Writer?
 
         @api: Datadog::CI::Transport::Api::Base?
@@ -16,6 +16,10 @@ module Datadog
 
         @skipped_tests_count: Integer
         @mutex: Thread::Mutex
+
+        attr_reader skippable_tests: Set[String]
+        attr_reader skipped_tests_count: Integer
+        attr_reader correlation_id: String?
 
         def initialize: (dd_env: String?, ?enabled: bool, coverage_writer: Datadog::CI::ITR::Coverage::Writer?, api: Datadog::CI::Transport::Api::Base?) -> void
 

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -10,18 +10,24 @@ module Datadog
           CONTENT_FIELDS: Array[String | Hash[String, String]]
           REQUIRED_FIELDS: Array[String]
 
-          @content_fields_count: Integer
-          @start: Integer
-          @duration: Integer
+          @trace: Datadog::Tracing::TraceSegment
+          @span: Datadog::Tracing::Span
+          @options: Hash[Symbol, untyped]
+
           @meta: Hash[untyped, untyped]
           @errors: Hash[String, Set[String]]
           @validated: bool
 
+          @content_fields_count: Integer
+          @start: Integer
+          @duration: Integer
+
           attr_reader trace: Datadog::Tracing::TraceSegment
           attr_reader span: Datadog::Tracing::Span
           attr_reader meta: Hash[untyped, untyped]
+          attr_reader options: Hash[Symbol, untyped]
 
-          def initialize: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> void
+          def initialize: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span, ?options: Hash[Symbol, untyped]) -> void
 
           def to_msgpack: (?untyped? packer) -> untyped
 

--- a/sig/datadog/ci/test_visibility/serializers/factories/test_level.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/factories/test_level.rbs
@@ -4,7 +4,7 @@ module Datadog
       module Serializers
         module Factories
           module TestLevel
-            def self?.serializer: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> Datadog::CI::TestVisibility::Serializers::Base
+            def self?.serializer: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span, ?options: Hash[Symbol, untyped]) -> Datadog::CI::TestVisibility::Serializers::Base
           end
         end
       end

--- a/sig/datadog/ci/test_visibility/serializers/factories/test_suite_level.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/factories/test_suite_level.rbs
@@ -4,7 +4,7 @@ module Datadog
       module Serializers
         module Factories
           module TestSuiteLevel
-            def self?.serializer: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> Datadog::CI::TestVisibility::Serializers::Base
+            def self?.serializer: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span, ?options: Hash[Symbol, untyped]) -> Datadog::CI::TestVisibility::Serializers::Base
           end
         end
       end

--- a/sig/datadog/ci/test_visibility/serializers/test_v2.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/test_v2.rbs
@@ -5,7 +5,11 @@ module Datadog
         class TestV2 < TestV1
           CONTENT_FIELDS: ::Array[String | ::Hash[::String, String]]
 
+          CONTENT_FIELDS_WITH_ITR_CORRELATION_ID: ::Array[String | ::Hash[::String, String]]
+
           CONTENT_MAP_SIZE: Integer
+
+          CONTENT_MAP_SIZE_WITH_ITR_CORRELATION_ID: Integer
 
           REQUIRED_FIELDS: ::Array[String]
 
@@ -14,6 +18,8 @@ module Datadog
           def content_map_size: () -> Integer
 
           def version: () -> 2
+
+          def itr_correlation_id: () -> String?
 
           private
 

--- a/sig/datadog/ci/test_visibility/transport.rbs
+++ b/sig/datadog/ci/test_visibility/transport.rbs
@@ -7,6 +7,7 @@ module Datadog
 
         @dd_env: String?
         @serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
+        @itr: Datadog::CI::ITR::Runner?
 
         def initialize: (
           api: Datadog::CI::Transport::Api::Base,
@@ -20,6 +21,7 @@ module Datadog
         def send_payload: (String encoded_payload) -> Datadog::CI::Transport::HTTP::ResponseDecorator
         def encode_events: (Array[Datadog::Tracing::TraceSegment] traces) -> ::Array[String]
         def encode_span: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> String?
+        def itr: () -> Datadog::CI::ITR::Runner?
       end
     end
   end

--- a/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
@@ -12,32 +12,45 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLev
     produce_test_session_trace(with_http_span: true)
   end
 
-  subject { described_class.serializer(trace_for_span(ci_span), ci_span) }
+  context "without options" do
+    subject { described_class.serializer(trace_for_span(ci_span), ci_span) }
 
-  describe ".convert_trace_to_serializable_events" do
-    context "with a session span" do
-      let(:ci_span) { test_session_span }
-      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSession) }
+    describe ".convert_trace_to_serializable_events" do
+      context "with a session span" do
+        let(:ci_span) { test_session_span }
+        it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSession) }
+      end
+
+      context "with a module span" do
+        let(:ci_span) { test_module_span }
+        it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestModule) }
+      end
+
+      context "with a suite span" do
+        let(:ci_span) { first_test_suite_span }
+        it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSuite) }
+      end
+
+      context "with a test span" do
+        let(:ci_span) { first_test_span }
+        it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestV2) }
+      end
+
+      context "with a http request span" do
+        let(:ci_span) { first_custom_span }
+        it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::Span) }
+      end
     end
+  end
 
-    context "with a module span" do
-      let(:ci_span) { test_module_span }
-      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestModule) }
-    end
+  context "with options" do
+    let(:ci_span) { first_test_span }
+    subject { described_class.serializer(trace_for_span(ci_span), ci_span, options: {custom: "option"}) }
 
-    context "with a suite span" do
-      let(:ci_span) { first_test_suite_span }
-      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestSuite) }
-    end
-
-    context "with a test span" do
-      let(:ci_span) { first_test_span }
-      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::TestV2) }
-    end
-
-    context "with a http request span" do
-      let(:ci_span) { first_custom_span }
-      it { is_expected.to be_kind_of(Datadog::CI::TestVisibility::Serializers::Span) }
+    describe ".serializer" do
+      it "passes options to the serializer" do
+        expect(subject.options).to eq({custom: "option"})
+      end
     end
   end
 end

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
     let(:integration_name) { :rspec }
   end
 
+  let(:options) { {} }
   include_context "msgpack serializer" do
-    subject { described_class.new(trace_for_span(first_test_span), first_test_span) }
+    subject { described_class.new(trace_for_span(first_test_span), first_test_span, options: options) }
   end
 
   describe "#to_msgpack" do
@@ -108,6 +109,18 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
           "start" => start_time.to_i * 1_000_000_000 + start_time.nsec,
           "duration" => 3 * 1_000_000_000
         })
+      end
+    end
+
+    context "with itr correlation id" do
+      let(:options) { {itr_correlation_id: "itr-correlation-id"} }
+
+      before do
+        produce_test_session_trace
+      end
+
+      it "correctly serializes itr correlation id" do
+        expect(content).to include("itr_correlation_id" => "itr-correlation-id")
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
To show "why this test was skipped" explanation in the Datadog UI, we need to send `itr_correlation_id` field in content part of test events: this PR adds just that. 

`TestVisibility::Transport` obtains itr_correlation_id by calling a method on `ITR::Runner` directly and then passes to serializers via new `options` keyword parameter.

**How to test the change?**
Tested using anmarchenko/jekyll project on dd-staging with the following result:
<img width="1333" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/22abd47a-1b79-48d7-8b51-7739d13786c8">
