### PR TITLE
[CIVIS-9901] accept gzipped responses from API

### DIFF
--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -7,6 +7,7 @@ module Datadog
         DEFAULT_DD_SITE = "datadoghq.com"
 
         HEADER_DD_API_KEY = "DD-API-KEY"
+        HEADER_ACCEPT_ENCODING = "Accept-Encoding"
         HEADER_CONTENT_TYPE = "Content-Type"
         HEADER_CONTENT_ENCODING = "Content-Encoding"
         HEADER_EVP_SUBDOMAIN = "X-Datadog-EVP-Subdomain"
@@ -48,6 +49,8 @@ module Datadog
         CONTENT_TYPE_JSON = "application/json"
         CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data"
         CONTENT_ENCODING_GZIP = "gzip"
+
+        GZIP_MAGIC_NUMBER = "\x1F\x8B"
       end
     end
   end

--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -50,7 +50,7 @@ module Datadog
         CONTENT_TYPE_MULTIPART_FORM_DATA = "multipart/form-data"
         CONTENT_ENCODING_GZIP = "gzip"
 
-        GZIP_MAGIC_NUMBER = "\x1F\x8B"
+        GZIP_MAGIC_NUMBER = "\x1F\x8B".b
       end
     end
   end

--- a/lib/datadog/ci/transport/api/agentless.rb
+++ b/lib/datadog/ci/transport/api/agentless.rb
@@ -26,7 +26,14 @@ module Datadog
           def api_request(path:, payload:, headers: {}, verb: "post")
             super
 
-            perform_request(@api_http, path: path, payload: payload, headers: headers, verb: verb)
+            perform_request(
+              @api_http,
+              path: path,
+              payload: payload,
+              headers: headers,
+              verb: verb,
+              accept_compressed_response: true
+            )
           end
 
           def citestcov_request(path:, payload:, headers: {}, verb: "post")
@@ -37,12 +44,13 @@ module Datadog
 
           private
 
-          def perform_request(http_client, path:, payload:, headers:, verb:)
+          def perform_request(http_client, path:, payload:, headers:, verb:, accept_compressed_response: false)
             http_client.request(
               path: path,
               payload: payload,
               headers: headers_with_default(headers),
-              verb: verb
+              verb: verb,
+              accept_compressed_response: accept_compressed_response
             )
           end
 

--- a/lib/datadog/ci/transport/gzip.rb
+++ b/lib/datadog/ci/transport/gzip.rb
@@ -19,7 +19,11 @@ module Datadog
 
         def decompress(input)
           sio = StringIO.new(input)
-          gzip_reader = Zlib::GzipReader.new(sio)
+          gzip_reader = Zlib::GzipReader.new(
+            sio,
+            external_encoding: Encoding::UTF_8.name,
+            internal_encoding: Encoding::UTF_8.name
+          )
           gzip_reader.read || ""
         ensure
           gzip_reader&.close

--- a/lib/datadog/ci/transport/gzip.rb
+++ b/lib/datadog/ci/transport/gzip.rb
@@ -21,8 +21,8 @@ module Datadog
           sio = StringIO.new(input)
           gzip_reader = Zlib::GzipReader.new(
             sio,
-            external_encoding: Encoding::UTF_8.name,
-            internal_encoding: Encoding::UTF_8.name
+            external_encoding: Encoding::UTF_8,
+            internal_encoding: Encoding::UTF_8
           )
           gzip_reader.read || ""
         ensure

--- a/lib/datadog/ci/transport/gzip.rb
+++ b/lib/datadog/ci/transport/gzip.rb
@@ -16,6 +16,14 @@ module Datadog
           gzip_writer.close
           sio.string
         end
+
+        def decompress(input)
+          sio = StringIO.new(input)
+          gzip_reader = Zlib::GzipReader.new(sio)
+          gzip_reader.read
+        ensure
+          gzip_reader&.close
+        end
       end
     end
   end

--- a/lib/datadog/ci/transport/gzip.rb
+++ b/lib/datadog/ci/transport/gzip.rb
@@ -20,7 +20,7 @@ module Datadog
         def decompress(input)
           sio = StringIO.new(input)
           gzip_reader = Zlib::GzipReader.new(sio)
-          gzip_reader.read
+          gzip_reader.read || ""
         ensure
           gzip_reader&.close
         end

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -109,6 +109,7 @@ module Datadog
             return @decompressed_payload if defined?(@decompressed_payload)
 
             if gzipped?(__getobj__.payload)
+              Datadog.logger.debug("Decompressing gzipped response payload")
               @decompressed_payload = Gzip.decompress(__getobj__.payload)
             else
               __getobj__.payload

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -123,7 +123,10 @@ module Datadog
           def gzipped?(payload)
             return false if payload.nil? || payload.empty?
 
-            payload[0, 2] == "\x1F\x8B"
+            first_bytes = payload[0, 2]
+            return false if first_bytes.nil? || first_bytes.empty?
+
+            first_bytes.b == Datadog::CI::Ext::Transport::GZIP_MAGIC_NUMBER
           end
         end
 

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -104,6 +104,7 @@ module Datadog
         end
 
         # adds compatibility with Datadog::Tracing transport and
+        # provides ungzipping capabilities
         class ResponseDecorator < ::SimpleDelegator
           def payload
             return @decompressed_payload if defined?(@decompressed_payload)

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -6,6 +6,8 @@ module Datadog
 
         HEADER_DD_API_KEY: "DD-API-KEY"
 
+        HEADER_ACCEPT_ENCODING: "Accept-Encoding"
+
         HEADER_CONTENT_TYPE: "Content-Type"
 
         HEADER_CONTENT_ENCODING: "Content-Encoding"
@@ -63,6 +65,8 @@ module Datadog
         CONTENT_TYPE_MULTIPART_FORM_DATA: "multipart/form-data"
 
         CONTENT_ENCODING_GZIP: "gzip"
+
+        GZIP_MAGIC_NUMBER: String
       end
     end
   end

--- a/sig/datadog/ci/transport/api/agentless.rbs
+++ b/sig/datadog/ci/transport/api/agentless.rbs
@@ -22,7 +22,7 @@ module Datadog
 
           private
 
-          def perform_request: (Datadog::CI::Transport::HTTP client, path: String, payload: String, headers: Hash[String, String], verb: ::String) -> Datadog::CI::Transport::HTTP::ResponseDecorator
+          def perform_request: (Datadog::CI::Transport::HTTP client, path: String, payload: String, headers: Hash[String, String], verb: ::String, ?accept_compressed_response: bool) -> Datadog::CI::Transport::HTTP::ResponseDecorator
 
           def build_http_client: (String url, compress: bool) -> Datadog::CI::Transport::HTTP
 

--- a/sig/datadog/ci/transport/gzip.rbs
+++ b/sig/datadog/ci/transport/gzip.rbs
@@ -3,6 +3,7 @@ module Datadog
     module Transport
       module Gzip
         def self?.compress: (String input) -> String
+        def self?.decompress: (String input) -> String
       end
     end
   end

--- a/sig/datadog/ci/transport/http.rbs
+++ b/sig/datadog/ci/transport/http.rbs
@@ -1,4 +1,9 @@
 class SimpleDelegator
+  @decompressed_payload: String
+
+  def __getobj__: () -> Datadog::Core::Transport::Response
+  def gzipped?: (String payload) -> bool
+  def payload: () -> String
 end
 
 module Datadog
@@ -19,7 +24,7 @@ module Datadog
 
         def initialize: (host: String, ?port: Integer?, ?ssl: bool, ?timeout: Integer, ?compress: bool) -> void
 
-        def request: (?verb: String, payload: String, headers: Hash[String, String], path: String, ?retries: Integer, ?backoff: Integer) -> ResponseDecorator
+        def request: (?verb: String, payload: String, headers: Hash[String, String], path: String, ?retries: Integer, ?backoff: Integer, ?accept_compressed_response: bool) -> ResponseDecorator
 
         private
 

--- a/spec/datadog/ci/transport/api/agentless_spec.rb
+++ b/spec/datadog/ci/transport/api/agentless_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           path: "path",
           payload: "payload",
           verb: "post",
-          headers: expected_headers
+          headers: expected_headers,
+          accept_compressed_response: false
         )
 
         subject.citestcycle_request(path: "path", payload: "payload")
@@ -120,7 +121,8 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           path: "path",
           payload: "payload",
           verb: "post",
-          headers: expected_headers
+          headers: expected_headers,
+          accept_compressed_response: false
         )
 
         subject.citestcycle_request(path: "path", payload: "payload")
@@ -131,7 +133,8 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           path: "path",
           payload: "payload",
           verb: "post",
-          headers: expected_headers.merge({"Content-Type" => "application/json"})
+          headers: expected_headers.merge({"Content-Type" => "application/json"}),
+          accept_compressed_response: false
         )
 
         subject.citestcycle_request(path: "path", payload: "payload", headers: {"Content-Type" => "application/json"})
@@ -154,7 +157,8 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           headers: {
             "DD-API-KEY" => "api_key",
             "Content-Type" => "application/json"
-          }
+          },
+          accept_compressed_response: true
         )
 
         subject.api_request(path: "path", payload: "payload")
@@ -199,6 +203,7 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           expect(args[:verb]).to eq("post")
           expect(args[:headers]).to eq(expected_headers)
           expect(args[:payload]).to eq(expected_payload)
+          expect(args[:accept_compressed_response]).to eq(false)
         end
       end
     end

--- a/spec/datadog/ci/transport/gzip_spec.rb
+++ b/spec/datadog/ci/transport/gzip_spec.rb
@@ -1,11 +1,8 @@
 require_relative "../../../../lib/datadog/ci/transport/gzip"
 
 RSpec.describe Datadog::CI::Transport::Gzip do
-  subject { described_class.compress(input) }
-
-  describe ".compress" do
-    let(:input) do
-      <<-LOREM
+  let(:input) do
+    <<-LOREM
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et est eu dui dignissim tempus. Aliquam
         scelerisque posuere odio id sollicitudin. Etiam dolor lorem, interdum sed mollis consectetur, sagittis a massa.
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec gravida, libero ac gravida ornare, leo elit
@@ -18,8 +15,11 @@ RSpec.describe Datadog::CI::Transport::Gzip do
         commodo sapien vel, consequat felis. Aenean velit turpis, rhoncus in ipsum ut, tempor iaculis nisi. Fusce
         faucibus consequat blandit. Nam maximus augue quis tellus cursus eleifend. Suspendisse auctor, orci sit amet
         vehicula molestie, magna nibh rutrum metus, eget sagittis felis mauris eu quam. Vivamus ut vulputate est.
-      LOREM
-    end
+    LOREM
+  end
+
+  describe ".compress" do
+    subject { described_class.compress(input) }
 
     it "compresses" do
       expect(input.size).to be > subject.size
@@ -29,6 +29,22 @@ RSpec.describe Datadog::CI::Transport::Gzip do
       Zlib::GzipReader.new(StringIO.new(subject)) do |gzip|
         expect(gzip.read).to eq(input)
       end
+    end
+  end
+
+  describe ".decompress" do
+    subject { described_class.decompress(compressed_input) }
+
+    let(:compressed_input) do
+      sio = StringIO.new
+      writer = Zlib::GzipWriter.new(sio)
+      writer << input
+      writer.close
+      sio.string
+    end
+
+    it "decompresses" do
+      expect(subject).to eq(input)
     end
   end
 end

--- a/spec/datadog/ci/transport/gzip_spec.rb
+++ b/spec/datadog/ci/transport/gzip_spec.rb
@@ -3,7 +3,7 @@ require_relative "../../../../lib/datadog/ci/transport/gzip"
 RSpec.describe Datadog::CI::Transport::Gzip do
   let(:input) do
     <<-LOREM
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et est eu dui dignissim tempus. Aliquam
+        ❤️ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc et est eu dui dignissim tempus. Aliquam
         scelerisque posuere odio id sollicitudin. Etiam dolor lorem, interdum sed mollis consectetur, sagittis a massa.
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec gravida, libero ac gravida ornare, leo elit
         facilisis nunc, in pharetra odio lectus sit amet augue. Cras fermentum interdum tortor, pulvinar laoreet massa

--- a/spec/datadog/ci/transport/gzip_spec.rb
+++ b/spec/datadog/ci/transport/gzip_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe Datadog::CI::Transport::Gzip do
     end
 
     it "can be decompressed with gzip" do
-      Zlib::GzipReader.new(StringIO.new(subject)) do |gzip|
+      Zlib::GzipReader.new(
+        StringIO.new(subject),
+        external_encoding: Encoding::UTF_8,
+        internal_encoding: Encoding::UTF_8
+      ) do |gzip|
         expect(gzip.read).to eq(input)
       end
     end


### PR DESCRIPTION
**What does this PR do?**
Adds capability for HTTP layer to request gzipped payload via Accept-Encoding header and decompress payloads if they are gzipped. Uses this capability for Rapid-API requests in agentless mode.

**Motivation**
Save time when fetching skippable tests for very large repos. Fetching 20k+ tests for rubocop happens in 5s with this change vs 13s before.

**How to test the change?**
Unit tests are provided