### PR TITLE
[NO TICKET] remove deprecated use alias

### DIFF
--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -89,9 +89,6 @@ module Datadog
                 fetch_integration(integration_name).configuration
               end
 
-              # @deprecated Will be removed on datadog-ci-rb 1.0.
-              alias_method :use, :instrument
-
               option :trace_flush
 
               option :writer_options do |o|


### PR DESCRIPTION
**What does this PR do?**
Removes deprecated `use` alias - use `instrument` instead
