### PR TITLE
[NO TICKET] more debug logging, do not skip tests when running in forked processes

### DIFF
--- a/docs/UpgradeGuide.md
+++ b/docs/UpgradeGuide.md
@@ -49,3 +49,15 @@ VCR.configure do |config|
   end
 end
 ```
+
+## Upgrade tracing auto instrumentation
+
+If you use auto instrumenation feature from tracing you need to change the require:
+
+```ruby
+# === Before ===
+require 'ddtrace/auto_instrument'
+
+# === After ===
+require 'datadog/auto_instrument'
+```

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -60,6 +60,9 @@ module Datadog
           # Choose user defined TraceFlush or default to CI TraceFlush
           settings.tracing.test_mode.trace_flush = settings.ci.trace_flush || CI::TestVisibility::Flush::Partial.new
 
+          # startup logs are useless for CI visibility and create noise
+          settings.diagnostics.startup_logs.enabled = false
+
           # transport creation
           writer_options = settings.ci.writer_options
           coverage_writer = nil

--- a/lib/datadog/ci/itr/coverage/writer.rb
+++ b/lib/datadog/ci/itr/coverage/writer.rb
@@ -58,9 +58,15 @@ module Datadog
           def perform(*events)
             responses = transport.send_events(events)
 
-            loop_back_off! if responses.find(&:server_error?)
+            if responses.find(&:server_error?)
+              loop_back_off!
+              Datadog.logger.warn { "Encountered server error while sending coverage events" }
+            end
 
             nil
+          rescue => e
+            Datadog.logger.warn { "Error while sending coverage events: #{e}" }
+            loop_back_off!
           end
 
           def stop(force_stop = false, timeout = @shutdown_timeout)


### PR DESCRIPTION
**What does this PR do?**
A couple of smaller changes ahead of ITR public beta:
- more debug logging
- error handling for coverage writer: instead of silently killing the the coverage writer on errors print WARN messages and back-off
- do not skip tests when using forked test runners (to be supported later)
- disable startup logging from tracing as it is useless for test visibility mode and spams logs
