### PR TITLE
[SDTEST-138] code coverage extension fixes and improvements

### DIFF
--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -118,19 +118,6 @@ static void dd_cov_update_coverage(rb_event_flag_t event, VALUE data, VALUE self
   }
   dd_cov_data->last_filename_ptr = current_filename_ptr;
 
-  // if the current filename is not located under the root, we skip it
-  if (strncmp(dd_cov_data->root, c_filename, dd_cov_data->root_len) != 0)
-  {
-    return;
-  }
-
-  // if ignored_path is provided and the current filename is located under the ignored_path, we skip it too
-  // this is useful for ignoring bundled gems location
-  if (dd_cov_data->ignored_path_len != 0 && strncmp(dd_cov_data->ignored_path, c_filename, dd_cov_data->ignored_path_len) == 0)
-  {
-    return;
-  }
-
   int captured_frames = rb_profile_frames(
       0 /* stack starting depth */,
       PROFILE_FRAMES_BUFFER_SIZE,
@@ -144,6 +131,20 @@ static void dd_cov_update_coverage(rb_event_flag_t event, VALUE data, VALUE self
 
   VALUE filename = rb_profile_frame_path(dd_cov_data->frame_buffer[0]);
   if (filename == Qnil)
+  {
+    return;
+  }
+
+  char *filename_ptr = StringValuePtr(filename);
+  // if the current filename is not located under the root, we skip it
+  if (strncmp(dd_cov_data->root, filename_ptr, dd_cov_data->root_len) != 0)
+  {
+    return;
+  }
+
+  // if ignored_path is provided and the current filename is located under the ignored_path, we skip it too
+  // this is useful for ignoring bundled gems location
+  if (dd_cov_data->ignored_path_len != 0 && strncmp(dd_cov_data->ignored_path, filename_ptr, dd_cov_data->ignored_path_len) == 0)
   {
     return;
   }

--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -1,55 +1,46 @@
 #include <ruby.h>
 #include <ruby/debug.h>
 
-// constants
-#define DD_COV_TARGET_FILES 1
-#define DD_COV_TARGET_LINES 2
+const int PROFILE_FRAMES_BUFFER_SIZE = 1;
 
-static int is_prefix(VALUE prefix, const char *str)
+char *ruby_strndup(const char *str, size_t size)
 {
-  if (prefix == Qnil)
-  {
-    return 0;
-  }
+  char *dup;
 
-  const char *c_prefix = RSTRING_PTR(prefix);
-  if (c_prefix == NULL)
-  {
-    return 0;
-  }
+  dup = xmalloc(size + 1);
+  memcpy(dup, str, size);
+  dup[size] = '\0';
 
-  long prefix_len = RSTRING_LEN(prefix);
-  if (strncmp(c_prefix, str, prefix_len) == 0)
-  {
-    return 1;
-  }
-  else
-  {
-    return 0;
-  }
+  return dup;
 }
 
 // Data structure
 struct dd_cov_data
 {
-  VALUE root;
-  VALUE ignored_path;
-  int mode;
+  char *root;
+  long root_len;
+
+  char *ignored_path;
+  long ignored_path_len;
+
   VALUE coverage;
+
+  VALUE *frame_buffer;
+  uintptr_t last_filename_ptr;
 };
 
 static void dd_cov_mark(void *ptr)
 {
   struct dd_cov_data *dd_cov_data = ptr;
   rb_gc_mark_movable(dd_cov_data->coverage);
-  rb_gc_mark_movable(dd_cov_data->root);
-  rb_gc_mark_movable(dd_cov_data->ignored_path);
 }
 
 static void dd_cov_free(void *ptr)
 {
   struct dd_cov_data *dd_cov_data = ptr;
-
+  xfree(dd_cov_data->root);
+  xfree(dd_cov_data->ignored_path);
+  xfree(dd_cov_data->frame_buffer);
   xfree(dd_cov_data);
 }
 
@@ -57,8 +48,6 @@ static void dd_cov_compact(void *ptr)
 {
   struct dd_cov_data *dd_cov_data = ptr;
   dd_cov_data->coverage = rb_gc_location(dd_cov_data->coverage);
-  dd_cov_data->root = rb_gc_location(dd_cov_data->root);
-  dd_cov_data->ignored_path = rb_gc_location(dd_cov_data->ignored_path);
 }
 
 const rb_data_type_t dd_cov_data_type = {
@@ -74,10 +63,15 @@ static VALUE dd_cov_allocate(VALUE klass)
 {
   struct dd_cov_data *dd_cov_data;
   VALUE obj = TypedData_Make_Struct(klass, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
+
   dd_cov_data->coverage = rb_hash_new();
-  dd_cov_data->root = Qnil;
-  dd_cov_data->ignored_path = Qnil;
-  dd_cov_data->mode = DD_COV_TARGET_FILES;
+  dd_cov_data->root = NULL;
+  dd_cov_data->root_len = 0;
+  dd_cov_data->ignored_path = NULL;
+  dd_cov_data->ignored_path_len = 0;
+  dd_cov_data->last_filename_ptr = 0;
+  dd_cov_data->frame_buffer = xcalloc(PROFILE_FRAMES_BUFFER_SIZE, sizeof(VALUE));
+
   return obj;
 }
 
@@ -85,7 +79,6 @@ static VALUE dd_cov_allocate(VALUE klass)
 static VALUE dd_cov_initialize(int argc, VALUE *argv, VALUE self)
 {
   VALUE opt;
-  int mode;
 
   rb_scan_args(argc, argv, "10", &opt);
   VALUE rb_root = rb_hash_lookup(opt, ID2SYM(rb_intern("root")));
@@ -93,85 +86,69 @@ static VALUE dd_cov_initialize(int argc, VALUE *argv, VALUE self)
   {
     rb_raise(rb_eArgError, "root is required");
   }
-
   VALUE rb_ignored_path = rb_hash_lookup(opt, ID2SYM(rb_intern("ignored_path")));
-
-  VALUE rb_mode = rb_hash_lookup(opt, ID2SYM(rb_intern("mode")));
-  if (!RTEST(rb_mode) || rb_mode == ID2SYM(rb_intern("files")))
-  {
-    mode = DD_COV_TARGET_FILES;
-  }
-  else if (rb_mode == ID2SYM(rb_intern("lines")))
-  {
-    mode = DD_COV_TARGET_LINES;
-  }
-  else
-  {
-    rb_raise(rb_eArgError, "mode is invalid");
-  }
 
   struct dd_cov_data *dd_cov_data;
   TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
 
-  dd_cov_data->root = rb_root;
-  dd_cov_data->ignored_path = rb_ignored_path;
-  dd_cov_data->mode = mode;
+  dd_cov_data->root_len = RSTRING_LEN(rb_root);
+  dd_cov_data->root = ruby_strndup(RSTRING_PTR(rb_root), dd_cov_data->root_len);
+
+  if (RTEST(rb_ignored_path))
+  {
+    dd_cov_data->ignored_path_len = RSTRING_LEN(rb_ignored_path);
+    dd_cov_data->ignored_path = ruby_strndup(RSTRING_PTR(rb_ignored_path), dd_cov_data->ignored_path_len);
+  }
 
   return Qnil;
 }
 
-static void dd_cov_update_line_coverage(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
+static void dd_cov_update_coverage(rb_event_flag_t event, VALUE data, VALUE self, ID id, VALUE klass)
 {
   struct dd_cov_data *dd_cov_data;
   TypedData_Get_Struct(data, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
 
-  const char *filename = rb_sourcefile();
-  if (filename == NULL)
+  const char *c_filename = rb_sourcefile();
+
+  // skip if we cover the same file again
+  uintptr_t current_filename_ptr = (uintptr_t)c_filename;
+  if (dd_cov_data->last_filename_ptr == current_filename_ptr)
+  {
+    return;
+  }
+  dd_cov_data->last_filename_ptr = current_filename_ptr;
+
+  // if the current filename is not located under the root, we skip it
+  if (strncmp(dd_cov_data->root, c_filename, dd_cov_data->root_len) != 0)
   {
     return;
   }
 
-  // if given filename is not located under the root, we skip it
-  if (is_prefix(dd_cov_data->root, filename) == 0)
-  {
-    return;
-  }
-
-  // if ignored_path is provided and given filename is located under the ignored_path, we skip it too
+  // if ignored_path is provided and the current filename is located under the ignored_path, we skip it too
   // this is useful for ignoring bundled gems location
-  if (RTEST(dd_cov_data->ignored_path) && is_prefix(dd_cov_data->ignored_path, filename) == 1)
+  if (dd_cov_data->ignored_path_len != 0 && strncmp(dd_cov_data->ignored_path, c_filename, dd_cov_data->ignored_path_len) == 0)
   {
     return;
   }
 
-  VALUE rb_str_source_file = rb_str_new2(filename);
+  int captured_frames = rb_profile_frames(
+      0 /* stack starting depth */,
+      PROFILE_FRAMES_BUFFER_SIZE,
+      dd_cov_data->frame_buffer,
+      NULL);
 
-  if (dd_cov_data->mode == DD_COV_TARGET_FILES)
+  if (captured_frames != PROFILE_FRAMES_BUFFER_SIZE)
   {
-    rb_hash_aset(dd_cov_data->coverage, rb_str_source_file, Qtrue);
     return;
   }
 
-  // this isn't optimized yet, this is a POC to show that lines coverage is possible
-  // ITR beta is going to use files coverage, we'll get back to this part when
-  // we need to implement lines coverage
-  if (dd_cov_data->mode == DD_COV_TARGET_LINES)
+  VALUE filename = rb_profile_frame_path(dd_cov_data->frame_buffer[0]);
+  if (filename == Qnil)
   {
-    int line_number = rb_sourceline();
-    if (line_number <= 0)
-    {
-      return;
-    }
-
-    VALUE rb_lines = rb_hash_aref(dd_cov_data->coverage, rb_str_source_file);
-    if (rb_lines == Qnil)
-    {
-      rb_lines = rb_hash_new();
-      rb_hash_aset(dd_cov_data->coverage, rb_str_source_file, rb_lines);
-    }
-
-    rb_hash_aset(rb_lines, INT2FIX(line_number), Qtrue);
+    return;
   }
+
+  rb_hash_aset(dd_cov_data->coverage, filename, Qtrue);
 }
 
 static VALUE dd_cov_start(VALUE self)
@@ -179,8 +156,14 @@ static VALUE dd_cov_start(VALUE self)
   // get current thread
   VALUE thval = rb_thread_current();
 
-  // add event hook
-  rb_thread_add_event_hook(thval, dd_cov_update_line_coverage, RUBY_EVENT_LINE, self);
+  struct dd_cov_data *dd_cov_data;
+  TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
+
+  if (dd_cov_data->root_len != 0)
+  {
+    // add event hook
+    rb_thread_add_event_hook(thval, dd_cov_update_coverage, RUBY_EVENT_LINE, self);
+  }
 
   return self;
 }
@@ -190,16 +173,17 @@ static VALUE dd_cov_stop(VALUE self)
   // get current thread
   VALUE thval = rb_thread_current();
   // remove event hook for the current thread
-  rb_thread_remove_event_hook(thval, dd_cov_update_line_coverage);
+  rb_thread_remove_event_hook(thval, dd_cov_update_coverage);
 
   struct dd_cov_data *dd_cov_data;
   TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
 
-  VALUE cov = dd_cov_data->coverage;
+  VALUE res = dd_cov_data->coverage;
 
   dd_cov_data->coverage = rb_hash_new();
+  dd_cov_data->last_filename_ptr = 0;
 
-  return cov;
+  return res;
 }
 
 void Init_datadog_cov(void)

--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -160,11 +160,13 @@ static VALUE dd_cov_start(VALUE self)
   struct dd_cov_data *dd_cov_data;
   TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type, dd_cov_data);
 
-  if (dd_cov_data->root_len != 0)
+  if (dd_cov_data->root_len == 0)
   {
-    // add event hook
-    rb_thread_add_event_hook(thval, dd_cov_update_coverage, RUBY_EVENT_LINE, self);
+    rb_raise(rb_eRuntimeError, "root is required");
   }
+
+  // add event hook
+  rb_thread_add_event_hook(thval, dd_cov_update_coverage, RUBY_EVENT_LINE, self);
 
   return self;
 }

--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -135,7 +135,7 @@ static void dd_cov_update_coverage(rb_event_flag_t event, VALUE data, VALUE self
     return;
   }
 
-  char *filename_ptr = StringValuePtr(filename);
+  char *filename_ptr = RSTRING_PTR(filename);
   // if the current filename is not located under the root, we skip it
   if (strncmp(dd_cov_data->root, filename_ptr, dd_cov_data->root_len) != 0)
   {

--- a/lib/datadog/ci/itr/coverage/writer.rb
+++ b/lib/datadog/ci/itr/coverage/writer.rb
@@ -22,6 +22,8 @@ module Datadog
           DEFAULT_BUFFER_MAX_SIZE = 10_000
           DEFAULT_SHUTDOWN_TIMEOUT = 60
 
+          DEFAULT_INTERVAL = 3
+
           def initialize(transport:, options: {})
             @transport = transport
 
@@ -32,7 +34,7 @@ module Datadog
             self.fork_policy = Core::Workers::Async::Thread::FORK_POLICY_RESTART
 
             # Workers::IntervalLoop settings
-            self.loop_base_interval = options[:interval] if options.key?(:interval)
+            self.loop_base_interval = options[:interval] || DEFAULT_INTERVAL
             self.loop_back_off_ratio = options[:back_off_ratio] if options.key?(:back_off_ratio)
             self.loop_back_off_max = options[:back_off_max] if options.key?(:back_off_max)
 

--- a/sig/datadog/ci/itr/coverage/ddcov.rbs
+++ b/sig/datadog/ci/itr/coverage/ddcov.rbs
@@ -4,7 +4,7 @@ module Datadog
       module Coverage
         class DDCov
 
-          def initialize: (root: String, ?mode: Symbol, ignored_path: String?) -> void
+          def initialize: (root: String, ignored_path: String?) -> void
 
           def start: () -> void
 

--- a/sig/datadog/ci/itr/coverage/writer.rbs
+++ b/sig/datadog/ci/itr/coverage/writer.rbs
@@ -22,6 +22,8 @@ module Datadog
 
           DEFAULT_SHUTDOWN_TIMEOUT: 60
 
+          DEFAULT_INTERVAL: 3
+
           def initialize: (transport: Datadog::CI::ITR::Coverage::Transport, ?options: ::Hash[untyped, untyped]) -> void
 
           def write: (Datadog::CI::ITR::Coverage::Event event) -> untyped

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -11,214 +11,26 @@ RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
   end
 
   let(:ignored_path) { nil }
-  subject { described_class.new(root: root, mode: mode, ignored_path: ignored_path) }
+  subject { described_class.new(root: root, ignored_path: ignored_path) }
 
   describe "code coverage collection" do
     let!(:calculator) { Calculator.new }
 
-    context "in files mode" do
-      let(:mode) { :files }
+    context "when allocating and starting coverage without a root" do
+      it "does not fail" do
+        cov = described_class.allocate
+        cov.start
+        expect(calculator.add(1, 2)).to eq(3)
 
-      context "when allocating and starting coverage without root" do
-        it "does not fail" do
-          cov = described_class.allocate
-          cov.start
-          expect(calculator.add(1, 2)).to eq(3)
-
-          coverage = cov.stop
-          expect(coverage).to eq({})
-        end
-      end
-
-      context "when root is the calculator project dir" do
-        let(:root) { absolute_path("calculator") }
-
-        it "collects code coverage including Calculator and operations" do
-          subject.start
-
-          expect(calculator.add(1, 2)).to eq(3)
-          expect(calculator.subtract(1, 2)).to eq(-1)
-
-          coverage = subject.stop
-
-          expect(coverage.size).to eq(3)
-          expect(coverage.keys).to include(
-            absolute_path("calculator/calculator.rb"),
-            absolute_path("calculator/operations/add.rb"),
-            absolute_path("calculator/operations/subtract.rb")
-          )
-        end
-
-        it "does not support files with non-ASCII characters yet due to additional overhead of UTF-8 strings parsing" do
-          subject.start
-          expect(I❤️Ruby.new.call).to eq("I ❤️ Ruby")
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-          # this string will have a bunch of UTF-8 codepoints in it
-          expect(coverage.keys.first).to include("calculator/code_with_")
-        end
-
-        context "when ignored_path is set" do
-          let(:ignored_path) { absolute_path("calculator/operations") }
-
-          it "collects code coverage excluding ignored_path" do
-            subject.start
-
-            expect(calculator.add(1, 2)).to eq(3)
-            expect(calculator.subtract(1, 2)).to eq(-1)
-
-            coverage = subject.stop
-
-            expect(coverage.size).to eq(1)
-            expect(coverage.keys).to include(absolute_path("calculator/calculator.rb"))
-          end
-        end
-      end
-
-      context "when root is in deeply nested dir" do
-        let(:root) { absolute_path("calculator/operations/suboperations") }
-
-        it "does not fail but also does not collect coverages" do
-          subject.start
-
-          expect(calculator.add(1, 2)).to eq(3)
-          expect(calculator.subtract(1, 2)).to eq(-1)
-
-          coverage = subject.stop
-
-          expect(coverage.size).to eq(0)
-        end
-      end
-
-      context "when root is in the subdirectory of the project" do
-        let(:root) { absolute_path("calculator/operations") }
-
-        it "collects code coverage including operations only" do
-          subject.start
-
-          expect(calculator.add(1, 2)).to eq(3)
-          expect(calculator.subtract(1, 2)).to eq(-1)
-
-          coverage = subject.stop
-
-          expect(coverage.size).to eq(2)
-          expect(coverage.keys).to include(
-            absolute_path("calculator/operations/add.rb"),
-            absolute_path("calculator/operations/subtract.rb")
-          )
-        end
-
-        it "clears the coverage data after stopping" do
-          subject.start
-          expect(calculator.add(1, 2)).to eq(3)
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-          expect(coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
-
-          subject.start
-          expect(calculator.subtract(1, 2)).to eq(-1)
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-          expect(coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
-        end
-
-        it "does not track coverage when stopped" do
-          subject.start
-          expect(calculator.add(1, 2)).to eq(3)
-          subject.stop
-
-          expect(calculator.subtract(1, 2)).to eq(-1)
-
-          subject.start
-          expect(calculator.multiply(1, 2)).to eq(2)
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-          expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
-        end
-
-        it "does not fail if start called several times" do
-          subject.start
-          expect(calculator.add(1, 2)).to eq(3)
-
-          subject.start
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-        end
-
-        it "does not fail if stop called several times" do
-          subject.start
-          expect(calculator.add(1, 2)).to eq(3)
-          coverage = subject.stop
-          expect(coverage.size).to eq(1)
-
-          expect(subject.stop).to eq({})
-        end
-
-        it "tracks coverage in mixins" do
-          subject.start
-          expect(calculator.divide(6, 3)).to eq(2)
-          coverage = subject.stop
-          expect(coverage.size).to eq(2)
-          expect(coverage.keys).to include(absolute_path("calculator/operations/divide.rb"))
-          expect(coverage.keys).to include(absolute_path("calculator/operations/helpers/calculator_logger.rb"))
-        end
-
-        context "multi threaded execution" do
-          def thread_local_cov
-            Thread.current[:datadog_ci_cov] ||= described_class.new(root: root)
-          end
-
-          it "collects coverage for each thread separately" do
-            t1_queue = Queue.new
-            t2_queue = Queue.new
-
-            t1 = Thread.new do
-              cov = thread_local_cov
-              cov.start
-
-              t1_queue << :ready
-              expect(t2_queue.pop).to be(:ready)
-
-              expect(calculator.add(1, 2)).to eq(3)
-              expect(calculator.multiply(1, 2)).to eq(2)
-
-              t1_queue << :done
-              expect(t2_queue.pop).to be :done
-
-              coverage = cov.stop
-              expect(coverage.size).to eq(2)
-              expect(coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
-              expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
-            end
-
-            t2 = Thread.new do
-              cov = thread_local_cov
-              cov.start
-
-              t2_queue << :ready
-              expect(t1_queue.pop).to be(:ready)
-
-              expect(calculator.subtract(1, 2)).to eq(-1)
-
-              t2_queue << :done
-              expect(t1_queue.pop).to be :done
-
-              coverage = cov.stop
-              expect(coverage.size).to eq(1)
-              expect(coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
-            end
-
-            [t1, t2].each(&:join)
-          end
-        end
+        coverage = cov.stop
+        expect(coverage).to eq({})
       end
     end
 
-    context "in lines mode" do
-      let(:mode) { :lines }
+    context "when root is the calculator project dir" do
       let(:root) { absolute_path("calculator") }
 
-      it "collects code coverage with lines" do
+      it "collects code coverage including Calculator and operations" do
         subject.start
 
         expect(calculator.add(1, 2)).to eq(3)
@@ -227,11 +39,173 @@ RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
         coverage = subject.stop
 
         expect(coverage.size).to eq(3)
-        expect(coverage).to eq({
-          absolute_path("calculator/calculator.rb") => {17 => true, 21 => true},
-          absolute_path("calculator/operations/add.rb") => {5 => true},
-          absolute_path("calculator/operations/subtract.rb") => {5 => true}
-        })
+        expect(coverage.keys).to include(
+          absolute_path("calculator/calculator.rb"),
+          absolute_path("calculator/operations/add.rb"),
+          absolute_path("calculator/operations/subtract.rb")
+        )
+      end
+
+      it "supports files with non-ASCII characters" do
+        subject.start
+        expect(I❤️Ruby.new.call).to eq("I ❤️ Ruby")
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+        expect(coverage.keys).to include(absolute_path("calculator/code_with_❤️.rb"))
+      end
+
+      context "when ignored_path is set" do
+        let(:ignored_path) { absolute_path("calculator/operations") }
+
+        it "collects code coverage excluding ignored_path" do
+          subject.start
+
+          expect(calculator.add(1, 2)).to eq(3)
+          expect(calculator.subtract(1, 2)).to eq(-1)
+
+          coverage = subject.stop
+
+          expect(coverage.size).to eq(1)
+          expect(coverage.keys).to include(absolute_path("calculator/calculator.rb"))
+        end
+      end
+    end
+
+    context "when root is in deeply nested dir" do
+      let(:root) { absolute_path("calculator/operations/suboperations") }
+
+      it "does not fail but also does not collect coverages" do
+        subject.start
+
+        expect(calculator.add(1, 2)).to eq(3)
+        expect(calculator.subtract(1, 2)).to eq(-1)
+
+        coverage = subject.stop
+
+        expect(coverage.size).to eq(0)
+      end
+    end
+
+    context "when root is in the subdirectory of the project" do
+      let(:root) { absolute_path("calculator/operations") }
+
+      it "collects code coverage including operations only" do
+        subject.start
+
+        expect(calculator.add(1, 2)).to eq(3)
+        expect(calculator.subtract(1, 2)).to eq(-1)
+
+        coverage = subject.stop
+
+        expect(coverage.size).to eq(2)
+        expect(coverage.keys).to include(
+          absolute_path("calculator/operations/add.rb"),
+          absolute_path("calculator/operations/subtract.rb")
+        )
+      end
+
+      it "clears the coverage data after stopping" do
+        subject.start
+        expect(calculator.add(1, 2)).to eq(3)
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+        expect(coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
+
+        subject.start
+        expect(calculator.subtract(1, 2)).to eq(-1)
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+        expect(coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
+      end
+
+      it "does not track coverage when stopped" do
+        subject.start
+        expect(calculator.add(1, 2)).to eq(3)
+        subject.stop
+
+        expect(calculator.subtract(1, 2)).to eq(-1)
+
+        subject.start
+        expect(calculator.multiply(1, 2)).to eq(2)
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+        expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
+      end
+
+      it "does not fail if start called several times" do
+        subject.start
+        expect(calculator.add(1, 2)).to eq(3)
+
+        subject.start
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+      end
+
+      it "does not fail if stop called several times" do
+        subject.start
+        expect(calculator.add(1, 2)).to eq(3)
+        coverage = subject.stop
+        expect(coverage.size).to eq(1)
+
+        expect(subject.stop).to eq({})
+      end
+
+      it "tracks coverage in mixins" do
+        subject.start
+        expect(calculator.divide(6, 3)).to eq(2)
+        coverage = subject.stop
+        expect(coverage.size).to eq(2)
+        expect(coverage.keys).to include(absolute_path("calculator/operations/divide.rb"))
+        expect(coverage.keys).to include(absolute_path("calculator/operations/helpers/calculator_logger.rb"))
+      end
+
+      context "multi threaded execution" do
+        def thread_local_cov
+          Thread.current[:datadog_ci_cov] ||= described_class.new(root: root)
+        end
+
+        it "collects coverage for each thread separately" do
+          t1_queue = Queue.new
+          t2_queue = Queue.new
+
+          t1 = Thread.new do
+            cov = thread_local_cov
+            cov.start
+
+            t1_queue << :ready
+            expect(t2_queue.pop).to be(:ready)
+
+            expect(calculator.add(1, 2)).to eq(3)
+            expect(calculator.multiply(1, 2)).to eq(2)
+
+            t1_queue << :done
+            expect(t2_queue.pop).to be :done
+
+            coverage = cov.stop
+            expect(coverage.size).to eq(2)
+            expect(coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
+            expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
+          end
+
+          t2 = Thread.new do
+            cov = thread_local_cov
+            cov.start
+
+            t2_queue << :ready
+            expect(t1_queue.pop).to be(:ready)
+
+            expect(calculator.subtract(1, 2)).to eq(-1)
+
+            t2_queue << :done
+            expect(t1_queue.pop).to be :done
+
+            coverage = cov.stop
+            expect(coverage.size).to eq(1)
+            expect(coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
+          end
+
+          [t1, t2].each(&:join)
+        end
       end
     end
   end

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -17,13 +17,10 @@ RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
     let!(:calculator) { Calculator.new }
 
     context "when allocating and starting coverage without a root" do
-      it "does not fail" do
+      it "throws Runtime error" do
         cov = described_class.allocate
-        cov.start
-        expect(calculator.add(1, 2)).to eq(3)
 
-        coverage = cov.stop
-        expect(coverage).to eq({})
+        expect { cov.start }.to raise_error(RuntimeError, "root is required")
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
Applies the following changes and optimizations to per test code coverage:
- removes lines code coverage mode as it is not used and is not going to be used in the near future, so it is just a dead code right now
- caches last seen filename pointer so that if we cover sequential lines in the same file we skip prefix check and saving file name in the coverage hash table
- `dd_cov_data->root` and `dd_cov_data->ignored_path` are now copied (once) in malloc'd memory and stored as C-strings
- to avoid string copying, `rb_profile_frames` function is now used to store filename in resulting hash: it improves performance and solves UTF-8 filenames issue

**How to test the change?**
Tested using test-environment integration test stand: https://github.com/DataDog/test-environment/pull/283

The following changes in performance overhead were recorded:

**Rubocop**
From [109%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/504983829) to [86%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/505079404) => 27% improvement

**Middleman**
From [29,7%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/504983815) to [28,6%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/505079396) => no change

**Jekyll**
From [0,4%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/504983806) to [0,3%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/505079390) => no change

**devdocs**
From [16,4%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/504983821) to [16,9%](https://gitlab.ddbuild.io/DataDog/apm-reliability/test-environment/-/jobs/505079400) => no change

Overall result: it does not change anything for projects where code coverage overhead was low enough but provides meaningful improvement for the project where code coverage overhead was the largest. 