### PR TITLE
[CIVIS-9333] support custom configuration tags supplied from the environment

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -13,6 +13,7 @@ require_relative "../test_visibility/serializers/factories/test_suite_level"
 require_relative "../test_visibility/transport"
 require_relative "../transport/api/builder"
 require_relative "../transport/remote_settings_api"
+require_relative "../utils/test_run"
 require_relative "../worker"
 
 module Datadog
@@ -90,14 +91,18 @@ module Datadog
 
           settings.tracing.test_mode.writer_options = writer_options
 
+          custom_configuration_tags = Utils::TestRun.custom_configuration(settings.tags)
+
           remote_settings_api = Transport::RemoteSettingsApi.new(
             api: test_visibility_api,
-            dd_env: settings.env
+            dd_env: settings.env,
+            config_tags: custom_configuration_tags
           )
 
           itr = ITR::Runner.new(
             api: test_visibility_api,
             dd_env: settings.env,
+            config_tags: custom_configuration_tags,
             coverage_writer: coverage_writer,
             enabled: settings.ci.enabled && settings.ci.itr_enabled
           )

--- a/lib/datadog/ci/itr/runner.rb
+++ b/lib/datadog/ci/itr/runner.rb
@@ -27,6 +27,7 @@ module Datadog
 
         def initialize(
           dd_env:,
+          config_tags: {},
           api: nil,
           coverage_writer: nil,
           enabled: false
@@ -34,6 +35,7 @@ module Datadog
           @enabled = enabled
           @api = api
           @dd_env = dd_env
+          @config_tags = config_tags || {}
 
           @test_skipping_enabled = false
           @code_coverage_enabled = false
@@ -191,7 +193,10 @@ module Datadog
           # we can only request skippable tests if git metadata is already uploaded
           git_tree_upload_worker.wait_until_done
 
-          skippable_response = Skippable.new(api: @api, dd_env: @dd_env).fetch_skippable_tests(test_session)
+          skippable_response =
+            Skippable.new(api: @api, dd_env: @dd_env, config_tags: @config_tags)
+              .fetch_skippable_tests(test_session)
+
           @correlation_id = skippable_response.correlation_id
           @skippable_tests = skippable_response.tests
 

--- a/lib/datadog/ci/itr/skippable.rb
+++ b/lib/datadog/ci/itr/skippable.rb
@@ -57,9 +57,10 @@ module Datadog
           end
         end
 
-        def initialize(dd_env:, api: nil)
+        def initialize(dd_env:, api: nil, config_tags: {})
           @api = api
           @dd_env = dd_env
+          @config_tags = config_tags
         end
 
         def fetch_skippable_tests(test_session)
@@ -94,7 +95,8 @@ module Datadog
                   Ext::Test::TAG_OS_ARCHITECTURE => test_session.os_architecture,
                   Ext::Test::TAG_OS_VERSION => test_session.os_version,
                   Ext::Test::TAG_RUNTIME_NAME => test_session.runtime_name,
-                  Ext::Test::TAG_RUNTIME_VERSION => test_session.runtime_version
+                  Ext::Test::TAG_RUNTIME_VERSION => test_session.runtime_version,
+                  "custom" => @config_tags
                 }
               }
             }

--- a/lib/datadog/ci/transport/remote_settings_api.rb
+++ b/lib/datadog/ci/transport/remote_settings_api.rb
@@ -51,9 +51,10 @@ module Datadog
           end
         end
 
-        def initialize(dd_env:, api: nil)
+        def initialize(dd_env:, api: nil, config_tags: {})
           @api = api
           @dd_env = dd_env
+          @config_tags = config_tags || {}
         end
 
         def fetch_library_settings(test_session)
@@ -90,7 +91,8 @@ module Datadog
                   Ext::Test::TAG_OS_ARCHITECTURE => test_session.os_architecture,
                   Ext::Test::TAG_OS_VERSION => test_session.os_version,
                   Ext::Test::TAG_RUNTIME_NAME => test_session.runtime_name,
-                  Ext::Test::TAG_RUNTIME_VERSION => test_session.runtime_version
+                  Ext::Test::TAG_RUNTIME_VERSION => test_session.runtime_version,
+                  "custom" => @config_tags
                 }
               }
             }

--- a/lib/datadog/ci/utils/test_run.rb
+++ b/lib/datadog/ci/utils/test_run.rb
@@ -22,6 +22,18 @@ module Datadog
             }
           )
         end
+
+        def self.custom_configuration(env_tags)
+          return {} if env_tags.nil?
+
+          res = {}
+          env_tags.each do |tag, value|
+            next unless tag.start_with?("test.configuration.")
+
+            res[tag.sub("test.configuration.", "")] = value
+          end
+          res
+        end
       end
     end
   end

--- a/sig/datadog/ci/itr/runner.rbs
+++ b/sig/datadog/ci/itr/runner.rbs
@@ -13,6 +13,7 @@ module Datadog
 
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?
+        @config_tags: Hash[String, String]
 
         @skipped_tests_count: Integer
         @mutex: Thread::Mutex
@@ -21,7 +22,7 @@ module Datadog
         attr_reader skipped_tests_count: Integer
         attr_reader correlation_id: String?
 
-        def initialize: (dd_env: String?, ?enabled: bool, coverage_writer: Datadog::CI::ITR::Coverage::Writer?, api: Datadog::CI::Transport::Api::Base?) -> void
+        def initialize: (dd_env: String?, ?enabled: bool, coverage_writer: Datadog::CI::ITR::Coverage::Writer?, api: Datadog::CI::Transport::Api::Base?, ?config_tags: Hash[String, String]?) -> void
 
         def configure: (Hash[String, untyped] remote_configuration, test_session: Datadog::CI::TestSession, git_tree_upload_worker: Datadog::CI::Worker) -> void
 

--- a/sig/datadog/ci/itr/skippable.rbs
+++ b/sig/datadog/ci/itr/skippable.rbs
@@ -4,6 +4,7 @@ module Datadog
       class Skippable
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?
+        @config_tags: Hash[String, String]
 
         class Response
           @http_response: Datadog::Core::Transport::HTTP::Adapters::Net::Response?
@@ -22,7 +23,7 @@ module Datadog
           def payload: () -> Hash[String, untyped]
         end
 
-        def initialize: (?api: Datadog::CI::Transport::Api::Base?, dd_env: String?) -> void
+        def initialize: (?api: Datadog::CI::Transport::Api::Base?, dd_env: String?, ?config_tags: Hash[String, String]) -> void
 
         def fetch_skippable_tests: (Datadog::CI::TestSession test_session) -> Response
 

--- a/sig/datadog/ci/transport/remote_settings_api.rbs
+++ b/sig/datadog/ci/transport/remote_settings_api.rbs
@@ -21,8 +21,9 @@ module Datadog
 
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?
+        @config_tags: Hash[String, String]
 
-        def initialize: (?api: Datadog::CI::Transport::Api::Base?, dd_env: String?) -> void
+        def initialize: (?api: Datadog::CI::Transport::Api::Base?, dd_env: String?, ?config_tags: Hash[String, String]?) -> void
 
         def fetch_library_settings: (Datadog::CI::TestSession test_session) -> Response
 

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -9,6 +9,8 @@ module Datadog
         def self.skippable_test_id: (String test_name, String? test_suite, ?String? parameters) -> String
 
         def self.test_parameters: (?arguments: Hash[untyped, untyped], ?metadata: Hash[untyped, untyped]) -> String
+
+        def self.custom_configuration: (Hash[String, String]? env_tags) -> Hash[String, String]
       end
     end
   end

--- a/spec/datadog/ci/utils/test_run_spec.rb
+++ b/spec/datadog/ci/utils/test_run_spec.rb
@@ -34,4 +34,28 @@ RSpec.describe ::Datadog::CI::Utils::TestRun do
       )
     end
   end
+
+  describe ".custom_configuration" do
+    subject { described_class.custom_configuration(env_tags) }
+
+    context "when env_tags is nil" do
+      let(:env_tags) { nil }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context "when env_tags is not nil" do
+      let(:env_tags) do
+        {
+          "test.configuration.tag1" => "value1",
+          "test.configuration.tag2" => "value2",
+          "tag3" => "value3",
+          "test.configurations.tag4" => "value4",
+          "test.configuration" => "value5"
+        }
+      end
+
+      it { is_expected.to eq({"tag1" => "value1", "tag2" => "value2"}) }
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
There are some configurations that cannot be directly identified and reported automatically. For those cases, the user must provide the configuration details to the library so CI Visibility can properly identify them. These tags affect the test fingerprint. These custom configurations are passed via DD_TAGS with a test.configuration. prefix, that is, every test.configuration.* tag will be treated as a custom configuration. 

We send these custom configurations when requesting **library settings** and **skippable tests** in `data.attributes.configurations.custom field`.

**How to test the change?**
Using anmarchenko/sidekiq

Test with custom configurations:
<img width="1303" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/bbb2c89b-9e7c-422d-b3d2-b4c81e4492bc">

Logs when sending skippable request:
```
D, [2024-04-24T14:02:38.210618 #19229] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/itr/skippable.rb:71:in `fetch_skippable_tests') Fetching skippable tests with request: {"data":{"type":"test_params","attributes":{"test_level":"test","service":"sidekiq","env":"ci","repository_url":"git@github.com:anmarchenko/sidekiq.git","sha":"345a0d3c42d02b86fb2b9e590d70e6fe67da95a4","configurations":{"os.platform":"darwin23","os.architecture":"arm64","os.version":"23.4.0","runtime.name":"ruby","runtime.version":"3.3.0","custom":{"disk":"slow","memory":"low"}}}}}
```

Logs when sending settings request:
```
D, [2024-04-24T14:02:36.620087 #19229] DEBUG -- datadog: [datadog] (/Users/andrey.marchenko/p/datadog-ci-rb/lib/datadog/ci/transport/remote_settings_api.rb:65:in `fetch_library_settings') Fetching library settings with request: {"data":{"id":"d0bf8c94-c9c2-45e0-a317-088d1ca75b7f","type":"ci_app_test_service_libraries_settings","attributes":{"service":"sidekiq","env":"ci","repository_url":"git@github.com:anmarchenko/sidekiq.git","branch":"itr_test1","sha":"345a0d3c42d02b86fb2b9e590d70e6fe67da95a4","test_level":"test","configurations":{"os.platform":"darwin23","os.architecture":"arm64","os.version":"23.4.0","runtime.name":"ruby","runtime.version":"3.3.0","custom":{"disk":"slow","memory":"low"}}}}}
```