### PR TITLE
[SDTEST-160] git commands telemetry

### DIFF
--- a/lib/datadog/ci/git/telemetry.rb
+++ b/lib/datadog/ci/git/telemetry.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module Git
+      module Telemetry
+        def self.git_command(command)
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_GIT_COMMAND, 1, tags_for_command(command))
+        end
+
+        def self.git_command_errors(command, exit_code: nil, executable_missing: false)
+          tags = tags_for_command(command)
+
+          exit_code_tag_value = exit_code_for(exit_code: exit_code, executable_missing: executable_missing)
+          tags[Ext::Telemetry::TAG_EXIT_CODE] = exit_code_tag_value if exit_code_tag_value
+
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_GIT_COMMAND_ERRORS, 1, tags)
+        end
+
+        def self.git_command_ms(command, duration_ms)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_GIT_COMMAND_MS, duration_ms, tags_for_command(command))
+        end
+
+        def self.tags_for_command(command)
+          {Ext::Telemetry::TAG_COMMAND => command}
+        end
+
+        def self.exit_code_for(exit_code: nil, executable_missing: false)
+          return Ext::Telemetry::ExitCode::MISSING if executable_missing
+          return exit_code.to_s if exit_code
+
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -8,7 +8,6 @@ require_relative "telemetry"
 require_relative "../codeowners/parser"
 require_relative "../contrib/contrib"
 require_relative "../ext/test"
-require_relative "../ext/environment"
 require_relative "../git/local_repository"
 
 require_relative "../worker"
@@ -28,7 +27,7 @@ module Datadog
           codeowners: Codeowners::Parser.new(Git::LocalRepository.root).parse
         )
           @test_suite_level_visibility_enabled = test_suite_level_visibility_enabled
-          @context = Context.new(Ext::Environment.tags(ENV).freeze)
+          @context = Context.new
           @codeowners = codeowners
           @test_optimisation = test_optimisation
           @remote_settings_api = remote_settings_api

--- a/lib/datadog/ci/test_visibility/context.rb
+++ b/lib/datadog/ci/test_visibility/context.rb
@@ -8,6 +8,7 @@ require_relative "store/global"
 require_relative "store/local"
 
 require_relative "../ext/app_types"
+require_relative "../ext/environment"
 require_relative "../ext/test"
 
 require_relative "../span"
@@ -23,11 +24,9 @@ module Datadog
       # Its responsibility includes building domain models for test visibility as well.
       # Internally it uses Datadog::Tracing module to create spans.
       class Context
-        def initialize(environment_tags)
+        def initialize
           @local_context = Store::Local.new
           @global_context = Store::Global.new
-
-          @environment_tags = environment_tags
         end
 
         def start_test_session(service: nil, tags: {})
@@ -197,6 +196,8 @@ module Datadog
 
         # TAGGING
         def set_initial_tags(ci_span, tags)
+          @environment_tags ||= Ext::Environment.tags(ENV).freeze
+
           ci_span.set_default_tags
           ci_span.set_environment_runtime_tags
 

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -2,6 +2,14 @@ module Datadog
   module CI
     module Git
       module LocalRepository
+        class GitCommandExecutionError < StandardError
+          attr_reader command: String
+          attr_reader output: String?
+          attr_reader status: Process::Status?
+
+          def initialize: (String message, output: String?, status: Process::Status?, command: String) -> void
+        end
+
         COMMAND_RETRY_COUNT: 3
 
         @root: String?
@@ -46,6 +54,8 @@ module Datadog
         def self.exec_git_command: (String ref, ?stdin: String?) -> String?
 
         def self.log_failure: (StandardError e, String action) -> void
+
+        def self.telemetry_track_error: (StandardError e, String command) -> void
       end
     end
   end

--- a/sig/datadog/ci/git/telemetry.rbs
+++ b/sig/datadog/ci/git/telemetry.rbs
@@ -1,0 +1,17 @@
+module Datadog
+  module CI
+    module Git
+      module Telemetry
+        def self.git_command: (String command) -> void
+
+        def self.git_command_errors: (String command, ?exit_code: Integer?, ?executable_missing: bool) -> void
+
+        def self.git_command_ms: (String command, untyped duration_ms) -> void
+
+        def self.tags_for_command: (String command) -> ::Hash[String, String]
+
+        def self.exit_code_for: (?exit_code: Integer?, ?executable_missing: bool) -> String?
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/test_visibility/context.rbs
+++ b/sig/datadog/ci/test_visibility/context.rbs
@@ -7,7 +7,7 @@ module Datadog
 
         @environment_tags: Hash[String, String]
 
-        def initialize: (Hash[String, String] environment_tags) -> void
+        def initialize: () -> void
 
         def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
 

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -107,10 +107,6 @@ RSpec.describe Datadog::CI::Configuration::Components do
         context "is enabled" do
           let(:enabled) { true }
 
-          it "collects environment tags" do
-            expect(Datadog::CI::Ext::Environment).to have_received(:tags).with(ENV)
-          end
-
           context "when tracing is disabled" do
             let(:tracing_enabled) { false }
 
@@ -344,10 +340,6 @@ RSpec.describe Datadog::CI::Configuration::Components do
           it do
             expect(settings.tracing.test_mode)
               .to_not have_received(:writer_options=)
-          end
-
-          it "does not collect tags" do
-            expect(Datadog::CI::Ext::Environment).not_to have_received(:tags)
           end
         end
       end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe "Cucumber formatter" do
       steps_file_for_run_path
     )
 
-    expect(Datadog::CI::Ext::Environment).to receive(:tags).never
+    # assert that environment tags are collected once per session
+    expect(Datadog::CI::Ext::Environment).to receive(:tags).once.and_call_original
+
     expect(kernel).to receive(:exit).with(expected_test_run_code)
 
     # do not use manual API

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Minitest instrumentation" do
     end
 
     it "creates spans for several tests" do
-      expect(Datadog::CI::Ext::Environment).to receive(:tags).never
+      expect(Datadog::CI::Ext::Environment).to receive(:tags).once.and_call_original
 
       num_tests = 20
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe "RSpec hooks" do
     end
 
     it "creates spans for several examples" do
-      expect(Datadog::CI::Ext::Environment).to receive(:tags).never
+      expect(Datadog::CI::Ext::Environment).to receive(:tags).once.and_call_original
 
       num_examples = 20
       with_new_rspec_environment do

--- a/spec/datadog/ci/git/local_repository_spec.rb
+++ b/spec/datadog/ci/git/local_repository_spec.rb
@@ -105,6 +105,9 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
     subject { described_class.git_repository_url }
 
     it { is_expected.to eq("git@github.com:DataDog/datadog-ci-rb.git") }
+
+    it_behaves_like "emits telemetry metric", :inc, "git.command", 1
+    it_behaves_like "emits telemetry metric", :distribution, "git.command_ms"
   end
 
   context "with git folder" do
@@ -138,6 +141,9 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       end
 
       it { is_expected.to eq("master") }
+
+      it_behaves_like "emits telemetry metric", :inc, "git.command", 1
+      it_behaves_like "emits telemetry metric", :distribution, "git.command_ms"
     end
 
     describe ".git_tag" do
@@ -189,6 +195,9 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       it "returns empty array as last commit was more than 1 month ago" do
         expect(subject).to eq([])
       end
+
+      it_behaves_like "emits telemetry metric", :inc, "git.command", 1
+      it_behaves_like "emits telemetry metric", :distribution, "git.command_ms"
     end
 
     describe ".git_commits_rev_list" do
@@ -202,6 +211,9 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
       end
 
       it { is_expected.to be_nil }
+
+      it_behaves_like "emits telemetry metric", :inc, "git.command", 1
+      it_behaves_like "emits telemetry metric", :distribution, "git.command_ms"
     end
   end
 

--- a/spec/datadog/ci/git/telemetry_spec.rb
+++ b/spec/datadog/ci/git/telemetry_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/git/telemetry"
+
+RSpec.describe Datadog::CI::Git::Telemetry do
+  describe ".git_command" do
+    subject(:git_command) { described_class.git_command(command) }
+
+    let(:command) { "git ls-remote --get-url" }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_GIT_COMMAND, 1, expected_tags)
+    end
+
+    let(:expected_tags) do
+      {
+        Datadog::CI::Ext::Telemetry::TAG_COMMAND => command
+      }
+    end
+
+    it { git_command }
+  end
+
+  describe ".git_command_errors" do
+    subject(:git_command_errors) { described_class.git_command_errors(command, exit_code: exit_code, executable_missing: executable_missing) }
+
+    let(:command) { "git ls-remote --get-url" }
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_GIT_COMMAND_ERRORS, 1, expected_tags)
+    end
+
+    context "when exit code is 1" do
+      let(:exit_code) { 1 }
+      let(:executable_missing) { false }
+
+      let(:expected_tags) do
+        {
+          Datadog::CI::Ext::Telemetry::TAG_COMMAND => command,
+          Datadog::CI::Ext::Telemetry::TAG_EXIT_CODE => exit_code.to_s
+        }
+      end
+
+      it { git_command_errors }
+    end
+
+    context "when executable is missing" do
+      let(:executable_missing) { true }
+      let(:exit_code) { nil }
+
+      let(:expected_tags) do
+        {
+          Datadog::CI::Ext::Telemetry::TAG_COMMAND => command,
+          Datadog::CI::Ext::Telemetry::TAG_EXIT_CODE => Datadog::CI::Ext::Telemetry::ExitCode::MISSING
+        }
+      end
+
+      it { git_command_errors }
+    end
+  end
+
+  describe ".git_command_ms" do
+    subject(:git_command_ms) { described_class.git_command_ms(command, duration_ms) }
+
+    let(:command) { "git ls-remote --get-url" }
+    let(:duration_ms) { 100 }
+
+    before do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:distribution)
+        .with(Datadog::CI::Ext::Telemetry::METRIC_GIT_COMMAND_MS, duration_ms, expected_tags)
+    end
+
+    let(:expected_tags) do
+      {
+        Datadog::CI::Ext::Telemetry::TAG_COMMAND => command
+      }
+    end
+
+    it { git_command_ms }
+  end
+end

--- a/spec/datadog/ci/transport/http_spec.rb
+++ b/spec/datadog/ci/transport/http_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Datadog::CI::Transport::HTTP do
         expect(response.code).to eq(200)
         expect(response.payload).to eq("sample payload")
         expect(response.request_compressed).to eq(false)
-        expect(response.request_size).to eq(payload.size)
+        expect(response.request_size).to eq(payload.bytesize)
         expect(response.telemetry_error_type).to be_nil
       end
 
@@ -155,7 +155,7 @@ RSpec.describe Datadog::CI::Transport::HTTP do
 
         expect(response.code).to eq(200)
         expect(response.request_compressed).to eq(true)
-        expect(response.request_size).to eq(expected_payload.size)
+        expect(response.request_size).to eq(expected_payload.bytesize)
       end
     end
 


### PR DESCRIPTION
**What does this PR do?**
Adds telemetry metrics collection to git commands

**Additional Notes**
This change caused curious fail: one must not access Telemetry when the library is initialized. We previously collected environment tags during the library initialization stage, which might include using git commands. I made the environment tags collection lazy, so it does not happen until at least one span is traced.

**How to test the change?**
Unit tests are provided