### PR TITLE
[SDTEST-116] Implement manual_api_events metric

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -2,7 +2,9 @@
 
 require_relative "ci/version"
 require_relative "ci/utils/configuration"
+require_relative "ci/utils/telemetry"
 require_relative "ci/ext/app_types"
+require_relative "ci/ext/telemetry"
 
 require "datadog/core"
 

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -41,6 +41,11 @@ module Datadog
       # @return [Datadog::CI::TestSession] the active, running {Datadog::CI::TestSession}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_session(service: Utils::Configuration.fetch_service_name("test"), tags: {})
+        Utils::Telemetry.inc(
+          Ext::Telemetry::METRIC_MANUAL_API_EVENTS,
+          1,
+          {Ext::Telemetry::TAG_EVENT_TYPE => Ext::Telemetry::EventType::SESSION}
+        )
         test_visibility.start_test_session(service: service, tags: tags)
       end
 
@@ -95,6 +100,12 @@ module Datadog
       # @return [Datadog::CI::TestModule] the active, running {Datadog::CI::TestModule}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_module(test_module_name, service: nil, tags: {})
+        Utils::Telemetry.inc(
+          Ext::Telemetry::METRIC_MANUAL_API_EVENTS,
+          1,
+          {Ext::Telemetry::TAG_EVENT_TYPE => Ext::Telemetry::EventType::MODULE}
+        )
+
         test_visibility.start_test_module(test_module_name, service: service, tags: tags)
       end
 
@@ -147,6 +158,12 @@ module Datadog
       # @return [Datadog::CI::TestSuite] the active, running {Datadog::CI::TestSuite}.
       # @return [nil] if test suite level visibility is disabled or CI mode is disabled.
       def start_test_suite(test_suite_name, service: nil, tags: {})
+        Utils::Telemetry.inc(
+          Ext::Telemetry::METRIC_MANUAL_API_EVENTS,
+          1,
+          {Ext::Telemetry::TAG_EVENT_TYPE => Ext::Telemetry::EventType::SUITE}
+        )
+
         test_visibility.start_test_suite(test_suite_name, service: service, tags: tags)
       end
 
@@ -224,6 +241,12 @@ module Datadog
       # @yieldparam [Datadog::CI::Test] ci_test the newly created and active [Datadog::CI::Test]
       # @yieldparam [nil] if CI mode is disabled
       def trace_test(test_name, test_suite_name, service: nil, tags: {}, &block)
+        Utils::Telemetry.inc(
+          Ext::Telemetry::METRIC_MANUAL_API_EVENTS,
+          1,
+          {Ext::Telemetry::TAG_EVENT_TYPE => Ext::Telemetry::EventType::TEST}
+        )
+
         test_visibility.trace_test(test_name, test_suite_name, service: service, tags: tags, &block)
       end
 
@@ -250,6 +273,11 @@ module Datadog
       # @return [Datadog::CI::Test] the active, unfinished {Datadog::CI::Test}.
       # @return [nil] if CI mode is disabled.
       def start_test(test_name, test_suite_name, service: nil, tags: {})
+        Utils::Telemetry.inc(
+          Ext::Telemetry::METRIC_MANUAL_API_EVENTS,
+          1,
+          {Ext::Telemetry::TAG_EVENT_TYPE => Ext::Telemetry::EventType::TEST}
+        )
         test_visibility.trace_test(test_name, test_suite_name, service: service, tags: tags)
       end
 

--- a/lib/datadog/ci/contrib/minitest/runnable.rb
+++ b/lib/datadog/ci/contrib/minitest/runnable.rb
@@ -19,7 +19,7 @@ module Datadog
 
               test_suite_name = Helpers.test_suite_name(self, method)
 
-              test_suite = Datadog::CI.start_test_suite(test_suite_name)
+              test_suite = test_visibility_component.start_test_suite(test_suite_name)
 
               results = super
               return results unless test_suite
@@ -33,6 +33,10 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:minitest]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
           end
         end

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -18,20 +18,24 @@ module Datadog
 
               return unless datadog_configuration[:enabled]
 
-              CI.start_test_session(
+              test_visibility_component.start_test_session(
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::Minitest::Integration.version.to_s
                 },
                 service: datadog_configuration[:service_name]
               )
-              CI.start_test_module(Ext::FRAMEWORK)
+              test_visibility_component.start_test_module(Ext::FRAMEWORK)
             end
 
             private
 
             def datadog_configuration
               Datadog.configuration.ci[:minitest]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
           end
         end

--- a/lib/datadog/ci/contrib/minitest/test.rb
+++ b/lib/datadog/ci/contrib/minitest/test.rb
@@ -26,12 +26,12 @@ module Datadog
                 test_suite_name = "#{test_suite_name} (#{name} concurrently)"
 
                 # for parallel execution we need to start a new test suite for each test
-                CI.start_test_suite(test_suite_name)
+                test_visibility_component.start_test_suite(test_suite_name)
               end
 
               source_file, line_number = method(name).source_location
 
-              test_span = CI.start_test(
+              test_span = test_visibility_component.trace_test(
                 name,
                 test_suite_name,
                 tags: {
@@ -47,7 +47,7 @@ module Datadog
             end
 
             def after_teardown
-              test_span = CI.active_test
+              test_span = test_visibility_component.active_test
               return super unless test_span
 
               finish_with_result(test_span, result_code)
@@ -76,6 +76,10 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:minitest]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
           end
 

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -34,10 +34,10 @@ module Datadog
 
               if ci_queue?
                 suite_name = "#{suite_name} (ci-queue running example [#{test_name}])"
-                test_suite_span = CI.start_test_suite(suite_name)
+                test_suite_span = test_visibility_component.start_test_suite(suite_name)
               end
 
-              CI.trace_test(
+              test_visibility_component.trace_test(
                 test_name,
                 suite_name,
                 tags: {
@@ -97,6 +97,10 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:rspec]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
 
             def ci_queue?

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -21,7 +21,7 @@ module Datadog
               return super unless top_level?
 
               suite_name = "#{description} at #{file_path}"
-              test_suite = Datadog::CI.start_test_suite(suite_name)
+              test_suite = test_visibility_component.start_test_suite(suite_name)
 
               success = super
               return success unless test_suite
@@ -43,6 +43,10 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:rspec]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
           end
         end

--- a/lib/datadog/ci/contrib/rspec/knapsack_pro/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/knapsack_pro/runner.rb
@@ -18,7 +18,7 @@ module Datadog
                 return super if ::RSpec.configuration.dry_run?
                 return super unless datadog_configuration[:enabled]
 
-                test_session = CI.start_test_session(
+                test_session = test_visibility_component.start_test_session(
                   tags: {
                     CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                     CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s
@@ -26,7 +26,7 @@ module Datadog
                   service: datadog_configuration[:service_name]
                 )
 
-                test_module = CI.start_test_module(Ext::FRAMEWORK)
+                test_module = test_visibility_component.start_test_module(Ext::FRAMEWORK)
 
                 result = super
                 return result unless test_module && test_session
@@ -48,6 +48,10 @@ module Datadog
 
               def datadog_configuration
                 Datadog.configuration.ci[:rspec]
+              end
+
+              def test_visibility_component
+                Datadog.send(:components).test_visibility
               end
             end
           end

--- a/lib/datadog/ci/contrib/rspec/runner.rb
+++ b/lib/datadog/ci/contrib/rspec/runner.rb
@@ -18,7 +18,7 @@ module Datadog
               return super if ::RSpec.configuration.dry_run?
               return super unless datadog_configuration[:enabled]
 
-              test_session = CI.start_test_session(
+              test_session = test_visibility_component.start_test_session(
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => CI::Contrib::RSpec::Integration.version.to_s
@@ -26,7 +26,7 @@ module Datadog
                 service: datadog_configuration[:service_name]
               )
 
-              test_module = CI.start_test_module(Ext::FRAMEWORK)
+              test_module = test_visibility_component.start_test_module(Ext::FRAMEWORK)
 
               result = super
               return result unless test_module && test_session
@@ -48,6 +48,10 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:rspec]
+            end
+
+            def test_visibility_component
+              Datadog.send(:components).test_visibility
             end
           end
         end

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -50,6 +50,8 @@ module Datadog
           def ok?: (Cucumber::Core::Test::Result result, untyped strict) -> bool
 
           def configuration: () -> untyped
+
+          def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
         end
       end
     end

--- a/sig/datadog/ci/contrib/minitest/runnable.rbs
+++ b/sig/datadog/ci/contrib/minitest/runnable.rbs
@@ -16,6 +16,8 @@ module Datadog
             def test_order: () -> (nil | :parallel | :random | :sorted | :alpha)
 
             def runnable_methods: () -> Array[String]
+
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/runner.rbs
+++ b/sig/datadog/ci/contrib/minitest/runner.rbs
@@ -13,6 +13,8 @@ module Datadog
             private
 
             def datadog_configuration: () -> untyped
+
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/test.rbs
+++ b/sig/datadog/ci/contrib/minitest/test.rbs
@@ -23,6 +23,8 @@ module Datadog
 
             def datadog_configuration: () -> untyped
 
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
+
             def finish_with_result: (Datadog::CI::Span? span, String result_code) -> void
           end
         end

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -13,6 +13,7 @@ module Datadog
 
             def fetch_top_level_example_group: () -> Hash[Symbol, untyped]
             def datadog_configuration: () -> untyped
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
             def ci_queue?: () -> bool
           end
         end

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -13,6 +13,8 @@ module Datadog
             private
 
             def datadog_configuration: () -> untyped
+
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/knapsack_pro/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/knapsack_pro/runner.rbs
@@ -14,6 +14,8 @@ module Datadog
               private
 
               def datadog_configuration: () -> untyped
+
+              def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
             end
           end
         end

--- a/sig/datadog/ci/contrib/rspec/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/runner.rbs
@@ -13,6 +13,8 @@ module Datadog
             private
 
             def datadog_configuration: () -> untyped
+
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
           end
         end
       end

--- a/spec/datadog/ci/contrib/ci_queue_rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/ci_queue_rspec/instrumentation_spec.rb
@@ -3,6 +3,14 @@ require "fileutils"
 require "securerandom"
 
 RSpec.describe "RSpec instrumentation with Shopify's ci-queue runner" do
+  before do
+    # expect that public manual API isn't used
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+  end
+
   include_context "CI mode activated" do
     let(:integration_name) { :rspec }
   end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -69,6 +69,12 @@ RSpec.describe "Cucumber formatter" do
     expect(Datadog::CI::Ext::Environment).to receive(:tags).never
     expect(kernel).to receive(:exit).with(expected_test_run_code)
 
+    # do not use manual API
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+
     cli.execute!(existing_runtime)
   end
 

--- a/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
@@ -2,6 +2,14 @@ require "knapsack_pro"
 require "fileutils"
 
 RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
+  before do
+    # expect that public manual API isn't used
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+  end
+
   include_context "CI mode activated" do
     let(:integration_name) { :rspec }
   end

--- a/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
@@ -2,6 +2,14 @@ require "knapsack_pro"
 require "fileutils"
 
 RSpec.describe "Knapsack Pro runner when Datadog::CI is configured during the knapsack run like in rspec_go rake task" do
+  before do
+    # expect that public manual API isn't used
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+  end
+
   # Yields to a block in a new RSpec global context. All RSpec
   # test configuration and execution should be wrapped in this method.
   def with_new_rspec_environment

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -10,6 +10,14 @@ module Kernel
 end
 
 RSpec.describe "Minitest instrumentation" do
+  before do
+    # expect that public manual API isn't used
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+  end
+
   context "without service name configured" do
     include_context "CI mode activated" do
       let(:integration_name) { :minitest }
@@ -78,7 +86,7 @@ RSpec.describe "Minitest instrumentation" do
         :source_file,
         "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
-      expect(span).to have_test_tag(:source_start, "51")
+      expect(span).to have_test_tag(:source_start, "59")
       expect(span).to have_test_tag(
         :codeowners,
         "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -1,6 +1,14 @@
 require "time"
 
 RSpec.describe "RSpec hooks" do
+  before do
+    # expect that public manual API isn't used
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+  end
+
   # Yields to a block in a new RSpec global context. All RSpec
   # test configuration and execution should be wrapped in this method.
   def with_new_rspec_environment
@@ -109,7 +117,7 @@ RSpec.describe "RSpec hooks" do
         :source_file,
         "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb"
       )
-      expect(first_test_span).to have_test_tag(:source_start, "82")
+      expect(first_test_span).to have_test_tag(:source_start, "90")
       expect(first_test_span).to have_test_tag(
         :codeowners,
         "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Datadog::CI do
   context "with test visibility stubbed" do
+    include_context "Telemetry spy"
     let(:test_visibility) { instance_double(Datadog::CI::TestVisibility::Component) }
 
     before do
@@ -26,6 +27,8 @@ RSpec.describe Datadog::CI do
       end
 
       it { is_expected.to be(ci_test) }
+
+      it_behaves_like "emits telemetry metric", :inc, "manual_api_events", 1
     end
 
     describe "::start_test" do
@@ -47,6 +50,8 @@ RSpec.describe Datadog::CI do
       end
 
       it { is_expected.to be(ci_test) }
+
+      it_behaves_like "emits telemetry metric", :inc, "manual_api_events", 1
     end
 
     describe "::trace" do
@@ -120,6 +125,8 @@ RSpec.describe Datadog::CI do
         end
 
         it { is_expected.to be(ci_test_session) }
+
+        it_behaves_like "emits telemetry metric", :inc, "manual_api_events", 1
       end
 
       context "when service is not provided" do
@@ -162,6 +169,8 @@ RSpec.describe Datadog::CI do
       end
 
       it { is_expected.to be(ci_test_module) }
+
+      it_behaves_like "emits telemetry metric", :inc, "manual_api_events", 1
     end
 
     describe "::active_test_module" do
@@ -188,6 +197,8 @@ RSpec.describe Datadog::CI do
       end
 
       it { is_expected.to be(ci_test_suite) }
+
+      it_behaves_like "emits telemetry metric", :inc, "manual_api_events", 1
     end
 
     describe "::active_test_suite" do


### PR DESCRIPTION
**What does this PR do?**
Tracks manual_api_events metric when public API is used.

Internal instrumentations don't use public API anymore.

**How to test the change?**
Unit tests are provided