### PR TITLE
[NO-TICKET] reenable git specs for jruby and delete useless flaky spec

### DIFF
--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -681,19 +681,6 @@ RSpec.describe "Minitest instrumentation" do
           expect(first_test_span).to have_test_tag(:test_session_id, test_session_span.id.to_s)
         end
 
-        it "correctly tracks test and session durations" do
-          test_session_duration = test_session_span.duration
-
-          test_durations_sum = test_spans.map { |span| span.duration }.sum
-          # with parallel execution test durations sum should be greater than test session duration
-          expect(test_durations_sum).to be > test_session_duration
-
-          # each individual test duration should be less than test session duration
-          test_spans.each do |span|
-            expect(span.duration).to be < test_session_duration
-          end
-        end
-
         it "creates test suite spans" do
           expect(test_suite_spans).to have(4).items
 

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -218,8 +218,6 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
   end
 
   context "with cloned repository" do
-    before { skip if PlatformHelpers.jruby? }
-
     let(:commits_count) { 2 }
 
     let(:tmpdir) { Dir.mktmpdir }


### PR DESCRIPTION
**What does this PR do?**
Very minor improvements for gem's CI as a follow up to the updated jruby 9.4 image

