### PR TITLE
[SDTEST-415] remove telemetry-specific provider tags

### DIFF
--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -112,20 +112,6 @@ module Datadog
         end
 
         module Provider
-          APPVEYOR = "appveyor"
-          AWS = "aws"
-          AZURE = "azp"
-          BITBUCKET = "bitbucket"
-          BITRISE = "bitrise"
-          BUDDYCI = "buddyci"
-          BUILDKITE = "buildkite"
-          CIRCLECI = "circleci"
-          CODEFRESH = "codefresh"
-          GITHUB = "githubactions"
-          GITLAB = "gitlab"
-          JENKINS = "jenkins"
-          TEAMCITY = "teamcity"
-          TRAVISCI = "travisci"
           UNSUPPORTED = "unsupported"
         end
       end

--- a/lib/datadog/ci/test_visibility/telemetry.rb
+++ b/lib/datadog/ci/test_visibility/telemetry.rb
@@ -18,23 +18,6 @@ module Datadog
           Ext::AppTypes::TYPE_TEST_SESSION => Ext::Telemetry::EventType::SESSION
         }.freeze
 
-        PROVIDER_TAG_TO_TELEMETRY_PROVIDER_TAG = {
-          Ext::Environment::Provider::APPVEYOR => Ext::Telemetry::Provider::APPVEYOR,
-          Ext::Environment::Provider::AWS => Ext::Telemetry::Provider::AWS,
-          Ext::Environment::Provider::AZURE => Ext::Telemetry::Provider::AZURE,
-          Ext::Environment::Provider::BITBUCKET => Ext::Telemetry::Provider::BITBUCKET,
-          Ext::Environment::Provider::BITRISE => Ext::Telemetry::Provider::BITRISE,
-          Ext::Environment::Provider::BUDDYCI => Ext::Telemetry::Provider::BUDDYCI,
-          Ext::Environment::Provider::BUILDKITE => Ext::Telemetry::Provider::BUILDKITE,
-          Ext::Environment::Provider::CIRCLECI => Ext::Telemetry::Provider::CIRCLECI,
-          Ext::Environment::Provider::CODEFRESH => Ext::Telemetry::Provider::CODEFRESH,
-          Ext::Environment::Provider::GITHUB => Ext::Telemetry::Provider::GITHUB,
-          Ext::Environment::Provider::GITLAB => Ext::Telemetry::Provider::GITLAB,
-          Ext::Environment::Provider::JENKINS => Ext::Telemetry::Provider::JENKINS,
-          Ext::Environment::Provider::TEAMCITY => Ext::Telemetry::Provider::TEAMCITY,
-          Ext::Environment::Provider::TRAVISCI => Ext::Telemetry::Provider::TRAVISCI
-        }.freeze
-
         def self.event_created(span)
           Utils::Telemetry.inc(Ext::Telemetry::METRIC_EVENT_CREATED, 1, event_tags_from_span(span))
         end
@@ -51,10 +34,9 @@ module Datadog
             1,
             {
               Ext::Telemetry::TAG_AUTO_INJECTED => "false", # ruby doesn't support auto injection yet
-              Ext::Telemetry::TAG_PROVIDER => PROVIDER_TAG_TO_TELEMETRY_PROVIDER_TAG.fetch(
-                test_session.get_tag(Ext::Environment::TAG_PROVIDER_NAME),
+              Ext::Telemetry::TAG_PROVIDER =>
+                test_session.get_tag(Ext::Environment::TAG_PROVIDER_NAME) ||
                 Ext::Telemetry::Provider::UNSUPPORTED
-              )
             }
           )
         end

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -164,20 +164,6 @@ module Datadog
         end
 
         module Provider
-          APPVEYOR: "appveyor"
-          AWS: "aws"
-          AZURE: "azp"
-          BITBUCKET: "bitbucket"
-          BITRISE: "bitrise"
-          BUDDYCI: "buddyci"
-          BUILDKITE: "buildkite"
-          CIRCLECI: "circleci"
-          CODEFRESH: "codefresh"
-          GITHUB: "githubactions"
-          GITLAB: "gitlab"
-          JENKINS: "jenkins"
-          TEAMCITY: "teamcity"
-          TRAVISCI: "travisci"
           UNSUPPORTED: "unsupported"
         end
       end

--- a/sig/datadog/ci/test_visibility/telemetry.rbs
+++ b/sig/datadog/ci/test_visibility/telemetry.rbs
@@ -3,9 +3,6 @@ module Datadog
     module TestVisibility
       module Telemetry
         SPAN_TYPE_TO_TELEMETRY_EVENT_TYPE: ::Hash[String, String]
-
-        PROVIDER_TAG_TO_TELEMETRY_PROVIDER_TAG: ::Hash[String, String]
-
         def self.event_created: (Datadog::CI::Span span) -> void
 
         def self.event_finished: (Datadog::CI::Span span) -> void

--- a/spec/datadog/ci/test_visibility/telemetry_spec.rb
+++ b/spec/datadog/ci/test_visibility/telemetry_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Datadog::CI::TestVisibility::Telemetry do
     subject(:test_session_started) { described_class.test_session_started(test_session) }
 
     let(:provider_tag) { "github" }
-    let(:expected_provider_telemetry_tag) { Datadog::CI::Ext::Telemetry::Provider::GITHUB }
+    let(:expected_provider_telemetry_tag) { "github" }
 
     let(:test_session) do
       instance_double(


### PR DESCRIPTION
**What does this PR do?**
Send the same provider tag values to citestcycle and telemetry

**How to test the change?**
Unit tests are provided