### PR TITLE
[SDTEST-188] depend on gem datadog ~> 2.0

### DIFF
--- a/datadog-ci.gemspec
+++ b/datadog-ci.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "datadog", "~> 2.0.0.beta2"
+  spec.add_dependency "datadog", "~> 2.0"
   spec.add_dependency "msgpack"
 
   spec.extensions = ["ext/datadog_cov/extconf.rb"]

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -23,9 +23,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -36,7 +36,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +29,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,7 +27,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,7 +51,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +53,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +28,7 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3-java)
     json (2.7.2-java)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
+    libdatadog (9.0.0.1.0)
     libddwaf (1.14.0.0.0-java)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +28,7 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +28,7 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +28,7 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,7 +34,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,7 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,7 +29,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,7 +27,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,7 +45,7 @@ GEM
     gherkin (5.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,7 +66,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,7 +67,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,7 +57,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,7 +51,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,7 +53,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,7 +28,7 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,7 +43,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,7 +26,7 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     lint_roller (1.1.0)

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,8 +34,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -21,9 +21,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -34,8 +34,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -22,9 +22,9 @@ GEM
     climate_control (1.2.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -35,8 +35,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,8 +43,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -18,9 +18,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -29,8 +29,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -16,9 +16,9 @@ GEM
     ci-queue (0.53.0)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -27,8 +27,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -33,9 +33,9 @@ GEM
     cucumber-expressions (6.0.1)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -45,8 +45,8 @@ GEM
     gherkin (5.1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -49,9 +49,9 @@ GEM
       cucumber-core (~> 7.0, >= 7.0.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.1, >= 12.1.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -62,8 +62,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -53,9 +53,9 @@ GEM
       cucumber-core (~> 8.0, >= 8.0.1)
       cucumber-cucumber-expressions (~> 10.3, >= 10.3.0)
       cucumber-messages (~> 13.0, >= 13.0.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -66,8 +66,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,9 +54,9 @@ GEM
       cucumber-core (~> 9.0, >= 9.0.1)
       cucumber-cucumber-expressions (~> 12.1, >= 12.1.1)
       cucumber-messages (~> 15.0, >= 15.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -67,8 +67,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -46,9 +46,9 @@ GEM
     cucumber-wire (6.2.1)
       cucumber-core (~> 10.1, >= 10.1.0)
       cucumber-cucumber-expressions (~> 14.0, >= 14.0.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -57,8 +57,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -40,9 +40,9 @@ GEM
       cucumber-messages (~> 18.0, >= 18.0.0)
     cucumber-messages (18.0.0)
     cucumber-tag-expressions (4.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -51,8 +51,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -42,9 +42,9 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -53,8 +53,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -28,8 +28,8 @@ GEM
     knapsack_pro (7.3.0)
       rake
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,8 +26,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -29,9 +29,9 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -43,8 +43,8 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,9 +15,9 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.beta2)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
     debase-ruby_core_source (3.3.1)
@@ -26,8 +26,8 @@ GEM
     ffi (1.16.3)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
+    libdatadog (9.0.0.1.0)
+    libdatadog (9.0.0.1.0-aarch64-linux)
     libddwaf (1.14.0.0.0-aarch64-linux)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-arm64-darwin)

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -54,7 +54,7 @@ GEM
       cucumber-messages (> 19, < 25)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.0)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     datadog-ci (1.0.0.beta6)
-      datadog (~> 2.0.0.beta2)
+      datadog (~> 2.0)
       msgpack
 
 GEM
@@ -15,7 +15,7 @@ GEM
     ast (2.4.2)
     climate_control (1.2.0)
     coderay (1.1.3)
-    datadog (2.0.0.rc1)
+    datadog (2.0.0)
       debase-ruby_core_source (= 3.3.1)
       libdatadog (~> 9.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)


### PR DESCRIPTION
**What does this PR do?**
Changes the dependency on gem datadog to "~> 2.0"

**Motivation**
gem datadog 2.0 is released
