### PR TITLE
[CIVIS-10061] Fix Knapsack Pro integration

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,10 @@ TEST_METADATA = {
     "minitest-5-shoulda-context-2-shoulda-matchers-6" => "❌ 2.7 / ❌ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby"
   },
   "knapsack_rspec" => {
-    "knapsack_pro-7-rspec-3" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ jruby"
+    "knapsack_pro-7-rspec-3" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ❌ jruby"
+  },
+  "knapsack_rspec_go" => {
+    "knapsack_pro-7-rspec-3" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ❌ jruby"
   }
 }
 
@@ -132,7 +135,8 @@ namespace :spec do
     :activesupport,
     :ci_queue_minitest,
     :ci_queue_rspec,
-    :knapsack_rspec
+    :knapsack_rspec,
+    :knapsack_rspec_go
   ].each do |contrib|
     desc "" # "Explicitly hiding from `rake -T`"
     RSpec::Core::RakeTask.new(contrib) do |t, args|

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -17,6 +17,7 @@ module Datadog
 
           module InstanceMethods
             def run(*)
+              return super if ::RSpec.configuration.dry_run?
               return super unless datadog_configuration[:enabled]
 
               test_name = full_description.strip

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -16,6 +16,7 @@ module Datadog
           # Instance methods for configuration
           module ClassMethods
             def run(reporter = ::RSpec::Core::NullReporter)
+              return super if ::RSpec.configuration.dry_run?
               return super unless datadog_configuration[:enabled]
               return super unless top_level?
 

--- a/lib/datadog/ci/contrib/rspec/knapsack_pro/extension.rb
+++ b/lib/datadog/ci/contrib/rspec/knapsack_pro/extension.rb
@@ -8,7 +8,6 @@ module Datadog
   module CI
     module Contrib
       module RSpec
-        # Instrument RSpec::Core::Example
         module KnapsackPro
           module Extension
             def self.included(base)

--- a/lib/datadog/ci/contrib/rspec/knapsack_pro/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/knapsack_pro/patcher.rb
@@ -11,7 +11,7 @@ module Datadog
                   ::RSpec::Core::Runner.ancestors.include?(::KnapsackPro::Extensions::RSpecExtension::Runner)
                 # knapsack already patched rspec runner
                 require_relative "runner"
-                ::RSpec::Core::Runner.include(Datadog::CI::Contrib::RSpec::KnapsackPro::Runner)
+                ::RSpec::Core::Runner.include(KnapsackPro::Runner)
               else
                 # knapsack didn't patch rspec runner yet
                 require_relative "extension"

--- a/lib/datadog/ci/contrib/rspec/knapsack_pro/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/knapsack_pro/patcher.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        module KnapsackPro
+          module Patcher
+            def self.patch
+              if defined?(::KnapsackPro::Extensions::RSpecExtension::Runner) &&
+                  ::RSpec::Core::Runner.ancestors.include?(::KnapsackPro::Extensions::RSpecExtension::Runner)
+                # knapsack already patched rspec runner
+                require_relative "runner"
+                ::RSpec::Core::Runner.include(Datadog::CI::Contrib::RSpec::KnapsackPro::Runner)
+              else
+                # knapsack didn't patch rspec runner yet
+                require_relative "extension"
+                ::KnapsackPro::Extensions::RSpecExtension.include(KnapsackPro::Extension)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/rspec/knapsack_pro/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/knapsack_pro/runner.rb
@@ -15,6 +15,7 @@ module Datadog
 
             module InstanceMethods
               def knapsack__run_specs(*)
+                return super if ::RSpec.configuration.dry_run?
                 return super unless datadog_configuration[:enabled]
 
                 test_session = CI.start_test_session(

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -27,14 +27,16 @@ module Datadog
               ::RSpec::Queue::Runner.include(Runner)
             end
 
-            # Knapsack Pro test runner instrumentation
-            # https://github.com/KnapsackPro/knapsack_pro-ruby
             if knapsack_pro?
-              require_relative "knapsack_pro/extension"
-              ::KnapsackPro::Extensions::RSpecExtension.include(KnapsackPro::Extension)
+              # Knapsack Pro test runner instrumentation
+              # https://github.com/KnapsackPro/knapsack_pro-ruby
+              require_relative "knapsack_pro/patcher"
+              Datadog::CI::Contrib::RSpec::KnapsackPro::Patcher.patch
             end
 
+            # default rspec test runner instrumentation
             ::RSpec::Core::Runner.include(Runner)
+
             ::RSpec::Core::Example.include(Example)
             ::RSpec::Core::ExampleGroup.include(ExampleGroup)
           end

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -15,6 +15,7 @@ module Datadog
 
           module InstanceMethods
             def run_specs(*)
+              return super if ::RSpec.configuration.dry_run?
               return super unless datadog_configuration[:enabled]
 
               test_session = CI.start_test_session(

--- a/sig/datadog/ci/contrib/rspec/knapsack_pro/patcher.rbs
+++ b/sig/datadog/ci/contrib/rspec/knapsack_pro/patcher.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module CI
+    module Contrib
+      module RSpec
+        module KnapsackPro
+          module Patcher
+            def self.patch: () -> void
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
@@ -73,26 +73,4 @@ RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
     expect(test_spans).to all have_test_tag(:test_module_id)
     expect(test_spans).to all have_test_tag(:test_session_id)
   end
-
-  context "when collecting examples with knapsack_pro:rspec_test_example_detector" do
-    it "does not instrument this rspec session" do
-      with_new_rspec_environment do
-        ClimateControl.modify(
-          "KNAPSACK_PRO_CI_NODE_BUILD_ID" => "143",
-          "KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" => "example_token",
-          "KNAPSACK_PRO_FIXED_QUEUE_SPLIT" => "true"
-        ) do
-          expect(KnapsackPro::SlowTestFileDeterminer).to receive(:read_from_json_report).and_return([])
-
-          detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
-          detector.generate_json_report
-        rescue ArgumentError
-          # suppress invalid API key error
-        end
-      end
-
-      expect(test_session_span).to be_nil
-      expect(test_spans).to be_empty
-    end
-  end
 end

--- a/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
@@ -1,18 +1,7 @@
 require "knapsack_pro"
 require "fileutils"
 
-RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
-  include_context "CI mode activated" do
-    let(:integration_name) { :rspec }
-  end
-
-  before do
-    allow_any_instance_of(KnapsackPro::Runners::Queue::RSpecRunner).to receive(:test_file_paths).and_return(
-      ["./spec/datadog/ci/contrib/knapsack_rspec/suite_under_test/some_test_rspec.rb"],
-      []
-    )
-  end
-
+RSpec.describe "Knapsack Pro runner when Datadog::CI is configured during the knapsack run like in rspec_go rake task" do
   # Yields to a block in a new RSpec global context. All RSpec
   # test configuration and execution should be wrapped in this method.
   def with_new_rspec_environment
@@ -31,15 +20,29 @@ RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
     File.new("/dev/null", "w")
   end
 
+  before do
+    allow_any_instance_of(Datadog::Core::Remote::Negotiation).to(
+      receive(:endpoint?).with("/evp_proxy/v4/").and_return(true)
+    )
+
+    allow(Datadog::CI::Utils::TestRun).to receive(:command).and_return("knapsack:queue:rspec")
+
+    allow_any_instance_of(KnapsackPro::Runners::Queue::RSpecRunner).to receive(:test_file_paths).and_return(
+      ["./spec/datadog/ci/contrib/knapsack_rspec_go/suite_under_test/some_test_rspec.rb"],
+      []
+    )
+  end
+
   it "instruments this rspec session" do
     with_new_rspec_environment do
       ClimateControl.modify(
-        "KNAPSACK_PRO_CI_NODE_BUILD_ID" => "142",
+        "KNAPSACK_PRO_CI_NODE_BUILD_ID" => "144",
         "KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" => "example_token",
-        "KNAPSACK_PRO_FIXED_QUEUE_SPLIT" => "true"
+        "KNAPSACK_PRO_FIXED_QUEUE_SPLIT" => "true",
+        "KNAPSACK_PRO_QUEUE_ID" => nil
       ) do
         KnapsackPro::Adapters::RSpecAdapter.bind
-        KnapsackPro::Runners::Queue::RSpecRunner.run("", devnull, devnull)
+        KnapsackPro::Runners::Queue::RSpecRunner.run("--require knapsack_helper", devnull, devnull)
       rescue ArgumentError
         # suppress invalid API key error
       end
@@ -57,7 +60,7 @@ RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
     expect(test_suite_spans.first).to have_test_tag(:status, Datadog::CI::Ext::Test::Status::FAIL)
     expect(test_suite_spans.first).to have_test_tag(
       :suite,
-      "SomeTest at ./spec/datadog/ci/contrib/knapsack_rspec/suite_under_test/some_test_rspec.rb"
+      "SomeTest at ./spec/datadog/ci/contrib/knapsack_rspec_go/suite_under_test/some_test_rspec.rb"
     )
 
     # there is test span for every test case
@@ -72,27 +75,5 @@ RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
     # every test span is connected to test module and test session
     expect(test_spans).to all have_test_tag(:test_module_id)
     expect(test_spans).to all have_test_tag(:test_session_id)
-  end
-
-  context "when collecting examples with knapsack_pro:rspec_test_example_detector" do
-    it "does not instrument this rspec session" do
-      with_new_rspec_environment do
-        ClimateControl.modify(
-          "KNAPSACK_PRO_CI_NODE_BUILD_ID" => "143",
-          "KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" => "example_token",
-          "KNAPSACK_PRO_FIXED_QUEUE_SPLIT" => "true"
-        ) do
-          expect(KnapsackPro::SlowTestFileDeterminer).to receive(:read_from_json_report).and_return([])
-
-          detector = KnapsackPro::TestCaseDetectors::RSpecTestExampleDetector.new
-          detector.generate_json_report
-        rescue ArgumentError
-          # suppress invalid API key error
-        end
-      end
-
-      expect(test_session_span).to be_nil
-      expect(test_spans).to be_empty
-    end
   end
 end

--- a/spec/datadog/ci/contrib/knapsack_rspec_go/suite_under_test/some_test_rspec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec_go/suite_under_test/some_test_rspec.rb
@@ -1,0 +1,13 @@
+require "rspec"
+
+RSpec.describe "SomeTest" do
+  context "nested" do
+    it "foo" do
+      # DO NOTHING
+    end
+
+    it "fails" do
+      expect(1).to eq(2)
+    end
+  end
+end

--- a/spec/knapsack_helper.rb
+++ b/spec/knapsack_helper.rb
@@ -1,0 +1,8 @@
+# this file is required for knapsack unit tests
+
+Datadog.configure do |c|
+  c.service = "knapsack_rspec_example"
+  c.ci.enabled = true
+  c.ci.git_metadata_upload_enabled = false
+  c.ci.instrument :rspec
+end

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -88,5 +88,9 @@ RSpec.shared_context "CI mode activated" do
 
     Datadog::CI.send(:itr_runner)&.shutdown!
     Datadog::CI.send(:recorder)&.shutdown!
+
+    Datadog.configure do |c|
+      c.ci.enabled = false
+    end
   end
 end

--- a/vendor/rbs/knapsack_pro/0/knapsack_pro.rbs
+++ b/vendor/rbs/knapsack_pro/0/knapsack_pro.rbs
@@ -12,6 +12,9 @@ module KnapsackPro
   module Extensions
     module RSpecExtension
       def setup!: () -> void
+
+      module Runner
+      end
     end
   end
 end

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -1,4 +1,5 @@
 module RSpec
+  def self.configuration: () -> RSpec::Core::Configuration
 end
 
 module RSpec::Core
@@ -35,4 +36,8 @@ module RSpec::Core::ExampleGroup
 end
 
 class RSpec::Core::NullReporter
+end
+
+class RSpec::Core::Configuration
+  def dry_run?: () -> bool
 end


### PR DESCRIPTION
Fixes #147

This PR fixes the following issues with our current Knapsack Pro support:

**Dropping tests because of missing test session**

When running `knapsack_pro:rspec:queue` command, `Datadog.configure` block gets called when `rails_helper` is required which in this case happens after `KnapsackPro::Extensions::RSpecExtension.setup!` had been run. 

To fix this, we check whether `RSpec::Core::Runner` was already instrumented by knapsack: if yes, we instrument `RSpec::Core::Runner` directly. If not, we hook into `KnapsackPro::Extensions::RSpecExtension` to instrument the runner after knapsack injects its methods:

```ruby
if defined?(::KnapsackPro::Extensions::RSpecExtension::Runner) &&
  ::RSpec::Core::Runner.ancestors.include?(::KnapsackPro::Extensions::RSpecExtension::Runner)
  # knapsack already patched rspec runner
  require_relative "runner"
  ::RSpec::Core::Runner.include(KnapsackPro::Runner)
else
  # knapsack didn't patch rspec runner yet
  require_relative "extension"
  ::KnapsackPro::Extensions::RSpecExtension.include(KnapsackPro::Extension)
end
```

**Noise from knapsack_pro:rspec_test_example_detector test command**

We noticed that in many cases when using knapsack, we got a lot more test runs than there are unique tests; additional test runs all have very short duration and are part of `knapsack_pro:rspec_test_example_detector`.

It turned out, that we trace rspec session that is running with `--dry-run`: test example detector from knapsack uses dry run to generate a report with all rspec examples. 

This issue is fixed by never tracing rspec tests when dry run is enabled:

```ruby
return super if ::RSpec.configuration.dry_run?
```

**How to test the change?**
Unit tests are provided and additionally tested with Github Actions: https://github.com/DataDog/rails-app-with-knapsack_pro/actions/workflows/main.yaml

The test runs arrived correctly:
<img width="1306" alt="image" src="https://github.com/DataDog/datadog-ci-rb/assets/426400/0140d762-382f-4f59-9776-6cea1eb8647f">

There are no additional test runs from `rspec_test_example_detector` - the number of tests is equal to the number of test runs (51 vs 51)