### PR TITLE
log an error message if tracing is disabled but test visibility is enabled

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -43,6 +43,16 @@ module Datadog
         end
 
         def activate_ci!(settings)
+          unless settings.tracing.enabled
+            Datadog.logger.error(
+              "CI visibility requires tracing to be enabled. Disabling CI visibility. " \
+              "NOTE: if you didn't disable tracing intentionally, add `c.tracing enabled = true` to " \
+              "your Datadog.configure block."
+            )
+            settings.ci.enabled = false
+            return
+          end
+
           # Configure ddtrace library for CI visibility mode
           # Deactivate telemetry
           settings.telemetry.enabled = false

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -46,7 +46,7 @@ module Datadog
           unless settings.tracing.enabled
             Datadog.logger.error(
               "CI visibility requires tracing to be enabled. Disabling CI visibility. " \
-              "NOTE: if you didn't disable tracing intentionally, add `c.tracing enabled = true` to " \
+              "NOTE: if you didn't disable tracing intentionally, add `c.tracing.enabled = true` to " \
               "your Datadog.configure block."
             )
             settings.ci.enabled = false

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Datadog::CI::Configuration::Components do
       context "when #ci" do
         before do
           # Configure CI mode
+          settings.tracing.enabled = tracing_enabled
           settings.ci.enabled = enabled
           settings.ci.agentless_mode_enabled = agentless_enabled
 
@@ -95,12 +96,23 @@ RSpec.describe Datadog::CI::Configuration::Components do
         let(:evp_proxy_v2_supported) { false }
         let(:evp_proxy_v4_supported) { false }
         let(:itr_enabled) { false }
+        let(:tracing_enabled) { true }
 
         context "is enabled" do
           let(:enabled) { true }
 
           it "collects environment tags" do
             expect(Datadog::CI::Ext::Environment).to have_received(:tags).with(ENV)
+          end
+
+          context "when tracing is disabled" do
+            let(:tracing_enabled) { false }
+
+            it "logs an error message and disables CI visibility" do
+              expect(Datadog.logger).to have_received(:error)
+
+              expect(settings.ci.enabled).to eq(false)
+            end
           end
 
           context "when #force_test_level_visibility" do


### PR DESCRIPTION
**What does this PR do?**
Logs an error message when tracing is disabled but test visibility is enabled.

**Motivation**
There are many cases when tracing is disabled by competing configuration (most often in `initializers` folder to disable APM in non-production environments). Currently in this cases this library continues to work silently skipping all traces. This PR fixes that by catching attention of developer: hopefully this will lead to easier onboarding.

**How to test the change?**
Unit tests are provided