### PR TITLE
[SDTEST-172] Refactor configs and components

### DIFF
--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -236,8 +236,8 @@ void Init_datadog_cov(void)
 {
   VALUE mDatadog = rb_define_module("Datadog");
   VALUE mCI = rb_define_module_under(mDatadog, "CI");
-  VALUE mITR = rb_define_module_under(mCI, "ITR");
-  VALUE mCoverage = rb_define_module_under(mITR, "Coverage");
+  VALUE mTestOptimisation = rb_define_module_under(mCI, "TestOptimisation");
+  VALUE mCoverage = rb_define_module_under(mTestOptimisation, "Coverage");
   VALUE cDatadogCov = rb_define_class_under(mCoverage, "DDCov", rb_cObject);
 
   rb_define_alloc_func(cDatadogCov, dd_cov_allocate);

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -39,7 +39,7 @@ module Datadog
       # @return [Datadog::CI::TestSession] the active, running {Datadog::CI::TestSession}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_session(service: Utils::Configuration.fetch_service_name("test"), tags: {})
-        recorder.start_test_session(service: service, tags: tags)
+        test_visibility.start_test_session(service: service, tags: tags)
       end
 
       # The active, unfinished test session.
@@ -61,7 +61,7 @@ module Datadog
       # @return [Datadog::CI::TestSession] the active test session
       # @return [nil] if no test session is active
       def active_test_session
-        recorder.active_test_session
+        test_visibility.active_test_session
       end
 
       # Starts a {Datadog::CI::TestModule ci_test_module} that represents a single test module (for most Ruby test frameworks
@@ -93,7 +93,7 @@ module Datadog
       # @return [Datadog::CI::TestModule] the active, running {Datadog::CI::TestModule}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_module(test_module_name, service: nil, tags: {})
-        recorder.start_test_module(test_module_name, service: service, tags: tags)
+        test_visibility.start_test_module(test_module_name, service: service, tags: tags)
       end
 
       # The active, unfinished test module.
@@ -116,7 +116,7 @@ module Datadog
       # @return [Datadog::CI::TestModule] the active test module
       # @return [nil] if no test module is active
       def active_test_module
-        recorder.active_test_module
+        test_visibility.active_test_module
       end
 
       # Starts a {Datadog::CI::TestSuite ci_test_suite} that represents a single test suite.
@@ -145,7 +145,7 @@ module Datadog
       # @return [Datadog::CI::TestSuite] the active, running {Datadog::CI::TestSuite}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_suite(test_suite_name, service: nil, tags: {})
-        recorder.start_test_suite(test_suite_name, service: service, tags: tags)
+        test_visibility.start_test_suite(test_suite_name, service: service, tags: tags)
       end
 
       # The active, unfinished test suite.
@@ -168,7 +168,7 @@ module Datadog
       # @return [Datadog::CI::TestSuite] the active test suite
       # @return [nil] if no test suite with given name is active
       def active_test_suite(test_suite_name)
-        recorder.active_test_suite(test_suite_name)
+        test_visibility.active_test_suite(test_suite_name)
       end
 
       # Return a {Datadog::CI::Test ci_test} that will trace a test called `test_name`.
@@ -222,7 +222,7 @@ module Datadog
       # @yieldparam [Datadog::CI::Test] ci_test the newly created and active [Datadog::CI::Test]
       # @yieldparam [nil] if CI mode is disabled
       def trace_test(test_name, test_suite_name, service: nil, tags: {}, &block)
-        recorder.trace_test(test_name, test_suite_name, service: service, tags: tags, &block)
+        test_visibility.trace_test(test_name, test_suite_name, service: service, tags: tags, &block)
       end
 
       # Same as {.trace_test} but it does not accept a block.
@@ -248,7 +248,7 @@ module Datadog
       # @return [Datadog::CI::Test] the active, unfinished {Datadog::CI::Test}.
       # @return [nil] if CI mode is disabled.
       def start_test(test_name, test_suite_name, service: nil, tags: {})
-        recorder.trace_test(test_name, test_suite_name, service: service, tags: tags)
+        test_visibility.trace_test(test_name, test_suite_name, service: service, tags: tags)
       end
 
       # Trace any custom span inside a test. For example, you could trace:
@@ -300,7 +300,7 @@ module Datadog
           )
         end
 
-        recorder.trace(span_name, type: type, tags: tags, &block)
+        test_visibility.trace(span_name, type: type, tags: tags, &block)
       end
 
       # The active, unfinished custom (i.e. not test/suite/module/session) span.
@@ -326,7 +326,7 @@ module Datadog
       # @return [Datadog::CI::Span] the active span
       # @return [nil] if no span is active, or if the active span is not a custom span
       def active_span
-        span = recorder.active_span
+        span = test_visibility.active_span
         span if span && !Ext::AppTypes::CI_SPAN_TYPES.include?(span.type)
       end
 
@@ -352,7 +352,7 @@ module Datadog
       # @return [Datadog::CI::Test] the active test
       # @return [nil] if no test is active
       def active_test
-        recorder.active_test
+        test_visibility.active_test
       end
 
       private
@@ -361,8 +361,8 @@ module Datadog
         Datadog.send(:components)
       end
 
-      def recorder
-        components.ci_recorder
+      def test_visibility
+        components.test_visibility
       end
 
       def itr_runner

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -365,8 +365,8 @@ module Datadog
         components.test_visibility
       end
 
-      def itr_runner
-        components.itr
+      def test_optimisation
+        components.test_optimisation
       end
     end
   end

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -202,9 +202,9 @@ module Datadog
 
       private
 
-      # provides access to global CI recorder for CI models to deactivate themselves
-      def recorder
-        Datadog.send(:components).ci_recorder
+      # provides access to the test visibility component for CI models to deactivate themselves
+      def test_visibility
+        Datadog.send(:components).test_visibility
       end
     end
   end

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -19,7 +19,7 @@ module Datadog
       # Finishes the current test.
       # @return [void]
       def finish
-        recorder.deactivate_test
+        test_visibility.deactivate_test
 
         super
       end

--- a/lib/datadog/ci/test_module.rb
+++ b/lib/datadog/ci/test_module.rb
@@ -14,7 +14,7 @@ module Datadog
       # Finishes this test module.
       # @return [void]
       def finish
-        recorder.deactivate_test_module
+        test_visibility.deactivate_test_module
 
         super
       end

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -16,11 +16,11 @@ require_relative "skippable"
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       # Intelligent test runner implementation
       # Integrates with backend to provide test impact analysis data and
       # skip tests that are not impacted by the changes
-      class Runner
+      class Component
         include Core::Utils::Forking
 
         attr_reader :correlation_id, :skippable_tests, :skipped_tests_count
@@ -57,11 +57,11 @@ module Datadog
           @skipped_tests_count = 0
           @mutex = Mutex.new
 
-          Datadog.logger.debug("ITR Runner initialized with enabled: #{@enabled}")
+          Datadog.logger.debug("TestOptimisation initialized with enabled: #{@enabled}")
         end
 
         def configure(remote_configuration, test_session:, git_tree_upload_worker:)
-          Datadog.logger.debug("Configuring ITR Runner with remote configuration: #{remote_configuration}")
+          Datadog.logger.debug("Configuring TestOptimisation with remote configuration: #{remote_configuration}")
 
           @enabled = Utils::Parsing.convert_to_bool(
             remote_configuration.fetch(Ext::Transport::DD_API_SETTINGS_RESPONSE_ITR_ENABLED_KEY, false)
@@ -83,7 +83,7 @@ module Datadog
 
           load_datadog_cov! if @code_coverage_enabled
 
-          Datadog.logger.debug("Configured ITR Runner with enabled: #{@enabled}, skipping_tests: #{@test_skipping_enabled}, code_coverage: #{@code_coverage_enabled}")
+          Datadog.logger.debug("Configured TestOptimisation with enabled: #{@enabled}, skipping_tests: #{@test_skipping_enabled}, code_coverage: #{@code_coverage_enabled}")
 
           fetch_skippable_tests(test_session: test_session, git_tree_upload_worker: git_tree_upload_worker)
         end
@@ -139,7 +139,7 @@ module Datadog
           skippable_test_id = Utils::TestRun.skippable_test_id(test.name, test.test_suite_name, test.parameters)
           if @skippable_tests.include?(skippable_test_id)
             if forked?
-              Datadog.logger.warn { "ITR is not supported for forking test runners yet" }
+              Datadog.logger.warn { "Intelligent test runner is not supported for forking test runners yet" }
               return
             end
 
@@ -155,7 +155,7 @@ module Datadog
           return if !test.skipped? || !test.skipped_by_itr?
 
           if forked?
-            Datadog.logger.warn { "ITR is not supported for forking test runners yet" }
+            Datadog.logger.warn { "Intelligent test runner is not supported for forking test runners yet" }
             return
           end
 
@@ -167,7 +167,7 @@ module Datadog
         def write_test_session_tags(test_session)
           return if !enabled?
 
-          Datadog.logger.debug { "Finished ITR session with test skipping enabled: #{@test_skipping_enabled}" }
+          Datadog.logger.debug { "Finished optimised session with test skipping enabled: #{@test_skipping_enabled}" }
           Datadog.logger.debug { "#{@skipped_tests_count} tests were skipped" }
 
           test_session.set_tag(Ext::Test::TAG_ITR_TESTS_SKIPPED, @skipped_tests_count.positive?.to_s)

--- a/lib/datadog/ci/test_optimisation/coverage/ddcov.rb
+++ b/lib/datadog/ci/test_optimisation/coverage/ddcov.rb
@@ -2,7 +2,7 @@
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         # Placeholder for code coverage collection
         # Implementation in ext/datadog_cov

--- a/lib/datadog/ci/test_optimisation/coverage/event.rb
+++ b/lib/datadog/ci/test_optimisation/coverage/event.rb
@@ -6,7 +6,7 @@ require_relative "../../git/local_repository"
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Event
           attr_reader :test_id, :test_suite_id, :test_session_id, :coverage

--- a/lib/datadog/ci/test_optimisation/coverage/transport.rb
+++ b/lib/datadog/ci/test_optimisation/coverage/transport.rb
@@ -5,7 +5,7 @@ require_relative "../../transport/event_platform_transport"
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Transport < Datadog::CI::Transport::EventPlatformTransport
           private

--- a/lib/datadog/ci/test_optimisation/coverage/writer.rb
+++ b/lib/datadog/ci/test_optimisation/coverage/writer.rb
@@ -11,7 +11,7 @@ require "datadog/core/environment/ext"
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Writer
           include Core::Workers::Queue

--- a/lib/datadog/ci/test_optimisation/skippable.rb
+++ b/lib/datadog/ci/test_optimisation/skippable.rb
@@ -8,7 +8,7 @@ require_relative "../utils/test_run"
 
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       class Skippable
         class Response
           def initialize(http_response)

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -15,7 +15,7 @@ module Datadog
       # Finishes the current test session.
       # @return [void]
       def finish
-        recorder.deactivate_test_session
+        test_visibility.deactivate_test_session
 
         super
       end

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -26,7 +26,7 @@ module Datadog
           # we try to derive test suite status from execution stats if no status was set explicitly
           set_status_from_stats! if undefined?
 
-          recorder.deactivate_test_suite(name)
+          test_visibility.deactivate_test_suite(name)
 
           super
         end

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -28,7 +28,7 @@ module Datadog
     module TestVisibility
       # Common behavior for CI tests
       # Note: this class has too many responsibilities and should be split into multiple classes
-      class Recorder
+      class Component
         attr_reader :environment_tags, :test_suite_level_visibility_enabled
 
         def initialize(

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -32,7 +32,7 @@ module Datadog
         attr_reader :environment_tags, :test_suite_level_visibility_enabled
 
         def initialize(
-          itr:,
+          test_optimisation:,
           remote_settings_api:,
           git_tree_upload_worker: DummyWorker.new,
           test_suite_level_visibility_enabled: false,
@@ -46,7 +46,7 @@ module Datadog
 
           @codeowners = codeowners
 
-          @itr = itr
+          @test_optimisation = test_optimisation
           @remote_settings_api = remote_settings_api
           @git_tree_upload_worker = git_tree_upload_worker
         end
@@ -210,7 +210,7 @@ module Datadog
         end
 
         def itr_enabled?
-          @itr.enabled?
+          @test_optimisation.enabled?
         end
 
         private
@@ -234,7 +234,7 @@ module Datadog
             end
           end
 
-          @itr.configure(
+          @test_optimisation.configure(
             remote_configuration.payload,
             test_session: test_session,
             git_tree_upload_worker: @git_tree_upload_worker
@@ -404,17 +404,17 @@ module Datadog
 
         # TODO: use kind of event system to notify about test finished?
         def on_test_finished(test)
-          @itr.stop_coverage(test)
-          @itr.count_skipped_test(test)
+          @test_optimisation.stop_coverage(test)
+          @test_optimisation.count_skipped_test(test)
         end
 
         def on_test_started(test)
-          @itr.mark_if_skippable(test)
-          @itr.start_coverage(test)
+          @test_optimisation.mark_if_skippable(test)
+          @test_optimisation.start_coverage(test)
         end
 
         def on_test_session_finished(test_session)
-          @itr.write_test_session_tags(test_session)
+          @test_optimisation.write_test_session_tags(test_session)
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/null_component.rb
+++ b/lib/datadog/ci/test_visibility/null_component.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require_relative "recorder"
-
 module Datadog
   module CI
     module TestVisibility
-      # Special recorder that does not record anything
-      class NullRecorder
+      # Special test visibility component that does not record anything
+      class NullComponent
         def start_test_session(service: nil, tags: {})
           skip_tracing
         end

--- a/lib/datadog/ci/test_visibility/null_recorder.rb
+++ b/lib/datadog/ci/test_visibility/null_recorder.rb
@@ -45,6 +45,10 @@ module Datadog
         def shutdown!
         end
 
+        def itr_enabled?
+          false
+        end
+
         private
 
         def skip_tracing(block = nil)

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -100,7 +100,7 @@ module Datadog
         end
 
         def itr
-          @itr ||= Datadog::CI.send(:itr_runner)
+          @test_optimisation ||= Datadog::CI.send(:test_optimisation)
         end
       end
     end

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -31,6 +31,6 @@ module Datadog
 
     def self.test_visibility: () -> (Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent)
 
-    def self.itr_runner: () -> Datadog::CI::ITR::Runner?
+    def self.test_optimisation: () -> Datadog::CI::TestOptimisation::Component?
   end
 end

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -29,7 +29,7 @@ module Datadog
 
     def self.components: () -> Datadog::CI::Configuration::Components
 
-    def self.recorder: () -> (Datadog::CI::TestVisibility::Recorder | Datadog::CI::TestVisibility::NullRecorder)
+    def self.test_visibility: () -> (Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent)
 
     def self.itr_runner: () -> Datadog::CI::ITR::Runner?
   end

--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -3,11 +3,11 @@ module Datadog
     module Configuration
       module Components : Datadog::Core::Configuration::Components
         @test_visibility: Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent
-        @itr: Datadog::CI::ITR::Runner?
+        @test_optimisation: Datadog::CI::TestOptimisation::Component?
         @custom_configuration: Hash[String, String]
 
         attr_reader test_visibility: Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent
-        attr_reader itr: Datadog::CI::ITR::Runner?
+        attr_reader test_optimisation: Datadog::CI::TestOptimisation::Component?
 
         def initialize: (untyped settings) -> void
 
@@ -21,7 +21,7 @@ module Datadog
 
         def build_tracing_transport: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::TestVisibility::Transport?
 
-        def build_coverage_writer: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::ITR::Coverage::Writer?
+        def build_coverage_writer: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::TestOptimisation::Coverage::Writer?
 
         def build_git_upload_worker: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::Worker
 

--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -2,11 +2,11 @@ module Datadog
   module CI
     module Configuration
       module Components : Datadog::Core::Configuration::Components
-        @ci_recorder: Datadog::CI::TestVisibility::Recorder | Datadog::CI::TestVisibility::NullRecorder
+        @test_visibility: Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent
         @itr: Datadog::CI::ITR::Runner?
         @custom_configuration: Hash[String, String]
 
-        attr_reader ci_recorder: Datadog::CI::TestVisibility::Recorder | Datadog::CI::TestVisibility::NullRecorder
+        attr_reader test_visibility: Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent
         attr_reader itr: Datadog::CI::ITR::Runner?
 
         def initialize: (untyped settings) -> void

--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -4,6 +4,7 @@ module Datadog
       module Components : Datadog::Core::Configuration::Components
         @ci_recorder: Datadog::CI::TestVisibility::Recorder | Datadog::CI::TestVisibility::NullRecorder
         @itr: Datadog::CI::ITR::Runner?
+        @custom_configuration: Hash[String, String]
 
         attr_reader ci_recorder: Datadog::CI::TestVisibility::Recorder | Datadog::CI::TestVisibility::NullRecorder
         attr_reader itr: Datadog::CI::ITR::Runner?
@@ -17,6 +18,16 @@ module Datadog
         def serializers_factory: (untyped settings) -> (singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel))
 
         def check_dd_site: (untyped settings) -> void
+
+        def build_tracing_transport: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::TestVisibility::Transport?
+
+        def build_coverage_writer: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::ITR::Coverage::Writer?
+
+        def build_git_upload_worker: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::Worker
+
+        def build_remote_settings_client: (untyped settings, Datadog::CI::Transport::Api::Base? api) -> Datadog::CI::Transport::RemoteSettingsApi
+
+        def custom_configuration: (untyped settings) -> Hash[String, String]
 
         def timecop?: () -> bool
       end

--- a/sig/datadog/ci/span.rbs
+++ b/sig/datadog/ci/span.rbs
@@ -67,7 +67,7 @@ module Datadog
 
       private
 
-      def recorder: () -> Datadog::CI::TestVisibility::Recorder
+      def test_visibility: () -> Datadog::CI::TestVisibility::Component
     end
   end
 end

--- a/sig/datadog/ci/test_optimisation/coverage/ddcov.rbs
+++ b/sig/datadog/ci/test_optimisation/coverage/ddcov.rbs
@@ -1,6 +1,6 @@
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class DDCov
           type threading_mode = :multi | :single

--- a/sig/datadog/ci/test_optimisation/coverage/event.rbs
+++ b/sig/datadog/ci/test_optimisation/coverage/event.rbs
@@ -1,6 +1,6 @@
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Event
           @test_id: String

--- a/sig/datadog/ci/test_optimisation/coverage/transport.rbs
+++ b/sig/datadog/ci/test_optimisation/coverage/transport.rbs
@@ -1,17 +1,17 @@
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Transport < Datadog::CI::Transport::EventPlatformTransport
           private
 
           def send_payload: (String payload) -> ::Datadog::CI::Transport::HTTP::ResponseDecorator
 
-          def encode_events: (Array[Datadog::CI::ITR::Coverage::Event] events) -> ::Array[String]
+          def encode_events: (Array[Datadog::CI::TestOptimisation::Coverage::Event] events) -> ::Array[String]
 
           def pack_events: (Array[String] encoded_events) -> String
 
-          def event_too_large?: (Datadog::CI::ITR::Coverage::Event event, String encoded_event) -> bool
+          def event_too_large?: (Datadog::CI::TestOptimisation::Coverage::Event event, String encoded_event) -> bool
         end
       end
     end

--- a/sig/datadog/ci/test_optimisation/coverage/writer.rbs
+++ b/sig/datadog/ci/test_optimisation/coverage/writer.rbs
@@ -1,6 +1,6 @@
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       module Coverage
         class Writer
           include Datadog::Core::Workers::Async::Thread
@@ -8,7 +8,7 @@ module Datadog
           include Datadog::Core::Workers::Queue
           include Datadog::Core::Workers::IntervalLoop
 
-          @transport: Datadog::CI::ITR::Coverage::Transport
+          @transport: Datadog::CI::TestOptimisation::Coverage::Transport
 
           @buffer_size: Integer
 
@@ -16,7 +16,7 @@ module Datadog
 
           @stopped: bool
 
-          attr_reader transport: Datadog::CI::ITR::Coverage::Transport
+          attr_reader transport: Datadog::CI::TestOptimisation::Coverage::Transport
 
           DEFAULT_BUFFER_MAX_SIZE: 10000
 
@@ -24,17 +24,17 @@ module Datadog
 
           DEFAULT_INTERVAL: 3
 
-          def initialize: (transport: Datadog::CI::ITR::Coverage::Transport, ?options: ::Hash[untyped, untyped]) -> void
+          def initialize: (transport: Datadog::CI::TestOptimisation::Coverage::Transport, ?options: ::Hash[untyped, untyped]) -> void
 
-          def write: (Datadog::CI::ITR::Coverage::Event event) -> untyped
+          def write: (Datadog::CI::TestOptimisation::Coverage::Event event) -> untyped
 
-          def perform: (*Datadog::CI::ITR::Coverage::Event events) -> nil
+          def perform: (*Datadog::CI::TestOptimisation::Coverage::Event events) -> nil
 
           def stop: (?bool force_stop, ?Integer timeout) -> untyped
 
-          def enqueue: (Datadog::CI::ITR::Coverage::Event event) -> untyped
+          def enqueue: (Datadog::CI::TestOptimisation::Coverage::Event event) -> untyped
 
-          def dequeue: () -> ::Array[Datadog::CI::ITR::Coverage::Event]
+          def dequeue: () -> ::Array[Datadog::CI::TestOptimisation::Coverage::Event]
 
           def async?: () -> true
 

--- a/sig/datadog/ci/test_optimisation/runner.rbs
+++ b/sig/datadog/ci/test_optimisation/runner.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module CI
-    module ITR
-      class Runner
+    module TestOptimisation
+      class Component
         include Datadog::Core::Utils::Forking
 
         @enabled: bool
@@ -9,7 +9,7 @@ module Datadog
         @code_coverage_enabled: bool
         @correlation_id: String?
         @skippable_tests: Set[String]
-        @coverage_writer: Datadog::CI::ITR::Coverage::Writer?
+        @coverage_writer: Datadog::CI::TestOptimisation::Coverage::Writer?
 
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?
@@ -24,7 +24,7 @@ module Datadog
         attr_reader skipped_tests_count: Integer
         attr_reader correlation_id: String?
 
-        def initialize: (dd_env: String?, ?enabled: bool, ?coverage_writer: Datadog::CI::ITR::Coverage::Writer?, ?api: Datadog::CI::Transport::Api::Base?, ?config_tags: Hash[String, String]?, ?bundle_location: String?, ?use_single_threaded_coverage: bool) -> void
+        def initialize: (dd_env: String?, ?enabled: bool, ?coverage_writer: Datadog::CI::TestOptimisation::Coverage::Writer?, ?api: Datadog::CI::Transport::Api::Base?, ?config_tags: Hash[String, String]?, ?bundle_location: String?, ?use_single_threaded_coverage: bool) -> void
 
         def configure: (Hash[String, untyped] remote_configuration, test_session: Datadog::CI::TestSession, git_tree_upload_worker: Datadog::CI::Worker) -> void
 
@@ -36,7 +36,7 @@ module Datadog
 
         def start_coverage: (Datadog::CI::Test test) -> void
 
-        def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::ITR::Coverage::Event?
+        def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::TestOptimisation::Coverage::Event?
 
         def mark_if_skippable: (Datadog::CI::Test test) -> void
 
@@ -48,11 +48,11 @@ module Datadog
 
         private
 
-        def coverage_collector: () -> Datadog::CI::ITR::Coverage::DDCov?
+        def coverage_collector: () -> Datadog::CI::TestOptimisation::Coverage::DDCov?
 
         def load_datadog_cov!: () -> void
 
-        def write: (Datadog::CI::ITR::Coverage::Event event) -> void
+        def write: (Datadog::CI::TestOptimisation::Coverage::Event event) -> void
 
         def ensure_test_source_covered: (String test_source_file, Hash[String, untyped] coverage) -> void
 
@@ -60,7 +60,7 @@ module Datadog
 
         def increment_skipped_tests_counter: () -> void
 
-        def code_coverage_mode: () -> Datadog::CI::ITR::Coverage::DDCov::threading_mode
+        def code_coverage_mode: () -> Datadog::CI::TestOptimisation::Coverage::DDCov::threading_mode
       end
     end
   end

--- a/sig/datadog/ci/test_optimisation/skippable.rbs
+++ b/sig/datadog/ci/test_optimisation/skippable.rbs
@@ -1,6 +1,6 @@
 module Datadog
   module CI
-    module ITR
+    module TestOptimisation
       class Skippable
         @api: Datadog::CI::Transport::Api::Base?
         @dd_env: String?

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module CI
     module TestVisibility
-      class Recorder
+      class Component
         @test_suite_level_visibility_enabled: bool
 
         @environment_tags: Hash[String, String]

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -7,7 +7,7 @@ module Datadog
         @environment_tags: Hash[String, String]
         @local_context: Datadog::CI::TestVisibility::Context::Local
         @global_context: Datadog::CI::TestVisibility::Context::Global
-        @itr: Datadog::CI::ITR::Runner
+        @test_optimisation: Datadog::CI::TestOptimisation::Component
         @remote_settings_api: Datadog::CI::Transport::RemoteSettingsApi
         @codeowners: Datadog::CI::Codeowners::Matcher
         @git_tree_upload_worker: Datadog::CI::Worker
@@ -15,7 +15,7 @@ module Datadog
         attr_reader environment_tags: Hash[String, String]
         attr_reader test_suite_level_visibility_enabled: bool
 
-        def initialize: (?test_suite_level_visibility_enabled: bool, ?codeowners: Datadog::CI::Codeowners::Matcher, itr: Datadog::CI::ITR::Runner, remote_settings_api: Datadog::CI::Transport::RemoteSettingsApi, ?git_tree_upload_worker: Datadog::CI::Worker) -> void
+        def initialize: (?test_suite_level_visibility_enabled: bool, ?codeowners: Datadog::CI::Codeowners::Matcher, test_optimisation: Datadog::CI::TestOptimisation::Component, remote_settings_api: Datadog::CI::Transport::RemoteSettingsApi, ?git_tree_upload_worker: Datadog::CI::Worker) -> void
 
         def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
 

--- a/sig/datadog/ci/test_visibility/null_component.rbs
+++ b/sig/datadog/ci/test_visibility/null_component.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module CI
     module TestVisibility
-      class NullRecorder
+      class NullComponent
         def initialize: (?untyped args) -> void
 
         def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (nil span) -> untyped } -> untyped
@@ -25,6 +25,8 @@ module Datadog
         def active_span: () -> nil
 
         def shutdown!: () -> nil
+
+        def itr_enabled?: () -> bool
 
         private
 

--- a/sig/datadog/ci/test_visibility/transport.rbs
+++ b/sig/datadog/ci/test_visibility/transport.rbs
@@ -7,7 +7,7 @@ module Datadog
 
         @dd_env: String?
         @serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
-        @itr: Datadog::CI::ITR::Runner?
+        @test_optimisation: Datadog::CI::TestOptimisation::Component?
 
         def initialize: (
           api: Datadog::CI::Transport::Api::Base,
@@ -21,7 +21,7 @@ module Datadog
         def send_payload: (String encoded_payload) -> Datadog::CI::Transport::HTTP::ResponseDecorator
         def encode_events: (Array[Datadog::Tracing::TraceSegment] traces) -> ::Array[String]
         def encode_span: (Datadog::Tracing::TraceSegment trace, Datadog::Tracing::Span span) -> String?
-        def itr: () -> Datadog::CI::ITR::Runner?
+        def itr: () -> Datadog::CI::TestOptimisation::Component?
       end
     end
   end

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -119,18 +119,18 @@ RSpec.describe Datadog::CI::Configuration::Components do
             let(:evp_proxy_v2_supported) { true }
 
             context "is false" do
-              it "creates a CI recorder with test_suite_level_visibility_enabled=true" do
-                expect(components.ci_recorder).to be_kind_of(Datadog::CI::TestVisibility::Recorder)
-                expect(components.ci_recorder.test_suite_level_visibility_enabled).to eq(true)
+              it "creates test visibility component with test_suite_level_visibility_enabled=true" do
+                expect(components.test_visibility).to be_kind_of(Datadog::CI::TestVisibility::Component)
+                expect(components.test_visibility.test_suite_level_visibility_enabled).to eq(true)
               end
             end
 
             context "is true" do
               let(:force_test_level_visibility) { true }
 
-              it "creates a CI recorder with test_suite_level_visibility_enabled=false" do
-                expect(components.ci_recorder).to be_kind_of(Datadog::CI::TestVisibility::Recorder)
-                expect(components.ci_recorder.test_suite_level_visibility_enabled).to eq(false)
+              it "creates test visibility component with test_suite_level_visibility_enabled=false" do
+                expect(components.test_visibility).to be_kind_of(Datadog::CI::TestVisibility::Component)
+                expect(components.test_visibility.test_suite_level_visibility_enabled).to eq(false)
               end
             end
           end
@@ -190,7 +190,7 @@ RSpec.describe Datadog::CI::Configuration::Components do
                     expect(options[:transport]).to be_nil
                   end
 
-                  expect(components.ci_recorder.itr_enabled?).to eq(false)
+                  expect(components.test_visibility.itr_enabled?).to eq(false)
                 end
               end
             end
@@ -239,16 +239,16 @@ RSpec.describe Datadog::CI::Configuration::Components do
                 context "when ITR is disabled" do
                   let(:itr_enabled) { false }
 
-                  it "creates a CI recorder with ITR disabled" do
-                    expect(components.ci_recorder.itr_enabled?).to eq(false)
+                  it "creates test visibility component with ITR disabled" do
+                    expect(components.test_visibility.itr_enabled?).to eq(false)
                   end
                 end
 
                 context "when ITR is enabled" do
                   let(:itr_enabled) { true }
 
-                  it "creates a CI recorder with ITR enabled" do
-                    expect(components.ci_recorder.itr_enabled?).to eq(true)
+                  it "creates test visibility component with ITR enabled" do
+                    expect(components.test_visibility.itr_enabled?).to eq(true)
                   end
                 end
               end
@@ -261,7 +261,7 @@ RSpec.describe Datadog::CI::Configuration::Components do
                   expect(Datadog.logger).to have_received(:error)
 
                   expect(settings.ci.enabled).to eq(false)
-                  expect(components.ci_recorder.itr_enabled?).to eq(false)
+                  expect(components.test_visibility.itr_enabled?).to eq(false)
                 end
               end
             end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -154,7 +154,6 @@ RSpec.describe "Cucumber formatter" do
       )
       expect(test_session_span).to have_pass_status
 
-      # ITR
       expect(test_session_span).to have_test_tag(:itr_test_skipping_enabled, "true")
       expect(test_session_span).to have_test_tag(:itr_test_skipping_type, "test")
       expect(test_session_span).to have_test_tag(:itr_tests_skipped, "false")

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -429,7 +429,6 @@ RSpec.describe "Minitest instrumentation" do
             Datadog::CI::Contrib::Minitest::Integration.version.to_s
           )
 
-          # ITR
           expect(test_session_span).to have_test_tag(:itr_test_skipping_enabled, "true")
           expect(test_session_span).to have_test_tag(:itr_test_skipping_type, "test")
           expect(test_session_span).to have_test_tag(:itr_tests_skipped, "false")
@@ -507,7 +506,7 @@ RSpec.describe "Minitest instrumentation" do
           expect(cov_event.coverage.keys).to include(absolute_path("helpers/addition_helper.rb"))
         end
 
-        context "when ITR skips tests" do
+        context "when test optimisation skips tests" do
           context "single skipped test" do
             let(:itr_skippable_tests) do
               Set.new(["SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_pass."])
@@ -717,7 +716,7 @@ RSpec.describe "Minitest instrumentation" do
           expect_non_empty_coverages
         end
 
-        context "when ITR skips tests" do
+        context "when test optimisation skips tests" do
           let(:itr_skippable_tests) do
             Set.new(
               [

--- a/spec/datadog/ci/test_module_spec.rb
+++ b/spec/datadog/ci/test_module_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe Datadog::CI::TestModule do
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, finish: true) }
-  let(:recorder) { spy("recorder") }
+  let(:test_visibility) { spy("test_visibility") }
 
-  before { allow_any_instance_of(described_class).to receive(:recorder).and_return(recorder) }
+  before { allow_any_instance_of(described_class).to receive(:test_visibility).and_return(test_visibility) }
 
   describe "#finish" do
     subject(:ci_test_module) { described_class.new(tracer_span) }
@@ -12,7 +12,7 @@ RSpec.describe Datadog::CI::TestModule do
     it "deactivates the test module" do
       ci_test_module.finish
 
-      expect(recorder).to have_received(:deactivate_test_module)
+      expect(test_visibility).to have_received(:deactivate_test_module)
     end
   end
 end

--- a/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
@@ -2,9 +2,9 @@
 
 require "pp"
 
-require_relative "../../../../../lib/datadog/ci/itr/coverage/event"
+require_relative "../../../../../lib/datadog/ci/test_optimisation/coverage/event"
 
-RSpec.describe Datadog::CI::ITR::Coverage::Event do
+RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
   subject do
     described_class.new(
       test_id: test_id,
@@ -97,7 +97,7 @@ RSpec.describe Datadog::CI::ITR::Coverage::Event do
             "test_suite_id" => 2,
             "span_id" => 1,
             "files" => [
-              {"filename" => "spec/datadog/ci/itr/coverage/project/file.rb"}
+              {"filename" => "spec/datadog/ci/test_optimisation/coverage/project/file.rb"}
             ]
           }
         )

--- a/spec/datadog/ci/test_optimisation/coverage/transport_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/transport_spec.rb
@@ -1,6 +1,6 @@
-require_relative "../../../../../lib/datadog/ci/itr/coverage/transport"
+require_relative "../../../../../lib/datadog/ci/test_optimisation/coverage/transport"
 
-RSpec.describe Datadog::CI::ITR::Coverage::Transport do
+RSpec.describe Datadog::CI::TestOptimisation::Coverage::Transport do
   subject do
     described_class.new(
       api: api,
@@ -16,7 +16,7 @@ RSpec.describe Datadog::CI::ITR::Coverage::Transport do
   let(:api) { spy(:api) }
 
   let(:event) do
-    Datadog::CI::ITR::Coverage::Event.new(
+    Datadog::CI::TestOptimisation::Coverage::Event.new(
       test_id: "1",
       test_suite_id: "2",
       test_session_id: "3",
@@ -49,7 +49,7 @@ RSpec.describe Datadog::CI::ITR::Coverage::Transport do
       let(:events) do
         [
           event,
-          Datadog::CI::ITR::Coverage::Event.new(
+          Datadog::CI::TestOptimisation::Coverage::Event.new(
             test_id: "4",
             test_suite_id: "5",
             test_session_id: "6",
@@ -78,7 +78,7 @@ RSpec.describe Datadog::CI::ITR::Coverage::Transport do
         let(:events) do
           [
             event,
-            Datadog::CI::ITR::Coverage::Event.new(
+            Datadog::CI::TestOptimisation::Coverage::Event.new(
               test_id: "4",
               test_suite_id: nil,
               test_session_id: "6",
@@ -135,13 +135,13 @@ RSpec.describe Datadog::CI::ITR::Coverage::Transport do
     context "when all events are invalid" do
       let(:events) do
         [
-          Datadog::CI::ITR::Coverage::Event.new(
+          Datadog::CI::TestOptimisation::Coverage::Event.new(
             test_id: "4",
             test_suite_id: "5",
             test_session_id: nil,
             coverage: {"file.rb" => true, "file2.rb" => true}
           ),
-          Datadog::CI::ITR::Coverage::Event.new(
+          Datadog::CI::TestOptimisation::Coverage::Event.new(
             test_id: "8",
             test_suite_id: nil,
             test_session_id: "6",

--- a/spec/datadog/ci/test_optimisation/coverage/writer_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/writer_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require_relative "../../../../../lib/datadog/ci/itr/coverage/writer"
-require_relative "../../../../../lib/datadog/ci/itr/coverage/transport"
+require_relative "../../../../../lib/datadog/ci/test_optimisation/coverage/writer"
+require_relative "../../../../../lib/datadog/ci/test_optimisation/coverage/transport"
 
-RSpec.describe Datadog::CI::ITR::Coverage::Writer do
+RSpec.describe Datadog::CI::TestOptimisation::Coverage::Writer do
   subject(:writer) { described_class.new(transport: transport, options: options) }
 
   let(:options) { {} }
-  let(:transport) { instance_double(Datadog::CI::ITR::Coverage::Transport) }
+  let(:transport) { instance_double(Datadog::CI::TestOptimisation::Coverage::Transport) }
   before do
     allow(transport).to receive(:send_events).and_return([])
   end

--- a/spec/datadog/ci/test_optimisation/runner_spec.rb
+++ b/spec/datadog/ci/test_optimisation/runner_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../../../../lib/datadog/ci/itr/runner"
+require_relative "../../../../lib/datadog/ci/test_optimisation/component"
 
-RSpec.describe Datadog::CI::ITR::Runner do
+RSpec.describe Datadog::CI::TestOptimisation::Component do
   let(:itr_enabled) { true }
 
   let(:api) { double("api") }
@@ -58,9 +58,9 @@ RSpec.describe Datadog::CI::ITR::Runner do
       let(:remote_configuration) { {"itr_enabled" => true, "code_coverage" => true, "tests_skipping" => true} }
       let(:skippable) do
         instance_double(
-          Datadog::CI::ITR::Skippable,
+          Datadog::CI::TestOptimisation::Skippable,
           fetch_skippable_tests: instance_double(
-            Datadog::CI::ITR::Skippable::Response,
+            Datadog::CI::TestOptimisation::Skippable::Response,
             correlation_id: "42",
             tests: Set.new(["suite.test."])
           )
@@ -68,7 +68,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
       end
 
       before do
-        expect(Datadog::CI::ITR::Skippable).to receive(:new).and_return(skippable)
+        expect(Datadog::CI::TestOptimisation::Skippable).to receive(:new).and_return(skippable)
         configure
       end
 
@@ -127,7 +127,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
       end
     end
 
-    context "when ITR is disabled" do
+    context "when TestOptimisation is disabled" do
       let(:remote_configuration) { {"itr_enabled" => false, "code_coverage" => false, "tests_skipping" => false} }
 
       it "does not start coverage" do
@@ -229,9 +229,9 @@ RSpec.describe Datadog::CI::ITR::Runner do
       let(:remote_configuration) { {"itr_enabled" => true, "code_coverage" => true, "tests_skipping" => true} }
       let(:skippable) do
         instance_double(
-          Datadog::CI::ITR::Skippable,
+          Datadog::CI::TestOptimisation::Skippable,
           fetch_skippable_tests: instance_double(
-            Datadog::CI::ITR::Skippable::Response,
+            Datadog::CI::TestOptimisation::Skippable::Response,
             correlation_id: "42",
             tests: Set.new(["suite.test.", "suite2.test.", "suite.test3."])
           )
@@ -239,7 +239,7 @@ RSpec.describe Datadog::CI::ITR::Runner do
       end
 
       before do
-        expect(Datadog::CI::ITR::Skippable).to receive(:new).and_return(skippable)
+        expect(Datadog::CI::TestOptimisation::Skippable).to receive(:new).and_return(skippable)
 
         configure
       end
@@ -383,10 +383,10 @@ RSpec.describe Datadog::CI::ITR::Runner do
       end
     end
 
-    context "when ITR is disabled" do
+    context "when TestOptimisation is disabled" do
       let(:itr_enabled) { false }
 
-      it "does not add ITR tags to the session" do
+      it "does not add ITR/TestOptimisation tags to the session" do
         subject
 
         expect(test_session_span.get_tag(Datadog::CI::Ext::Test::TAG_ITR_TESTS_SKIPPED)).to be_nil

--- a/spec/datadog/ci/test_optimisation/skippable_spec.rb
+++ b/spec/datadog/ci/test_optimisation/skippable_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../../../../lib/datadog/ci/itr/skippable"
+require_relative "../../../../lib/datadog/ci/test_optimisation/skippable"
 
-RSpec.describe Datadog::CI::ITR::Skippable do
+RSpec.describe Datadog::CI::TestOptimisation::Skippable do
   let(:api) { spy("api") }
   let(:dd_env) { "ci" }
   let(:config_tags) { {} }

--- a/spec/datadog/ci/test_session_spec.rb
+++ b/spec/datadog/ci/test_session_spec.rb
@@ -2,16 +2,16 @@
 
 RSpec.describe Datadog::CI::TestSession do
   let(:tracer_span) { Datadog::Tracing::SpanOperation.new("session") }
-  let(:recorder) { spy("recorder") }
+  let(:test_visibility) { spy("test_visibility") }
 
-  before { allow_any_instance_of(described_class).to receive(:recorder).and_return(recorder) }
+  before { allow_any_instance_of(described_class).to receive(:test_visibility).and_return(test_visibility) }
   subject(:ci_test_session) { described_class.new(tracer_span) }
 
   describe "#finish" do
     it "deactivates the test session" do
       ci_test_session.finish
 
-      expect(recorder).to have_received(:deactivate_test_session)
+      expect(test_visibility).to have_received(:deactivate_test_session)
     end
   end
 

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -2,10 +2,10 @@
 
 RSpec.describe Datadog::CI::Test do
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, finish: true) }
-  let(:recorder) { spy("recorder") }
+  let(:test_visibility) { spy("test_visibility") }
   subject(:ci_test) { described_class.new(tracer_span) }
 
-  before { allow_any_instance_of(described_class).to receive(:recorder).and_return(recorder) }
+  before { allow_any_instance_of(described_class).to receive(:test_visibility).and_return(test_visibility) }
 
   describe "#name" do
     subject(:name) { ci_test.name }
@@ -18,7 +18,7 @@ RSpec.describe Datadog::CI::Test do
   describe "#finish" do
     it "deactivates the test" do
       ci_test.finish
-      expect(recorder).to have_received(:deactivate_test)
+      expect(test_visibility).to have_received(:deactivate_test)
     end
   end
 

--- a/spec/datadog/ci/test_suite_spec.rb
+++ b/spec/datadog/ci/test_suite_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe Datadog::CI::TestSuite do
   let(:test_suite_name) { "my.suite" }
   let(:tracer_span) { instance_double(Datadog::Tracing::SpanOperation, finish: true, name: test_suite_name) }
-  let(:recorder) { spy("recorder") }
+  let(:test_visibility) { spy("test_visibility") }
 
-  before { allow_any_instance_of(described_class).to receive(:recorder).and_return(recorder) }
+  before { allow_any_instance_of(described_class).to receive(:test_visibility).and_return(test_visibility) }
   subject(:ci_test_suite) { described_class.new(tracer_span) }
 
   describe "#record_test_result" do
@@ -47,7 +47,7 @@ RSpec.describe Datadog::CI::TestSuite do
       it "deactivates the test suite" do
         finish
 
-        expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+        expect(test_visibility).to have_received(:deactivate_test_suite).with(test_suite_name)
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe Datadog::CI::TestSuite do
 
           finish
 
-          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+          expect(test_visibility).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
 
@@ -83,7 +83,7 @@ RSpec.describe Datadog::CI::TestSuite do
 
           finish
 
-          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+          expect(test_visibility).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
 
@@ -102,7 +102,7 @@ RSpec.describe Datadog::CI::TestSuite do
 
           finish
 
-          expect(recorder).to have_received(:deactivate_test_suite).with(test_suite_name)
+          expect(test_visibility).to have_received(:deactivate_test_suite).with(test_suite_name)
         end
       end
     end

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../lib/datadog/ci/test_visibility/component"
 
-RSpec.describe Datadog::CI::TestVisibility::Recorder do
+RSpec.describe Datadog::CI::TestVisibility::Component do
   shared_examples_for "trace with ciapp-test origin" do
     let(:trace_under_test) { subject }
 
@@ -57,36 +57,36 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
     end
 
     describe "#trace_test_session" do
-      subject { recorder.start_test_session(service: service, tags: tags) }
+      subject { test_visibility.start_test_session(service: service, tags: tags) }
 
       it { is_expected.to be_nil }
 
       it "does not activate session" do
-        expect(recorder.active_test_session).to be_nil
+        expect(test_visibility.active_test_session).to be_nil
       end
     end
 
     describe "#trace_test_module" do
       let(:module_name) { "my-module" }
 
-      subject { recorder.start_test_module(module_name, service: service, tags: tags) }
+      subject { test_visibility.start_test_module(module_name, service: service, tags: tags) }
 
       it { is_expected.to be_nil }
 
       it "does not activate module" do
-        expect(recorder.active_test_module).to be_nil
+        expect(test_visibility.active_test_module).to be_nil
       end
     end
 
     describe "#trace_test_suite" do
       let(:suite_name) { "my-module" }
 
-      subject { recorder.start_test_suite(suite_name, service: service, tags: tags) }
+      subject { test_visibility.start_test_suite(suite_name, service: service, tags: tags) }
 
       it { is_expected.to be_nil }
 
       it "does not activate test suite" do
-        expect(recorder.active_test_suite(suite_name)).to be_nil
+        expect(test_visibility.active_test_suite(suite_name)).to be_nil
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
       context "when given a block" do
         before do
-          recorder.trace(span_name, type: type, tags: tags) do |span|
+          test_visibility.trace(span_name, type: type, tags: tags) do |span|
             span.set_metric("my.metric", 42)
           end
         end
@@ -122,7 +122,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "when given a block" do
           before do
-            recorder.trace(span_name, type: type, tags: tags) do |span|
+            test_visibility.trace(span_name, type: type, tags: tags) do |span|
               span.set_metric("my.metric", 42)
             end
           end
@@ -148,7 +148,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         end
 
         context "without a block" do
-          subject { recorder.trace("my test step", type: type, tags: tags) }
+          subject { test_visibility.trace("my test step", type: type, tags: tags) }
 
           it "returns a new CI span" do
             expect(subject).to be_kind_of(Datadog::CI::Span)
@@ -180,7 +180,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "without a block" do
           subject do
-            recorder.trace_test(
+            test_visibility.trace_test(
               test_name,
               test_suite_name,
               service: test_service,
@@ -228,7 +228,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
             let(:session_service) { "my-session-service" }
             let(:test_service) { nil }
 
-            let(:test_session) { recorder.start_test_session(service: session_service, tags: test_session_tags) }
+            let(:test_session) { test_visibility.start_test_session(service: session_service, tags: test_session_tags) }
 
             before do
               test_session
@@ -273,7 +273,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
               let(:module_name) { "my-module" }
 
               let(:test_module) do
-                recorder.start_test_module(module_name)
+                test_visibility.start_test_module(module_name)
               end
 
               before do
@@ -298,7 +298,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
               context "when there is an active test suite" do
                 let(:test_suite) do
-                  recorder.start_test_suite(test_suite_name)
+                  test_visibility.start_test_suite(test_suite_name)
                 end
 
                 before do
@@ -313,7 +313,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
               context "when there is a running test suite but with a different name" do
                 let(:test_suite) do
-                  recorder.start_test_suite("other suite")
+                  test_visibility.start_test_suite("other suite")
                 end
 
                 before do
@@ -328,8 +328,8 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
               context "when there are several running test suites with different names" do
                 before do
-                  recorder.start_test_suite("other suite")
-                  recorder.start_test_suite("other other suite")
+                  test_visibility.start_test_suite("other suite")
+                  test_visibility.start_test_suite("other other suite")
                 end
 
                 it "does not connect test to test suite" do
@@ -342,7 +342,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "when given a block" do
           before do
-            recorder.trace_test(
+            test_visibility.trace_test(
               test_name,
               test_suite_name,
               service: test_service,
@@ -384,7 +384,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         let(:service) { "my-service" }
         let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-        subject { recorder.start_test_session(service: service, tags: tags) }
+        subject { test_visibility.start_test_session(service: service, tags: tags) }
 
         it "returns a new CI test_session span" do
           expect(subject).to be_kind_of(Datadog::CI::TestSession)
@@ -436,7 +436,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         let(:service) { "my-service" }
         let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-        subject { recorder.start_test_module(module_name, service: service, tags: tags) }
+        subject { test_visibility.start_test_module(module_name, service: service, tags: tags) }
 
         context "when there is no active test session" do
           it "returns a new CI test_module span" do
@@ -479,7 +479,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           let(:service) { nil }
           let(:session_service) { "session_service" }
           let(:session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
-          let(:test_session) { recorder.start_test_session(service: session_service, tags: session_tags) }
+          let(:test_session) { test_visibility.start_test_session(service: session_service, tags: session_tags) }
 
           before do
             test_session
@@ -513,8 +513,8 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         let(:session_service) { "session_service" }
         let(:session_tags) { {"test.framework_version" => "1.0", "my.session.tag" => "my_session_value"} }
 
-        let(:test_session) { recorder.start_test_session(service: session_service, tags: session_tags) }
-        let(:test_module) { recorder.start_test_module(module_name) }
+        let(:test_session) { test_visibility.start_test_session(service: session_service, tags: session_tags) }
+        let(:test_module) { test_visibility.start_test_module(module_name) }
 
         before do
           test_session
@@ -525,7 +525,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           let(:suite_name) { "my-suite" }
           let(:tags) { {"my.tag" => "my_value"} }
 
-          subject { recorder.start_test_suite(suite_name, tags: tags) }
+          subject { test_visibility.start_test_suite(suite_name, tags: tags) }
 
           it "returns a new CI test_suite span" do
             expect(subject).to be_kind_of(Datadog::CI::TestSuite)
@@ -559,13 +559,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         context "when test suite with given name is already started" do
           let(:suite_name) { "my-suite" }
           let(:tags) { {"my.tag" => "my_value"} }
-          let(:already_running_test_suite) { recorder.start_test_suite(suite_name, tags: tags) }
+          let(:already_running_test_suite) { test_visibility.start_test_suite(suite_name, tags: tags) }
 
           before do
             already_running_test_suite
           end
 
-          subject { recorder.start_test_suite(suite_name) }
+          subject { test_visibility.start_test_suite(suite_name) }
 
           it "returns the already running test suite" do
             expect(subject.id).to eq(already_running_test_suite.id)
@@ -575,13 +575,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       end
 
       describe "#active_test_session" do
-        subject { recorder.active_test_session }
+        subject { test_visibility.active_test_session }
         context "when there is no active test session" do
           it { is_expected.to be_nil }
         end
 
         context "when test session is started" do
-          let(:test_session) { recorder.start_test_session }
+          let(:test_session) { test_visibility.start_test_session }
           before do
             test_session
           end
@@ -593,13 +593,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       end
 
       describe "#active_test_module" do
-        subject { recorder.active_test_module }
+        subject { test_visibility.active_test_module }
         context "when there is no active test module" do
           it { is_expected.to be_nil }
         end
 
         context "when test module is started" do
-          let(:test_module) { recorder.start_test_module("my module") }
+          let(:test_module) { test_visibility.start_test_module("my module") }
           before do
             test_module
           end
@@ -611,14 +611,14 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       end
 
       describe "#active_test" do
-        subject { recorder.active_test }
+        subject { test_visibility.active_test }
 
         context "when there is no active test" do
           it { is_expected.to be_nil }
         end
 
         context "when test is started" do
-          let(:ci_test) { recorder.trace_test("my test", "my suite") }
+          let(:ci_test) { test_visibility.trace_test("my test", "my suite") }
 
           before do
             ci_test
@@ -631,14 +631,14 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       end
 
       describe "#active_span" do
-        subject { recorder.active_span }
+        subject { test_visibility.active_span }
 
         context "when there is no active span" do
           it { is_expected.to be_nil }
         end
 
         context "when span is started" do
-          let(:ci_span) { recorder.trace("my test step", type: "step") }
+          let(:ci_span) { test_visibility.trace("my test step", type: "step") }
 
           before do
             ci_span
@@ -652,7 +652,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
       end
 
       describe "#deactivate_test" do
-        subject { recorder.deactivate_test }
+        subject { test_visibility.deactivate_test }
 
         context "when there is no active test" do
           let(:ci_test) { Datadog::CI::Test.new(double("tracer span")) }
@@ -661,18 +661,18 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
         end
 
         context "when deactivating the currently active test" do
-          let(:ci_test) { recorder.trace_test("my test", "my suite") }
+          let(:ci_test) { test_visibility.trace_test("my test", "my suite") }
 
           it "deactivates the test" do
             subject
 
-            expect(recorder.active_test).to be_nil
+            expect(test_visibility.active_test).to be_nil
           end
         end
       end
 
       describe "#deactivate_test_session" do
-        subject { recorder.deactivate_test_session }
+        subject { test_visibility.deactivate_test_session }
 
         context "when there is no active test session" do
           it { is_expected.to be_nil }
@@ -680,19 +680,19 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "when deactivating the currently active test session" do
           before do
-            recorder.start_test_session
+            test_visibility.start_test_session
           end
 
           it "deactivates the test session" do
             subject
 
-            expect(recorder.active_test_session).to be_nil
+            expect(test_visibility.active_test_session).to be_nil
           end
         end
       end
 
       describe "#deactivate_test_module" do
-        subject { recorder.deactivate_test_module }
+        subject { test_visibility.deactivate_test_module }
 
         context "when there is no active test module" do
           it { is_expected.to be_nil }
@@ -700,19 +700,19 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "when deactivating the currently active test module" do
           before do
-            recorder.start_test_module("my module")
+            test_visibility.start_test_module("my module")
           end
 
           it "deactivates the test module" do
             subject
 
-            expect(recorder.active_test_module).to be_nil
+            expect(test_visibility.active_test_module).to be_nil
           end
         end
       end
 
       describe "#deactivate_test_suite" do
-        subject { recorder.deactivate_test_suite("my suite") }
+        subject { test_visibility.deactivate_test_suite("my suite") }
 
         context "when there is no active test suite" do
           it { is_expected.to be_nil }
@@ -720,13 +720,13 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
 
         context "when deactivating the currently active test suite" do
           before do
-            recorder.start_test_suite("my suite")
+            test_visibility.start_test_suite("my suite")
           end
 
           it "deactivates the test suite" do
             subject
 
-            expect(recorder.active_test_suite("my suite")).to be_nil
+            expect(test_visibility.active_test_suite("my suite")).to be_nil
           end
         end
       end
@@ -744,7 +744,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           let(:service) { "my-service" }
           let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-          subject { recorder.start_test_session(service: service, tags: tags) }
+          subject { test_visibility.start_test_session(service: service, tags: tags) }
 
           it "returns a new CI test_session span with ITR tags" do
             expect(subject).to be_kind_of(Datadog::CI::TestSession)
@@ -768,7 +768,7 @@ RSpec.describe Datadog::CI::TestVisibility::Recorder do
           let(:service) { "my-service" }
           let(:tags) { {"test.framework" => "my-framework", "my.tag" => "my_value"} }
 
-          subject { recorder.start_test_session(service: service, tags: tags) }
+          subject { test_visibility.start_test_session(service: service, tags: tags) }
 
           it { is_expected.not_to be_skipping_tests }
         end

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
   end
 
   context "when test suite level visibility is enabled" do
-    context "without ITR" do
+    context "without TestOptimisation" do
       include_context "CI mode activated"
 
       describe "#trace" do
@@ -732,7 +732,7 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
       end
     end
 
-    context "with ITR" do
+    context "with TestOptimisation" do
       context "without require_git in settings response" do
         include_context "CI mode activated" do
           let(:itr_enabled) { true }
@@ -746,7 +746,7 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
 
           subject { test_visibility.start_test_session(service: service, tags: tags) }
 
-          it "returns a new CI test_session span with ITR tags" do
+          it "returns a new CI test_session span with ITR/TestOptimisation tags" do
             expect(subject).to be_kind_of(Datadog::CI::TestSession)
             expect(subject.service).to eq(service)
 

--- a/spec/datadog/ci/test_visibility/null_component_spec.rb
+++ b/spec/datadog/ci/test_visibility/null_component_spec.rb
@@ -1,37 +1,41 @@
-RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
-  let(:recorder) { described_class.new }
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/test_visibility/null_component"
+
+RSpec.describe Datadog::CI::TestVisibility::NullComponent do
+  let(:test_visibility) { described_class.new }
 
   describe "#start_test_session" do
-    subject { recorder.start_test_session }
+    subject { test_visibility.start_test_session }
 
     it { is_expected.to be_nil }
 
     it "does not activate session" do
-      expect(recorder.active_test_session).to be_nil
+      expect(test_visibility.active_test_session).to be_nil
     end
   end
 
   describe "#start_test_module" do
     let(:module_name) { "my-module" }
 
-    subject { recorder.start_test_module(module_name) }
+    subject { test_visibility.start_test_module(module_name) }
 
     it { is_expected.to be_nil }
 
     it "does not activate module" do
-      expect(recorder.active_test_module).to be_nil
+      expect(test_visibility.active_test_module).to be_nil
     end
   end
 
   describe "#start_test_suite" do
     let(:suite_name) { "my-module" }
 
-    subject { recorder.start_test_suite(suite_name) }
+    subject { test_visibility.start_test_suite(suite_name) }
 
     it { is_expected.to be_nil }
 
     it "does not activate test suite" do
-      expect(recorder.active_test_suite(suite_name)).to be_nil
+      expect(test_visibility.active_test_suite(suite_name)).to be_nil
     end
   end
 
@@ -40,7 +44,7 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
       let(:spy_under_test) { spy("spy") }
 
       before do
-        recorder.trace_test("my test", "my suite") do |test_span|
+        test_visibility.trace_test("my test", "my suite") do |test_span|
           spy_under_test.call
 
           test_span&.passed!
@@ -57,7 +61,7 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
     end
 
     context "without a block" do
-      subject { recorder.trace_test("my test", "my suite") }
+      subject { test_visibility.trace_test("my test", "my suite") }
 
       it { is_expected.to be_nil }
     end
@@ -68,7 +72,7 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
       let(:spy_under_test) { spy("spy") }
 
       before do
-        recorder.trace("my step", type: "step") do |span|
+        test_visibility.trace("my step", type: "step") do |span|
           spy_under_test.call
 
           span&.set_metric("my.metric", 42)
@@ -85,31 +89,31 @@ RSpec.describe Datadog::CI::TestVisibility::NullRecorder do
     end
 
     context "without a block" do
-      subject { recorder.trace("my step", type: "step") }
+      subject { test_visibility.trace("my step", type: "step") }
 
       it { is_expected.to be_nil }
     end
   end
 
   describe "#active_test_session" do
-    subject { recorder.active_test_session }
+    subject { test_visibility.active_test_session }
 
     it { is_expected.to be_nil }
   end
 
   describe "#active_test_module" do
-    subject { recorder.active_test_module }
+    subject { test_visibility.active_test_module }
     it { is_expected.to be_nil }
   end
 
   describe "#active_test" do
-    subject { recorder.active_test }
+    subject { test_visibility.active_test }
 
     it { is_expected.to be_nil }
   end
 
   describe "#active_span" do
-    subject { recorder.active_span }
+    subject { test_visibility.active_span }
 
     it { is_expected.to be_nil }
   end

--- a/spec/datadog/ci/test_visibility/serializers/factories/test_level_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/factories/test_level_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../../../../../lib/datadog/ci/test_visibility/serializers/factories/test_level"
 require_relative "../../../../../../lib/datadog/ci/test_visibility/serializers/test_v1"
-require_relative "../../../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../../../lib/datadog/ci/test_visibility/component"
 
 RSpec.describe Datadog::CI::TestVisibility::Serializers::Factories::TestLevel do
   include_context "CI mode activated" do
@@ -10,7 +10,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::Factories::TestLevel do
   subject { described_class.serializer(trace_for_span(span), span) }
 
   describe ".convert_trace_to_serializable_events" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_trace
       end

--- a/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/factories/test_suite_level_spec.rb
@@ -1,7 +1,7 @@
 require_relative "../../../../../../lib/datadog/ci/test_visibility/serializers/factories/test_suite_level"
 require_relative "../../../../../../lib/datadog/ci/test_visibility/serializers/test_v2"
 require_relative "../../../../../../lib/datadog/ci/test_visibility/serializers/test_session"
-require_relative "../../../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../../../lib/datadog/ci/test_visibility/component"
 
 RSpec.describe Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel do
   include_context "CI mode activated" do

--- a/spec/datadog/ci/test_visibility/serializers/span_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/span_spec.rb
@@ -1,5 +1,5 @@
 require_relative "../../../../../lib/datadog/ci/test_visibility/serializers/span"
-require_relative "../../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../../lib/datadog/ci/test_visibility/component"
 
 RSpec.describe Datadog::CI::TestVisibility::Serializers::Span do
   include_context "CI mode activated" do
@@ -11,7 +11,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::Span do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_trace(with_http_span: true)
       end

--- a/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_module_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestModule do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_session_trace
       end

--- a/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_session_trace
       end

--- a/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_suite_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSuite do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_session_trace
       end

--- a/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
@@ -1,5 +1,5 @@
 require_relative "../../../../../lib/datadog/ci/test_visibility/serializers/test_v1"
-require_relative "../../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../../lib/datadog/ci/test_visibility/component"
 
 RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
   include_context "CI mode activated" do
@@ -11,7 +11,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_trace
       end

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -1,5 +1,5 @@
 require_relative "../../../../../lib/datadog/ci/test_visibility/serializers/test_v2"
-require_relative "../../../../../lib/datadog/ci/test_visibility/recorder"
+require_relative "../../../../../lib/datadog/ci/test_visibility/component"
 
 RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
   include_context "CI mode activated" do
@@ -12,7 +12,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
   end
 
   describe "#to_msgpack" do
-    context "traced a single test execution with Recorder" do
+    context "traced a single test execution with test visibility" do
       before do
         produce_test_session_trace
       end
@@ -53,7 +53,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
       end
     end
 
-    context "trace several tests executions with Recorder" do
+    context "trace several tests executions with test visibility" do
       let(:test_spans) { spans.select { |span| span.type == "test" } }
       subject { test_spans.map { |span| described_class.new(trace_for_span(span), span) } }
 

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
       let(:serializers_factory) { Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel }
 
       before do
-        allow_any_instance_of(Datadog::CI::ITR::Runner).to receive(:correlation_id).and_return("correlation-id")
+        allow_any_instance_of(Datadog::CI::TestOptimisation::Component).to receive(:correlation_id).and_return("correlation-id")
 
         produce_test_session_trace
       end

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Datadog::CI do
-  context "with recorder stubbed" do
-    let(:recorder) { instance_double(Datadog::CI::TestVisibility::Recorder) }
+  context "with test visibility stubbed" do
+    let(:test_visibility) { instance_double(Datadog::CI::TestVisibility::Component) }
 
     before do
-      allow(Datadog::CI).to receive(:recorder).and_return(recorder)
+      allow(Datadog::CI).to receive(:test_visibility).and_return(test_visibility)
     end
 
     describe "::trace_test" do
@@ -22,7 +22,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test) { instance_double(Datadog::CI::Test) }
 
       before do
-        allow(recorder).to receive(:trace_test).with(test_name, test_suite_name, **options, &block).and_return(ci_test)
+        allow(test_visibility).to receive(:trace_test).with(test_name, test_suite_name, **options, &block).and_return(ci_test)
       end
 
       it { is_expected.to be(ci_test) }
@@ -43,7 +43,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test) { instance_double(Datadog::CI::Test) }
 
       before do
-        allow(recorder).to receive(:trace_test).with(test_name, test_suite_name, **options).and_return(ci_test)
+        allow(test_visibility).to receive(:trace_test).with(test_name, test_suite_name, **options).and_return(ci_test)
       end
 
       it { is_expected.to be(ci_test) }
@@ -60,7 +60,7 @@ RSpec.describe Datadog::CI do
       let(:ci_span) { instance_double(Datadog::CI::Span) }
 
       before do
-        allow(recorder).to receive(:trace).with(span_name, type: type, **options, &block).and_return(ci_span)
+        allow(test_visibility).to receive(:trace).with(span_name, type: type, **options, &block).and_return(ci_span)
       end
 
       it { is_expected.to be(ci_span) }
@@ -83,7 +83,7 @@ RSpec.describe Datadog::CI do
         let(:ci_span) { instance_double(Datadog::CI::Span, type: type) }
 
         before do
-          allow(recorder).to receive(:active_span).and_return(ci_span)
+          allow(test_visibility).to receive(:active_span).and_return(ci_span)
         end
 
         it { is_expected.to be(ci_span) }
@@ -93,7 +93,7 @@ RSpec.describe Datadog::CI do
         let(:ci_span) { instance_double(Datadog::CI::Span, type: "test") }
 
         before do
-          allow(recorder).to receive(:active_span).and_return(ci_span)
+          allow(test_visibility).to receive(:active_span).and_return(ci_span)
         end
 
         it { is_expected.to be_nil }
@@ -101,7 +101,7 @@ RSpec.describe Datadog::CI do
 
       context "when no active span" do
         before do
-          allow(recorder).to receive(:active_span).and_return(nil)
+          allow(test_visibility).to receive(:active_span).and_return(nil)
         end
 
         it { is_expected.to be_nil }
@@ -116,7 +116,7 @@ RSpec.describe Datadog::CI do
         subject(:start_test_session) { described_class.start_test_session(service: service) }
 
         before do
-          allow(recorder).to receive(:start_test_session).with(service: service, tags: {}).and_return(ci_test_session)
+          allow(test_visibility).to receive(:start_test_session).with(service: service, tags: {}).and_return(ci_test_session)
         end
 
         it { is_expected.to be(ci_test_session) }
@@ -128,7 +128,7 @@ RSpec.describe Datadog::CI do
         context "when service is configured on library level" do
           before do
             allow(Datadog.configuration).to receive(:service_without_fallback).and_return("configured-service")
-            allow(recorder).to receive(:start_test_session).with(
+            allow(test_visibility).to receive(:start_test_session).with(
               service: "configured-service", tags: {}
             ).and_return(ci_test_session)
           end
@@ -144,7 +144,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test_session) { instance_double(Datadog::CI::TestSession) }
 
       before do
-        allow(recorder).to receive(:active_test_session).and_return(ci_test_session)
+        allow(test_visibility).to receive(:active_test_session).and_return(ci_test_session)
       end
 
       it { is_expected.to be(ci_test_session) }
@@ -156,7 +156,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test_module) { instance_double(Datadog::CI::TestModule) }
 
       before do
-        allow(recorder).to(
+        allow(test_visibility).to(
           receive(:start_test_module).with("my-module", service: nil, tags: {}).and_return(ci_test_module)
         )
       end
@@ -170,7 +170,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test_module) { instance_double(Datadog::CI::TestModule) }
 
       before do
-        allow(recorder).to receive(:active_test_module).and_return(ci_test_module)
+        allow(test_visibility).to receive(:active_test_module).and_return(ci_test_module)
       end
 
       it { is_expected.to be(ci_test_module) }
@@ -182,7 +182,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test_suite) { instance_double(Datadog::CI::TestSuite) }
 
       before do
-        allow(recorder).to(
+        allow(test_visibility).to(
           receive(:start_test_suite).with("my-suite", service: nil, tags: {}).and_return(ci_test_suite)
         )
       end
@@ -197,7 +197,7 @@ RSpec.describe Datadog::CI do
       let(:ci_test_suite) { instance_double(Datadog::CI::TestSuite) }
 
       before do
-        allow(recorder).to receive(:active_test_suite).with(test_suite_name).and_return(ci_test_suite)
+        allow(test_visibility).to receive(:active_test_suite).with(test_suite_name).and_return(ci_test_suite)
       end
 
       it { is_expected.to be(ci_test_suite) }

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -5,7 +5,7 @@ require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
 require_relative "calculator/calculator"
 require_relative "calculator/code_with_❤️"
 
-RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
+RSpec.describe Datadog::CI::TestOptimisation::Coverage::DDCov do
   let(:ignored_path) { nil }
   let(:threading_mode) { :multi }
   subject { described_class.new(root: root, ignored_path: ignored_path, threading_mode: threading_mode) }

--- a/spec/ddcov/ddcov_with_symlinks_spec.rb
+++ b/spec/ddcov/ddcov_with_symlinks_spec.rb
@@ -4,7 +4,7 @@ require "fileutils"
 
 require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
 
-RSpec.describe Datadog::CI::ITR::Coverage::DDCov do
+RSpec.describe Datadog::CI::TestOptimisation::Coverage::DDCov do
   before do
     # create a symlink to the calculator_with_symlinks/operations folder in vendor/gems
     FileUtils.ln_s(

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -30,7 +30,7 @@ RSpec.shared_context "CI mode activated" do
 
   let(:skippable_tests_response) do
     instance_double(
-      Datadog::CI::ITR::Skippable::Response,
+      Datadog::CI::TestOptimisation::Skippable::Response,
       ok?: true,
       correlation_id: itr_correlation_id,
       tests: itr_skippable_tests
@@ -69,8 +69,8 @@ RSpec.shared_context "CI mode activated" do
         require_git?: !require_git
       )
     )
-    allow_any_instance_of(Datadog::CI::ITR::Skippable).to receive(:fetch_skippable_tests).and_return(skippable_tests_response)
-    allow_any_instance_of(Datadog::CI::ITR::Coverage::Transport).to receive(:send_events).and_return([])
+    allow_any_instance_of(Datadog::CI::TestOptimisation::Skippable).to receive(:fetch_skippable_tests).and_return(skippable_tests_response)
+    allow_any_instance_of(Datadog::CI::TestOptimisation::Coverage::Transport).to receive(:send_events).and_return([])
 
     Datadog.configure do |c|
       c.ci.enabled = ci_enabled
@@ -88,7 +88,7 @@ RSpec.shared_context "CI mode activated" do
   after do
     ::Datadog::Tracing.shutdown!
 
-    Datadog::CI.send(:itr_runner)&.shutdown!
+    Datadog::CI.send(:test_optimisation)&.shutdown!
     Datadog::CI.send(:test_visibility)&.shutdown!
 
     Datadog.configure do |c|

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -1,4 +1,4 @@
-# CI mode shared context sets up the CI recorder and configures the CI mode for tracer like customers do.
+# CI mode shared context sets up the CI test_visibility and configures the CI mode for tracer like customers do.
 # Example usage:
 #
 # include_context "CI mode activated" do
@@ -37,7 +37,7 @@ RSpec.shared_context "CI mode activated" do
     )
   end
 
-  let(:recorder) { Datadog.send(:components).ci_recorder }
+  let(:test_visibility) { Datadog.send(:components).test_visibility }
 
   before do
     setup_test_coverage_writer!
@@ -89,7 +89,7 @@ RSpec.shared_context "CI mode activated" do
     ::Datadog::Tracing.shutdown!
 
     Datadog::CI.send(:itr_runner)&.shutdown!
-    Datadog::CI.send(:recorder)&.shutdown!
+    Datadog::CI.send(:test_visibility)&.shutdown!
 
     Datadog.configure do |c|
       c.ci.enabled = false

--- a/spec/support/coverage_helpers.rb
+++ b/spec/support/coverage_helpers.rb
@@ -26,7 +26,7 @@ module CoverageHelpers
   def setup_test_coverage_writer!
     # DEV `*_any_instance_of` has concurrency issues when running with parallelism (e.g. JRuby).
     # DEV Single object `allow` and `expect` work as intended with parallelism.
-    allow(Datadog::CI::ITR::Runner).to receive(:new).and_wrap_original do |method, **args, &block|
+    allow(Datadog::CI::TestOptimisation::Component).to receive(:new).and_wrap_original do |method, **args, &block|
       instance = method.call(**args, &block)
 
       write_lock = Mutex.new
@@ -44,7 +44,7 @@ module CoverageHelpers
   end
 
   def runner
-    Datadog::CI.send(:itr_runner)
+    Datadog::CI.send(:test_optimisation)
   end
 
   def expect_coverage_events_belong_to_session(test_session_span)


### PR DESCRIPTION
**What does this PR do?**
Applies some refactorings:
- splits some code in components.rb in methods to make 
- renames TestVisibility::Recorder to TestVisibility::Component
- renames ITR to TestOptimisation to make the name more generic
- renames ITR::Runner to TestOptimisation::Component

**Motivation**
There are some topics that require attention before adding telemetry to the mix

**How to test the change?**
Unit tests, no behavior change