### PR TITLE
[SDTEST-160] Implement code coverage metrics for internal telemetry

### DIFF
--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -53,7 +53,6 @@ module Datadog
         METRIC_CODE_COVERAGE_FINISHED = "code_coverage_finished"
         METRIC_CODE_COVERAGE_IS_EMPTY = "code_coverage.is_empty"
         METRIC_CODE_COVERAGE_FILES = "code_coverage.files"
-        METRIC_CODE_COVERAGE_ERRORS = "code_coverage.errors"
 
         METRIC_TEST_SESSION = "test_session"
 

--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -86,7 +86,7 @@ module Datadog
         end
 
         module Library
-          BUILTIN = "builtin"
+          CUSTOM = "custom"
         end
 
         module Endpoint

--- a/lib/datadog/ci/test_optimisation/telemetry.rb
+++ b/lib/datadog/ci/test_optimisation/telemetry.rb
@@ -25,10 +25,6 @@ module Datadog
           Utils::Telemetry.distribution(Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, count.to_f)
         end
 
-        def self.code_coverage_errors
-          Utils::Telemetry.inc(Ext::Telemetry::METRIC_CODE_COVERAGE_ERRORS, 1)
-        end
-
         def self.tags_for_test(test)
           {
             Ext::Telemetry::TAG_TEST_FRAMEWORK => test.get_tag(Ext::Test::TAG_FRAMEWORK),

--- a/lib/datadog/ci/test_optimisation/telemetry.rb
+++ b/lib/datadog/ci/test_optimisation/telemetry.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "../ext/telemetry"
+require_relative "../ext/test"
+require_relative "../utils/telemetry"
+
+module Datadog
+  module CI
+    module TestOptimisation
+      # Telemetry for test optimisation component
+      module Telemetry
+        def self.code_coverage_started(test)
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_CODE_COVERAGE_STARTED, 1, tags_for_test(test))
+        end
+
+        def self.code_coverage_finished(test)
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_CODE_COVERAGE_FINISHED, 1, tags_for_test(test))
+        end
+
+        def self.code_coverage_is_empty
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_CODE_COVERAGE_IS_EMPTY, 1)
+        end
+
+        def self.code_coverage_files(count)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, count.to_f)
+        end
+
+        def self.code_coverage_errors
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_CODE_COVERAGE_ERRORS, 1)
+        end
+
+        def self.tags_for_test(test)
+          {
+            Ext::Telemetry::TAG_TEST_FRAMEWORK => test.get_tag(Ext::Test::TAG_FRAMEWORK),
+            Ext::Telemetry::TAG_LIBRARY => Ext::Telemetry::Library::CUSTOM
+          }
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -132,7 +132,7 @@ module Datadog
         end
 
         module Library
-          BUILTIN: "builtin"
+          CUSTOM: "custom"
         end
 
         module Endpoint

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -80,8 +80,6 @@ module Datadog
 
         METRIC_CODE_COVERAGE_FILES: "code_coverage.files"
 
-        METRIC_CODE_COVERAGE_ERRORS: "code_coverage.errors"
-
         METRIC_TEST_SESSION: "test_session"
 
         TAG_TEST_FRAMEWORK: "test_framework"

--- a/sig/datadog/ci/test_optimisation/telemetry.rbs
+++ b/sig/datadog/ci/test_optimisation/telemetry.rbs
@@ -10,8 +10,6 @@ module Datadog
 
         def self.code_coverage_files: (Integer count) -> void
 
-        def self.code_coverage_errors: () -> void
-
         def self.tags_for_test: (Datadog::CI::Test test) -> ::Hash[String, String]
       end
     end

--- a/sig/datadog/ci/test_optimisation/telemetry.rbs
+++ b/sig/datadog/ci/test_optimisation/telemetry.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module CI
+    module TestOptimisation
+      module Telemetry
+        def self.code_coverage_started: (Datadog::CI::Test test) -> void
+
+        def self.code_coverage_finished: (Datadog::CI::Test test) -> void
+
+        def self.code_coverage_is_empty: () -> void
+
+        def self.code_coverage_files: (Integer count) -> void
+
+        def self.code_coverage_errors: () -> void
+
+        def self.tags_for_test: (Datadog::CI::Test test) -> ::Hash[String, String]
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/test_optimisation/telemetry_spec.rb
+++ b/spec/datadog/ci/test_optimisation/telemetry_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/test_optimisation/telemetry"
+
+RSpec.describe Datadog::CI::TestOptimisation::Telemetry do
+  describe ".code_coverage_started" do
+    subject(:code_coverage_started) { described_class.code_coverage_started(test) }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_STARTED, 1, expected_tags)
+    end
+
+    let(:test) do
+      Datadog::Tracing::SpanOperation.new(
+        "test",
+        type: Datadog::CI::Ext::AppTypes::TYPE_TEST,
+        tags: {
+          Datadog::CI::Ext::Test::TAG_FRAMEWORK => "rspec"
+        }
+      )
+    end
+
+    let(:expected_tags) do
+      {
+        Datadog::CI::Ext::Telemetry::TAG_TEST_FRAMEWORK => "rspec",
+        Datadog::CI::Ext::Telemetry::TAG_LIBRARY => Datadog::CI::Ext::Telemetry::Library::CUSTOM
+      }
+    end
+
+    it { code_coverage_started }
+  end
+
+  describe ".code_coverage_finished" do
+    subject(:code_coverage_finished) { described_class.code_coverage_finished(test) }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FINISHED, 1, expected_tags)
+    end
+
+    let(:test) do
+      Datadog::Tracing::SpanOperation.new(
+        "test",
+        type: Datadog::CI::Ext::AppTypes::TYPE_TEST,
+        tags: {
+          Datadog::CI::Ext::Test::TAG_FRAMEWORK => "rspec"
+        }
+      )
+    end
+
+    let(:expected_tags) do
+      {
+        Datadog::CI::Ext::Telemetry::TAG_TEST_FRAMEWORK => "rspec",
+        Datadog::CI::Ext::Telemetry::TAG_LIBRARY => Datadog::CI::Ext::Telemetry::Library::CUSTOM
+      }
+    end
+
+    it { code_coverage_finished }
+  end
+
+  describe ".code_coverage_is_empty" do
+    subject(:code_coverage_is_empty) { described_class.code_coverage_is_empty }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_IS_EMPTY, 1)
+    end
+
+    it { code_coverage_is_empty }
+  end
+
+  describe ".code_coverage_files" do
+    subject(:code_coverage_files) { described_class.code_coverage_files(count) }
+
+    let(:count) { 42 }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:distribution)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, count.to_f)
+    end
+
+    it { code_coverage_files }
+  end
+
+  describe ".code_coverage_errors" do
+    subject(:code_coverage_errors) { described_class.code_coverage_errors }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_ERRORS, 1)
+    end
+
+    it { code_coverage_errors }
+  end
+end

--- a/spec/datadog/ci/test_optimisation/telemetry_spec.rb
+++ b/spec/datadog/ci/test_optimisation/telemetry_spec.rb
@@ -82,15 +82,4 @@ RSpec.describe Datadog::CI::TestOptimisation::Telemetry do
 
     it { code_coverage_files }
   end
-
-  describe ".code_coverage_errors" do
-    subject(:code_coverage_errors) { described_class.code_coverage_errors }
-
-    before do
-      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
-        .with(Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_ERRORS, 1)
-    end
-
-    it { code_coverage_errors }
-  end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds code coverage metrics to internal telemetry.

**Additional Notes**
Note that code_coverage.errors metric is unused and remove. Code coverage collection in this library is "error-free" as any potential fatal bug in native extension will most likely cause segfault and crash of the Ruby process.

**How to test the change?**
Unit tests are provided