### PR TITLE
[NO TICKET] test code coverage with symlinked dependency required via entrypoint

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ namespace :test do
           "bundle exec appraisal #{ruby_runtime}-#{appraisal_group} rake #{spec_task}"
         end
 
-        command += "'[#{spec_arguments}]'" if spec_arguments
+        command = "#{command} '[#{spec_arguments}]'" if spec_arguments
 
         total_executors = ENV.key?("CIRCLE_NODE_TOTAL") ? ENV["CIRCLE_NODE_TOTAL"].to_i : nil
         current_executor = ENV.key?("CIRCLE_NODE_INDEX") ? ENV["CIRCLE_NODE_INDEX"].to_i : nil
@@ -133,18 +133,17 @@ namespace :spec do
   end
 
   # Datadog CI integrations
-  [
-    :cucumber,
-    :rspec,
-    :minitest,
-    :minitest_shoulda_context,
-    :activesupport,
-    :ci_queue_minitest,
-    :ci_queue_rspec,
-    :knapsack_rspec,
-    :knapsack_rspec_go,
-    :selenium,
-    :timecop
+  %i[
+    cucumber
+    rspec
+    minitest
+    minitest_shoulda_context
+    activesupport
+    ci_queue_minitest
+    ci_queue_rspec
+    knapsack_rspec
+    knapsack_rspec_go
+    selenium timecop
   ].each do |contrib|
     desc "" # "Explicitly hiding from `rake -T`"
     RSpec::Core::RakeTask.new(contrib) do |t, args|

--- a/spec/ddcov/calculator_with_symlinks/calculator.rb
+++ b/spec/ddcov/calculator_with_symlinks/calculator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative "vendor/gems/operations/operations"
+
+class Calculator
+  def initialize
+    @adder = Add.new
+    @subtractor = Subtract.new
+    @multiplier = Multiply.new
+    @divider = Divide.new
+  end
+
+  def add(a, b)
+    @adder.call(a, b)
+  end
+
+  def subtract(a, b)
+    @subtractor.call(a, b)
+  end
+
+  def multiply(a, b)
+    @multiplier.call(a, b)
+  end
+
+  def divide(a, b)
+    @divider.call(a, b)
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/operations/add.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/add.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Add
+  def call(a, b)
+    a + b
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/operations/divide.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/divide.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "helpers/calculator_logger"
+
+class Divide
+  prepend CalculatorLogger
+
+  def call(a, b)
+    a / b
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/operations/helpers/calculator_logger.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/helpers/calculator_logger.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CalculatorLogger
+  def call(a, b)
+    res = super
+
+    @log ||= []
+    @log << "operation performed"
+
+    res
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/operations/multiply.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/multiply.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Multiply
+  def call(a, b)
+    a * b
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/operations/operations.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/operations.rb
@@ -1,0 +1,4 @@
+require_relative "add"
+require_relative "divide"
+require_relative "multiply"
+require_relative "subtract"

--- a/spec/ddcov/calculator_with_symlinks/operations/subtract.rb
+++ b/spec/ddcov/calculator_with_symlinks/operations/subtract.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Subtract
+  def call(a, b)
+    a - b
+  end
+end

--- a/spec/ddcov/calculator_with_symlinks/vendor/gems/operations
+++ b/spec/ddcov/calculator_with_symlinks/vendor/gems/operations
@@ -1,0 +1,1 @@
+/Users/andrey.marchenko/p/datadog-ci-rb/spec/ddcov/calculator_with_symlinks/operations

--- a/spec/ddcov/calculator_with_symlinks/vendor/gems/operations
+++ b/spec/ddcov/calculator_with_symlinks/vendor/gems/operations
@@ -1,1 +1,0 @@
-/Users/andrey.marchenko/p/datadog-ci-rb/spec/ddcov/calculator_with_symlinks/operations

--- a/spec/ddcov/ddcov_with_symlinks_spec.rb
+++ b/spec/ddcov/ddcov_with_symlinks_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+
+require_relative "calculator_with_symlinks/calculator"
+
+RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
+  def absolute_path(path)
+    File.expand_path(File.join(__dir__, path))
+  end
+
+  subject { described_class.new(root: root) }
+
+  describe "code coverage collection" do
+    let!(:calculator) { Calculator.new }
+
+    context "when root is the calculator project dir" do
+      let(:root) { absolute_path("calculator_with_symlinks") }
+
+      it "collects code coverage including Calculator and operations" do
+        subject.start
+
+        expect(calculator.add(1, 2)).to eq(3)
+        expect(calculator.subtract(1, 2)).to eq(-1)
+
+        coverage = subject.stop
+
+        expect(coverage.size).to eq(3)
+        expect(coverage.keys).to include(
+          absolute_path("calculator_with_symlinks/calculator.rb"),
+          absolute_path("calculator_with_symlinks/operations/add.rb"),
+          absolute_path("calculator_with_symlinks/operations/subtract.rb")
+        )
+      end
+    end
+  end
+end

--- a/spec/ddcov/ddcov_with_symlinks_spec.rb
+++ b/spec/ddcov/ddcov_with_symlinks_spec.rb
@@ -1,12 +1,30 @@
 # frozen_string_literal: true
 
-require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
+require "fileutils"
 
-require_relative "calculator_with_symlinks/calculator"
+require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
 
 RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
   def absolute_path(path)
     File.expand_path(File.join(__dir__, path))
+  end
+
+  before do
+    # create a symlink to the calculator_with_symlinks/operations folder in vendor/gems
+    FileUtils.ln_s(
+      absolute_path("calculator_with_symlinks/operations"),
+      absolute_path("calculator_with_symlinks/vendor/gems/operations"),
+      force: true
+    )
+
+    require_relative "calculator_with_symlinks/calculator"
+  end
+
+  after do
+    # delete symlink
+    FileUtils.rm_f(
+      absolute_path("calculator_with_symlinks/vendor/gems/operations")
+    )
   end
 
   subject { described_class.new(root: root) }


### PR DESCRIPTION
**What does this PR do?**
This PR adds a test to assert that code coverage tool gets correct file paths when dependencies are located in symlinked folder and required via single entrypoint (emulating usage of local dependencies that are just symlinks to modules in minirepo).

**Motivation**
Make sure that code coverage won't break in the future as this is known case for the monorepo setup.

**How to test the change?**
This PR adds only unit tests.