### PR TITLE
Bump to version 1.0.0.beta5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [1.0.0.beta5] - 2024-05-23
+
+### Changed
+
+* accept gzipped responses from API ([#170][])
+
+### Fixed
+
+* Fix Knapsack Pro integration ([#180][])
+
 ## [1.0.0.beta4] - 2024-05-14
 
 ### Added
@@ -238,7 +248,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta4...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta5...main
+[1.0.0.beta5]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta4...v1.0.0.beta5
 [1.0.0.beta4]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta3...v1.0.0.beta4
 [1.0.0.beta3]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta2...v1.0.0.beta3
 [1.0.0.beta2]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.0.beta1...v1.0.0.beta2
@@ -334,7 +345,9 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#166]: https://github.com/DataDog/datadog-ci-rb/issues/166
 [#167]: https://github.com/DataDog/datadog-ci-rb/issues/167
 [#168]: https://github.com/DataDog/datadog-ci-rb/issues/168
+[#170]: https://github.com/DataDog/datadog-ci-rb/issues/170
 [#172]: https://github.com/DataDog/datadog-ci-rb/issues/172
 [#173]: https://github.com/DataDog/datadog-ci-rb/issues/173
 [#174]: https://github.com/DataDog/datadog-ci-rb/issues/174
 [#175]: https://github.com/DataDog/datadog-ci-rb/issues/175
+[#180]: https://github.com/DataDog/datadog-ci-rb/issues/180

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.0.0.beta4)
+    datadog-ci (1.0.0.beta5)
       datadog (~> 2.0.0.beta2)
       msgpack
 

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -6,7 +6,7 @@ module Datadog
       MAJOR = "1"
       MINOR = "0"
       PATCH = "0"
-      PRE = "beta4"
+      PRE = "beta5"
       BUILD = nil
       # PRE and BUILD above are modified for dev gems during gem build GHA workflow
 


### PR DESCRIPTION
### Changed

* accept gzipped responses from API (#170)

### Fixed

* Fix Knapsack Pro integration (#180)

