### PR TITLE
[SDTEST-160] API metrics

### DIFF
--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -71,9 +71,7 @@ module Datadog
         TAG_RESPONSE_COMPRESSED = "rs_compressed"
         TAG_COMMAND = "command"
         TAG_COVERAGE_ENABLED = "coverage_enabled"
-        TAG_ITR_ENABLED = "itr_enabled"
-        TAG_ITR_SKIP_ENABLED = "itr_skip_enabled"
-        TAG_REQUIRE_GIT = "require_git"
+        TAG_ITR_SKIP_ENABLED = "itrskip_enabled"
         TAG_PROVIDER = "provider"
         TAG_AUTO_INJECTED = "auto_injected"
 

--- a/lib/datadog/ci/git/search_commits.rb
+++ b/lib/datadog/ci/git/search_commits.rb
@@ -7,6 +7,7 @@ require_relative "../ext/telemetry"
 require_relative "../ext/transport"
 require_relative "../transport/telemetry"
 require_relative "../utils/git"
+require_relative "../utils/telemetry"
 
 module Datadog
   module CI
@@ -33,7 +34,7 @@ module Datadog
             1,
             compressed: http_response.request_compressed
           )
-          Transport::Telemetry.api_requests_ms(Ext::Telemetry::METRIC_GIT_REQUESTS_SEARCH_COMMITS_MS, http_response.duration_ms)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_GIT_REQUESTS_SEARCH_COMMITS_MS, http_response.duration_ms)
 
           unless http_response.ok?
             Transport::Telemetry.api_requests_errors(

--- a/lib/datadog/ci/git/search_commits.rb
+++ b/lib/datadog/ci/git/search_commits.rb
@@ -3,7 +3,9 @@
 require "json"
 require "set"
 
+require_relative "../ext/telemetry"
 require_relative "../ext/transport"
+require_relative "../transport/telemetry"
 require_relative "../utils/git"
 
 module Datadog
@@ -25,7 +27,23 @@ module Datadog
             path: Ext::Transport::DD_API_GIT_SEARCH_COMMITS_PATH,
             payload: request_payload(repository_url, commits)
           )
-          raise ApiError, "Failed to search commits: #{http_response.inspect}" unless http_response.ok?
+
+          Transport::Telemetry.api_requests(
+            Ext::Telemetry::METRIC_GIT_REQUESTS_SEARCH_COMMITS,
+            1,
+            compressed: http_response.request_compressed
+          )
+          Transport::Telemetry.api_requests_ms(Ext::Telemetry::METRIC_GIT_REQUESTS_SEARCH_COMMITS_MS, http_response.duration_ms)
+
+          unless http_response.ok?
+            Transport::Telemetry.api_requests_errors(
+              Ext::Telemetry::METRIC_GIT_REQUESTS_SEARCH_COMMITS_ERRORS,
+              1,
+              error_type: http_response.telemetry_error_type,
+              status_code: http_response.code
+            )
+            raise ApiError, "Failed to search commits: #{http_response.inspect}"
+          end
 
           response_payload = parse_json_response(http_response)
           extract_commits(response_payload)

--- a/lib/datadog/ci/git/upload_packfile.rb
+++ b/lib/datadog/ci/git/upload_packfile.rb
@@ -45,7 +45,7 @@ module Datadog
             compressed: http_response.request_compressed
           )
           Utils::Telemetry.distribution(Ext::Telemetry::METRIC_GIT_REQUESTS_OBJECT_PACK_MS, http_response.duration_ms)
-          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_GIT_REQUESTS_OBJECT_PACK_BYTES, http_response.request_size)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_GIT_REQUESTS_OBJECT_PACK_BYTES, http_response.request_size.to_f)
 
           unless http_response.ok?
             Transport::Telemetry.api_requests_errors(

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -5,11 +5,13 @@ require "pp"
 require "datadog/core/utils/forking"
 
 require_relative "../ext/test"
+require_relative "../ext/telemetry"
 require_relative "../ext/transport"
 
 require_relative "../git/local_repository"
 
 require_relative "../utils/parsing"
+require_relative "../utils/telemetry"
 
 require_relative "coverage/event"
 require_relative "skippable"
@@ -239,6 +241,8 @@ module Datadog
           Datadog.logger.debug { "Fetched skippable tests: \n #{@skippable_tests}" }
           Datadog.logger.debug { "Found #{@skippable_tests.count} skippable tests." }
           Datadog.logger.debug { "ITR correlation ID: #{@correlation_id}" }
+
+          Utils::Telemetry.inc(Ext::Telemetry::METRIC_ITR_SKIPPABLE_TESTS_RESPONSE_TESTS, @skippable_tests.count)
         end
 
         def code_coverage_mode

--- a/lib/datadog/ci/test_optimisation/skippable.rb
+++ b/lib/datadog/ci/test_optimisation/skippable.rb
@@ -75,6 +75,18 @@ module Datadog
             payload: request_payload
           )
 
+          Transport::Telemetry.api_requests(
+            Ext::Telemetry::METRIC_ITR_SKIPPABLE_TESTS_REQUEST,
+            1,
+            compressed: http_response.request_compressed
+          )
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_ITR_SKIPPABLE_TESTS_REQUEST_MS, http_response.duration_ms)
+          Utils::Telemetry.distribution(
+            Ext::Telemetry::METRIC_ITR_SKIPPABLE_TESTS_RESPONSE_BYTES,
+            http_response.response_size.to_f,
+            {Ext::Telemetry::TAG_RESPONSE_COMPRESSED => http_response.gzipped_content?.to_s}
+          )
+
           Response.new(http_response)
         end
 

--- a/lib/datadog/ci/test_optimisation/skippable.rb
+++ b/lib/datadog/ci/test_optimisation/skippable.rb
@@ -87,6 +87,15 @@ module Datadog
             {Ext::Telemetry::TAG_RESPONSE_COMPRESSED => http_response.gzipped_content?.to_s}
           )
 
+          unless http_response.ok?
+            Transport::Telemetry.api_requests_errors(
+              Ext::Telemetry::METRIC_ITR_SKIPPABLE_TESTS_REQUEST_ERRORS,
+              1,
+              error_type: http_response.telemetry_error_type,
+              status_code: http_response.code
+            )
+          end
+
           Response.new(http_response)
         end
 

--- a/lib/datadog/ci/test_optimisation/skippable.rb
+++ b/lib/datadog/ci/test_optimisation/skippable.rb
@@ -2,9 +2,12 @@
 
 require "json"
 
+require_relative "../ext/telemetry"
 require_relative "../ext/transport"
 require_relative "../ext/test"
+require_relative "../transport/telemetry"
 require_relative "../utils/test_run"
+require_relative "../utils/telemetry"
 
 module Datadog
   module CI

--- a/lib/datadog/ci/transport/adapters/net.rb
+++ b/lib/datadog/ci/transport/adapters/net.rb
@@ -81,6 +81,10 @@ module Datadog
               @decompressed_payload = Gzip.decompress(http_response.body)
             end
 
+            def response_size
+              http_response.body.bytesize
+            end
+
             def header(name)
               http_response[name]
             end

--- a/lib/datadog/ci/transport/adapters/net.rb
+++ b/lib/datadog/ci/transport/adapters/net.rb
@@ -66,7 +66,7 @@ module Datadog
 
             attr_reader :http_response
             # Stats for telemetry
-            attr_accessor :request_compressed, :request_size
+            attr_accessor :duration_ms, :request_compressed, :request_size
 
             def initialize(http_response)
               @http_response = http_response

--- a/lib/datadog/ci/transport/event_platform_transport.rb
+++ b/lib/datadog/ci/transport/event_platform_transport.rb
@@ -4,7 +4,6 @@ require "msgpack"
 
 require "datadog/core/encoding"
 require "datadog/core/chunker"
-require "datadog/core/utils/time"
 
 require_relative "telemetry"
 
@@ -49,18 +48,13 @@ module Datadog
             end
             Telemetry.endpoint_payload_events_count(chunk.count, endpoint: telemetry_endpoint_tag)
 
-            response = nil
-            # @type var request_duration_ms: Float
-            request_duration_ms = Core::Utils::Time.measure(:float_millisecond) do
-              response = send_payload(encoded_payload)
-            end
-            # @type var response: Datadog::CI::Transport::Adapters::Net::Response
+            response = send_payload(encoded_payload)
 
             Telemetry.endpoint_payload_requests(
               1,
               endpoint: telemetry_endpoint_tag, compressed: response.request_compressed
             )
-            Telemetry.endpoint_payload_requests_ms(request_duration_ms, endpoint: telemetry_endpoint_tag)
+            Telemetry.endpoint_payload_requests_ms(response.duration_ms, endpoint: telemetry_endpoint_tag)
             Telemetry.endpoint_payload_bytes(response.request_size, endpoint: telemetry_endpoint_tag)
 
             # HTTP layer could send events and exhausted retries (if any)

--- a/lib/datadog/ci/transport/telemetry.rb
+++ b/lib/datadog/ci/transport/telemetry.rb
@@ -60,15 +60,36 @@ module Datadog
 
         def self.endpoint_payload_requests_errors(count, endpoint:, error_type:, status_code:)
           tags = tags(endpoint: endpoint)
-
-          tags[Ext::Telemetry::TAG_ERROR_TYPE] = error_type if error_type
-          tags[Ext::Telemetry::TAG_STATUS_CODE] = status_code.to_s if status_code
+          set_error_tags(tags, error_type: error_type, status_code: status_code)
 
           Utils::Telemetry.inc(Ext::Telemetry::METRIC_ENDPOINT_PAYLOAD_REQUESTS_ERRORS, count, tags)
         end
 
+        def self.api_requests(metric_name, count, compressed:)
+          tags = {}
+          tags[Ext::Telemetry::TAG_REQUEST_COMPRESSED] = "true" if compressed
+
+          Utils::Telemetry.inc(metric_name, count, tags)
+        end
+
+        def self.api_requests_ms(metric_name, duration_ms)
+          Utils::Telemetry.distribution(metric_name, duration_ms)
+        end
+
+        def self.api_requests_errors(metric_name, count, error_type:, status_code:)
+          tags = {}
+          set_error_tags(tags, error_type: error_type, status_code: status_code)
+
+          Utils::Telemetry.inc(metric_name, count, tags)
+        end
+
         def self.tags(endpoint:)
           {Ext::Telemetry::TAG_ENDPOINT => endpoint}
+        end
+
+        def self.set_error_tags(tags, error_type:, status_code:)
+          tags[Ext::Telemetry::TAG_ERROR_TYPE] = error_type if error_type
+          tags[Ext::Telemetry::TAG_STATUS_CODE] = status_code.to_s if status_code
         end
       end
     end

--- a/lib/datadog/ci/transport/telemetry.rb
+++ b/lib/datadog/ci/transport/telemetry.rb
@@ -72,10 +72,6 @@ module Datadog
           Utils::Telemetry.inc(metric_name, count, tags)
         end
 
-        def self.api_requests_ms(metric_name, duration_ms)
-          Utils::Telemetry.distribution(metric_name, duration_ms)
-        end
-
         def self.api_requests_errors(metric_name, count, error_type:, status_code:)
           tags = {}
           set_error_tags(tags, error_type: error_type, status_code: status_code)

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -112,11 +112,7 @@ module Datadog
 
         TAG_COVERAGE_ENABLED: "coverage_enabled"
 
-        TAG_ITR_ENABLED: "itr_enabled"
-
-        TAG_ITR_SKIP_ENABLED: "itr_skip_enabled"
-
-        TAG_REQUIRE_GIT: "require_git"
+        TAG_ITR_SKIP_ENABLED: "itrskip_enabled"
 
         TAG_PROVIDER: "provider"
 

--- a/sig/datadog/ci/git/search_commits.rbs
+++ b/sig/datadog/ci/git/search_commits.rbs
@@ -17,7 +17,7 @@ module Datadog
 
         def request_payload: (String repository_url, Array[String] commits) -> String
 
-        def parse_json_response: (Datadog::Core::Transport::Response response) -> Hash[String, untyped]
+        def parse_json_response: (Datadog::CI::Transport::Adapters::Net::Response response) -> Hash[String, untyped]
 
         def extract_commits: (Hash[String, untyped] response) -> Set[String]
       end

--- a/sig/datadog/ci/test_optimisation/skippable.rbs
+++ b/sig/datadog/ci/test_optimisation/skippable.rbs
@@ -7,10 +7,10 @@ module Datadog
         @config_tags: Hash[String, String]
 
         class Response
-          @http_response: Datadog::Core::Transport::HTTP::Adapters::Net::Response?
+          @http_response: Datadog::CI::Transport::Adapters::Net::Response?
           @json: Hash[String, untyped]?
 
-          def initialize: (Datadog::Core::Transport::HTTP::Adapters::Net::Response? http_response) -> void
+          def initialize: (Datadog::CI::Transport::Adapters::Net::Response? http_response) -> void
 
           def ok?: () -> bool
 

--- a/sig/datadog/ci/transport/adapters/net.rbs
+++ b/sig/datadog/ci/transport/adapters/net.rbs
@@ -66,6 +66,8 @@ module Datadog
 
             def telemetry_error_type: () -> String?
 
+            def response_size: () -> Integer
+
             def trace_count: () -> 0
 
             def inspect: () -> ::String

--- a/sig/datadog/ci/transport/adapters/net.rbs
+++ b/sig/datadog/ci/transport/adapters/net.rbs
@@ -40,6 +40,8 @@ module Datadog
 
             attr_accessor request_size: Integer
 
+            attr_accessor duration_ms: Float
+
             def initialize: (::Net::HTTPResponse http_response) -> void
 
             def payload: () -> String

--- a/sig/datadog/ci/transport/http.rbs
+++ b/sig/datadog/ci/transport/http.rbs
@@ -1,11 +1,3 @@
-class SimpleDelegator
-  @decompressed_payload: String
-
-  def __getobj__: () -> Datadog::Core::Transport::Response
-  def gzipped?: (String payload) -> bool
-  def payload: () -> String
-end
-
 module Datadog
   module CI
     module Transport

--- a/sig/datadog/ci/transport/remote_settings_api.rbs
+++ b/sig/datadog/ci/transport/remote_settings_api.rbs
@@ -3,10 +3,10 @@ module Datadog
     module Transport
       class RemoteSettingsApi
         class Response
-          @http_response: Datadog::Core::Transport::HTTP::Adapters::Net::Response?
+          @http_response: Datadog::CI::Transport::Adapters::Net::Response?
           @json: Hash[String, untyped]?
 
-          def initialize: (Datadog::Core::Transport::HTTP::Adapters::Net::Response? http_response) -> void
+          def initialize: (Datadog::CI::Transport::Adapters::Net::Response? http_response) -> void
 
           def ok?: () -> bool
 

--- a/sig/datadog/ci/transport/telemetry.rbs
+++ b/sig/datadog/ci/transport/telemetry.rbs
@@ -20,8 +20,6 @@ module Datadog
 
         def self.api_requests: (String metric_name, Integer count, compressed: bool) -> void
 
-        def self.api_requests_ms: (String metric_name, Float duration_ms) -> void
-
         def self.api_requests_errors: (String metric_name, Integer count, error_type: String?, status_code: Integer?) -> void
 
         def self.tags: (endpoint: String) -> Hash[String, String]

--- a/sig/datadog/ci/transport/telemetry.rbs
+++ b/sig/datadog/ci/transport/telemetry.rbs
@@ -18,7 +18,15 @@ module Datadog
 
         def self.endpoint_payload_requests_errors: (Integer count, endpoint: String, error_type: String?, status_code: Integer?) -> void
 
+        def self.api_requests: (String metric_name, Integer count, compressed: bool) -> void
+
+        def self.api_requests_ms: (String metric_name, Float duration_ms) -> void
+
+        def self.api_requests_errors: (String metric_name, Integer count, error_type: String?, status_code: Integer?) -> void
+
         def self.tags: (endpoint: String) -> Hash[String, String]
+
+        def self.set_error_tags: (Hash[String, String] tags, error_type: String?, status_code: Integer?) -> void
       end
     end
   end

--- a/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec/instrumentation_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe "RSpec instrumentation with Knapsack Pro runner in queue mode" do
       ["./spec/datadog/ci/contrib/knapsack_rspec/suite_under_test/some_test_rspec.rb"],
       []
     )
+    # raise to prevent Knapsack from running Kernel.exit(0)
+    allow(KnapsackPro::Report).to receive(:save_node_queue_to_api).and_raise(ArgumentError)
   end
 
   # Yields to a block in a new RSpec global context. All RSpec

--- a/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_rspec_go/instrumentation_spec.rb
@@ -39,6 +39,9 @@ RSpec.describe "Knapsack Pro runner when Datadog::CI is configured during the kn
       ["./spec/datadog/ci/contrib/knapsack_rspec_go/suite_under_test/some_test_rspec.rb"],
       []
     )
+
+    # raise to prevent Knapsack from running Kernel.exit(0)
+    allow(KnapsackPro::Report).to receive(:save_node_queue_to_api).and_raise(ArgumentError)
   end
 
   it "instruments this rspec session" do

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
           fetch_skippable_tests: instance_double(
             Datadog::CI::TestOptimisation::Skippable::Response,
             correlation_id: "42",
-            tests: Set.new(["suite.test."])
+            tests: Set.new(["suite.test.", "suite.test2."])
           )
         )
       end
@@ -79,10 +79,12 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
         expect(component.skipping_tests?).to be true
 
         expect(component.correlation_id).to eq("42")
-        expect(component.skippable_tests).to eq(Set.new(["suite.test."]))
+        expect(component.skippable_tests).to eq(Set.new(["suite.test.", "suite.test2."]))
 
         expect(git_worker).to have_received(:wait_until_done)
       end
+
+      it_behaves_like "emits telemetry metric", :inc, "itr_skippable_tests.response_tests", 2
     end
 
     context "when remote configuration call returned correct response with strings instead of bools" do

--- a/spec/datadog/ci/test_optimisation/skippable_spec.rb
+++ b/spec/datadog/ci/test_optimisation/skippable_spec.rb
@@ -122,7 +122,9 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
               request_compressed: false,
               duration_ms: 1.2,
               gzipped_content?: false,
-              response_size: 100
+              response_size: 100,
+              telemetry_error_type: nil,
+              code: 422
             )
           end
 
@@ -131,6 +133,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
             expect(response.correlation_id).to be_nil
             expect(response.tests).to be_empty
           end
+
+          it_behaves_like "emits telemetry metric", :inc, "itr_skippable_tests.request_errors", 1
         end
 
         context "when response is OK but JSON is malformed" do

--- a/spec/datadog/ci/test_optimisation/skippable_spec.rb
+++ b/spec/datadog/ci/test_optimisation/skippable_spec.rb
@@ -3,6 +3,8 @@
 require_relative "../../../../lib/datadog/ci/test_optimisation/skippable"
 
 RSpec.describe Datadog::CI::TestOptimisation::Skippable do
+  include_context "Telemetry spy"
+
   let(:api) { spy("api") }
   let(:dd_env) { "ci" }
   let(:config_tags) { {} }
@@ -10,6 +12,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
   subject(:client) { described_class.new(api: api, dd_env: dd_env, config_tags: config_tags) }
 
   describe "#fetch_skippable_tests" do
+    subject { client.fetch_skippable_tests(test_session) }
+
     let(:service) { "service" }
     let(:tracer_span) do
       Datadog::Tracing::SpanOperation.new("session", service: service).tap do |span|
@@ -30,7 +34,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
     let(:path) { Datadog::CI::Ext::Transport::DD_API_SKIPPABLE_TESTS_PATH }
 
     it "requests the skippable tests" do
-      client.fetch_skippable_tests(test_session)
+      subject
 
       expect(api).to have_received(:api_request) do |args|
         expect(args[:path]).to eq(path)
@@ -90,7 +94,11 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
                     }
                   }
                 ]
-              }.to_json
+              }.to_json,
+              request_compressed: false,
+              duration_ms: 1.2,
+              gzipped_content?: false,
+              response_size: 100
             )
           end
 
@@ -99,6 +107,10 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
             expect(response.correlation_id).to eq("correlation_id_123")
             expect(response.tests).to eq(Set.new(["test_suite_name.test_name.string"]))
           end
+
+          it_behaves_like "emits telemetry metric", :inc, "itr_skippable_tests.request", 1
+          it_behaves_like "emits telemetry metric", :distribution, "itr_skippable_tests.request_ms"
+          it_behaves_like "emits telemetry metric", :distribution, "itr_skippable_tests.response_bytes"
         end
 
         context "when response is not OK" do
@@ -106,7 +118,11 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
             double(
               "http_response",
               ok?: false,
-              payload: ""
+              payload: "",
+              request_compressed: false,
+              duration_ms: 1.2,
+              gzipped_content?: false,
+              response_size: 100
             )
           end
 
@@ -122,7 +138,11 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
             double(
               "http_response",
               ok?: true,
-              payload: "not json"
+              payload: "not json",
+              request_compressed: false,
+              duration_ms: 1.2,
+              gzipped_content?: false,
+              response_size: 100
             )
           end
 
@@ -155,7 +175,11 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
                     "runtime.architecture" => "amd64"
                   }
                 }
-              }.to_json
+              }.to_json,
+              request_compressed: false,
+              duration_ms: 1.2,
+              gzipped_content?: false,
+              response_size: 100
             )
           end
 
@@ -186,7 +210,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Skippable do
       end
 
       it "requests the skippable tests with custom configurations" do
-        client.fetch_skippable_tests(test_session)
+        subject
 
         expect(api).to have_received(:api_request) do |args|
           data = JSON.parse(args[:payload])["data"]

--- a/spec/datadog/ci/transport/http_spec.rb
+++ b/spec/datadog/ci/transport/http_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Datadog::CI::Transport::HTTP do
         expect(response.payload).to eq("sample payload")
         expect(response.request_compressed).to eq(false)
         expect(response.request_size).to eq(payload.bytesize)
+        expect(response.response_size).to eq(response_payload.bytesize)
         expect(response.duration_ms).to be > 0
         expect(response.telemetry_error_type).to be_nil
       end

--- a/spec/datadog/ci/transport/http_spec.rb
+++ b/spec/datadog/ci/transport/http_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe Datadog::CI::Transport::HTTP do
         expect(response.payload).to eq("sample payload")
         expect(response.request_compressed).to eq(false)
         expect(response.request_size).to eq(payload.bytesize)
+        expect(response.duration_ms).to be > 0
         expect(response.telemetry_error_type).to be_nil
       end
 

--- a/spec/datadog/ci/transport/telemetry_spec.rb
+++ b/spec/datadog/ci/transport/telemetry_spec.rb
@@ -200,17 +200,4 @@ RSpec.describe Datadog::CI::Transport::Telemetry do
       end
     end
   end
-
-  describe ".api_requests_ms" do
-    subject { described_class.api_requests_ms(metric_name, duration_ms) }
-
-    let(:metric_name) { "metric_name" }
-    let(:duration_ms) { 1.5 }
-
-    it "tracks the api requests duration distribution" do
-      expect(Datadog::CI::Utils::Telemetry).to receive(:distribution).with(metric_name, duration_ms)
-
-      subject
-    end
-  end
 end

--- a/spec/datadog/ci/transport/telemetry_spec.rb
+++ b/spec/datadog/ci/transport/telemetry_spec.rb
@@ -172,4 +172,45 @@ RSpec.describe Datadog::CI::Transport::Telemetry do
       end
     end
   end
+
+  describe ".api_requests" do
+    subject { described_class.api_requests(metric_name, count, compressed: compressed) }
+
+    let(:metric_name) { "metric_name" }
+    let(:count) { 1 }
+    let(:compressed) { true }
+
+    it "increments the api requests metric" do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:inc).with(
+        metric_name,
+        count,
+        {Datadog::CI::Ext::Telemetry::TAG_REQUEST_COMPRESSED => "true"}
+      )
+
+      subject
+    end
+
+    context "when not compressed" do
+      let(:compressed) { false }
+
+      it "increments the api requests metric without request compressed tag" do
+        expect(Datadog::CI::Utils::Telemetry).to receive(:inc).with(metric_name, count, {})
+
+        subject
+      end
+    end
+  end
+
+  describe ".api_requests_ms" do
+    subject { described_class.api_requests_ms(metric_name, duration_ms) }
+
+    let(:metric_name) { "metric_name" }
+    let(:duration_ms) { 1.5 }
+
+    it "tracks the api requests duration distribution" do
+      expect(Datadog::CI::Utils::Telemetry).to receive(:distribution).with(metric_name, duration_ms)
+
+      subject
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds the following metrics:
- git_requests.search_commits
- git_requests.search_commits_ms
- git_requests.search_commits_errors
- git_requests.objects_pack
- git_requests.objects_pack_ms
- git_requests.objects_pack_errors
- git_requests.objects_pack_bytes
- git_requests.objects_pack_files
- git_requests.settings
- git_requests.settings_ms
- git_requests.settings_errors
- git_requests.settings_response
- itr_skippable_tests.request
- itr_skippable_tests.request_ms
- itr_skippable_tests.request_errors
- itr_skippable_tests.response_bytes
- itr_skippable_tests.response_tests

**How to test the change?**
Unit tests are provided