### PR TITLE
[SDTEST-437] Auto test retries for minitest

### DIFF
--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -28,6 +28,19 @@ module Datadog
               test_visibility_component.start_test_module(Ext::FRAMEWORK)
             end
 
+            def run_one_method(klass, method_name)
+              return super unless datadog_configuration[:enabled]
+
+              result = nil
+              # retries here
+              test_retries_component.with_retries do |test_finished_callback|
+                Thread.current[:__dd_retry_callback] = test_finished_callback
+
+                result = super
+              end
+              result
+            end
+
             private
 
             def datadog_configuration
@@ -36,6 +49,10 @@ module Datadog
 
             def test_visibility_component
               Datadog.send(:components).test_visibility
+            end
+
+            def test_retries_component
+              Datadog.send(:components).test_retries
             end
           end
         end

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -32,12 +32,11 @@ module Datadog
               return super unless datadog_configuration[:enabled]
 
               result = nil
-              # retries here
-              test_retries_component.with_retries do |test_finished_callback|
-                Thread.current[:__dd_retry_callback] = test_finished_callback
 
+              test_retries_component.with_retries do
                 result = super
               end
+
               result
             end
 

--- a/lib/datadog/ci/contrib/minitest/test.rb
+++ b/lib/datadog/ci/contrib/minitest/test.rb
@@ -50,7 +50,7 @@ module Datadog
               test_span = test_visibility_component.active_test
               return super unless test_span
 
-              finish_with_result(test_span, result_code)
+              finish_with_result(test_span, result_code, Thread.current[:__dd_retry_callback])
               if Helpers.parallel?(self.class)
                 finish_with_result(test_span.test_suite, result_code)
               end
@@ -60,7 +60,7 @@ module Datadog
 
             private
 
-            def finish_with_result(span, result_code)
+            def finish_with_result(span, result_code, callback = nil)
               return unless span
 
               case result_code
@@ -71,6 +71,9 @@ module Datadog
               when "S"
                 span.skipped!(reason: failure.message)
               end
+
+              callback.call(span) if callback
+
               span.finish
             end
 

--- a/lib/datadog/ci/contrib/minitest/test.rb
+++ b/lib/datadog/ci/contrib/minitest/test.rb
@@ -50,7 +50,7 @@ module Datadog
               test_span = test_visibility_component.active_test
               return super unless test_span
 
-              finish_with_result(test_span, result_code, Thread.current[:__dd_retry_callback])
+              finish_with_result(test_span, result_code)
               if Helpers.parallel?(self.class)
                 finish_with_result(test_span.test_suite, result_code)
               end
@@ -60,7 +60,7 @@ module Datadog
 
             private
 
-            def finish_with_result(span, result_code, callback = nil)
+            def finish_with_result(span, result_code)
               return unless span
 
               case result_code
@@ -71,8 +71,6 @@ module Datadog
               when "S"
                 span.skipped!(reason: failure.message)
               end
-
-              callback.call(span) if callback
 
               span.finish
             end

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -40,7 +40,7 @@ module Datadog
               # don't report test to RSpec::Core::Reporter until retries are done
               @skip_reporting = true
 
-              test_retries_component.with_retries do |retry_callback|
+              test_retries_component.with_retries do
                 test_visibility_component.trace_test(
                   test_name,
                   suite_name,
@@ -76,8 +76,6 @@ module Datadog
                       exception: execution_result.pending_exception
                     )
                   end
-
-                  retry_callback.call(test_span)
                 end
               end
 

--- a/lib/datadog/ci/test_retries/component.rb
+++ b/lib/datadog/ci/test_retries/component.rb
@@ -45,11 +45,15 @@ module Datadog
             end
           end
 
+          test_visibility_component.set_test_finished_callback(test_finished_callback)
+
           loop do
-            yield test_finished_callback
+            yield
 
             break unless retry_strategy&.should_retry?
           end
+        ensure
+          test_visibility_component.remove_test_finished_callback
         end
 
         def build_strategy(test_span)
@@ -69,6 +73,10 @@ module Datadog
 
         def should_retry_failed_test?(test_span)
           @retry_failed_tests_enabled && !!test_span&.failed? && @retry_failed_tests_count < @retry_failed_tests_total_limit
+        end
+
+        def test_visibility_component
+          Datadog.send(:components).test_visibility
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/null_component.rb
+++ b/lib/datadog/ci/test_visibility/null_component.rb
@@ -47,6 +47,12 @@ module Datadog
           false
         end
 
+        def set_test_finished_callback(_)
+        end
+
+        def remove_test_finished_callback
+        end
+
         private
 
         def skip_tracing(block = nil)

--- a/sig/datadog/ci/contrib/minitest/runner.rbs
+++ b/sig/datadog/ci/contrib/minitest/runner.rbs
@@ -10,11 +10,15 @@ module Datadog
 
             def init_plugins: (*untyped) -> (nil | untyped)
 
+            def run_one_method: (untyped klass, String method_name) -> untyped
+
             private
 
             def datadog_configuration: () -> untyped
 
             def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
+
+            def test_retries_component: () -> Datadog::CI::TestRetries::Component
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/test.rbs
+++ b/sig/datadog/ci/contrib/minitest/test.rbs
@@ -13,6 +13,7 @@ module Datadog
 
           module InstanceMethods : ::Minitest::Test
             include ::Minitest::Test::LifecycleHooks
+
             extend ClassMethods
 
             def before_setup: () -> (nil | untyped)

--- a/sig/datadog/ci/test_retries/component.rbs
+++ b/sig/datadog/ci/test_retries/component.rbs
@@ -16,13 +16,15 @@ module Datadog
 
         def configure: (Datadog::CI::Remote::LibrarySettings library_settings) -> void
 
-        def with_retries: () { (untyped) -> void } -> void
+        def with_retries: () { () -> void } -> void
 
         def build_strategy: (Datadog::CI::Test test) -> Datadog::CI::TestRetries::Strategy::Base
 
         private
 
         def should_retry_failed_test?: (Datadog::CI::Test test) -> bool
+
+        def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
       end
     end
   end

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -7,6 +7,8 @@ module Datadog
         @codeowners: Datadog::CI::Codeowners::Matcher
         @context: Datadog::CI::TestVisibility::Context
 
+        FIBER_LOCAL_TEST_FINISHED_CALLBACK_KEY: Symbol
+
         attr_reader test_suite_level_visibility_enabled: bool
 
         def initialize: (?test_suite_level_visibility_enabled: bool, ?codeowners: Datadog::CI::Codeowners::Matcher) -> void
@@ -38,6 +40,10 @@ module Datadog
         def deactivate_test_module: () -> void
 
         def deactivate_test_suite: (String test_suite_name) -> void
+
+        def set_test_finished_callback: (Proc callback) -> void
+
+        def remove_test_finished_callback: () -> void
 
         def itr_enabled?: () -> bool
 

--- a/sig/datadog/ci/test_visibility/null_component.rbs
+++ b/sig/datadog/ci/test_visibility/null_component.rbs
@@ -24,6 +24,10 @@ module Datadog
 
         def active_span: () -> nil
 
+        def set_test_finished_callback: (Proc callback) -> void
+
+        def remove_test_finished_callback: () -> void
+
         def shutdown!: () -> nil
 
         def itr_enabled?: () -> bool

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -961,8 +961,6 @@ RSpec.describe "Minitest instrumentation" do
     end
 
     before(:context) do
-      Thread.current[:dd_coverage_collector] = nil
-
       Minitest::Runnable.reset
 
       class FlakyTestSuite < Minitest::Test
@@ -989,7 +987,7 @@ RSpec.describe "Minitest instrumentation" do
       expect(test_spans).to have(6).items
 
       failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
-      expect(failed_spans).to have(4).items # see steps.rb
+      expect(failed_spans).to have(4).items
       expect(passed_spans).to have(2).items
 
       test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
@@ -1021,8 +1019,6 @@ RSpec.describe "Minitest instrumentation" do
     end
 
     before(:context) do
-      Thread.current[:dd_coverage_collector] = nil
-
       Minitest::Runnable.reset
 
       class FlakyTestSuite2 < Minitest::Test
@@ -1044,12 +1040,12 @@ RSpec.describe "Minitest instrumentation" do
       end
     end
 
-    it "retries flaky test" do
+    it "retries flaky test without success" do
       # 1 initial run of flaky test + 3 retries without success + 1 passing test = 5 spans
       expect(test_spans).to have(5).items
 
       failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
-      expect(failed_spans).to have(4).items # see steps.rb
+      expect(failed_spans).to have(4).items
       expect(passed_spans).to have(1).items
 
       test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
@@ -1060,6 +1056,71 @@ RSpec.describe "Minitest instrumentation" do
       expect(retries_count).to eq(3)
 
       expect(test_spans_by_test_name["test_passed"]).to have(1).item
+
+      expect(test_suite_spans).to have(1).item
+      expect(test_suite_spans.first).to have_fail_status
+
+      expect(test_session_span).to have_fail_status
+    end
+  end
+
+  context "with failed test, flaky test, test retries enabled, and low overall failed tests retry limit" do
+    include_context "CI mode activated" do
+      let(:integration_name) { :minitest }
+
+      let(:flaky_test_retries_enabled) { true }
+      let(:retry_failed_tests_total_limit) { 1 }
+    end
+
+    before do
+      Minitest.run([])
+    end
+
+    before(:context) do
+      Minitest::Runnable.reset
+
+      class FailedAndFlakyTestSuite < Minitest::Test
+        # yep, this test is indeed order dependent!
+        i_suck_and_my_tests_are_order_dependent!
+
+        @@max_flaky_test_failures = 4
+        @@flaky_test_failures = 0
+
+        def test_failed
+          assert 1 + 1 == 4
+        end
+
+        def test_flaky
+          if @@flaky_test_failures < @@max_flaky_test_failures
+            @@flaky_test_failures += 1
+            assert 1 + 1 == 3
+          else
+            assert 1 + 1 == 2
+          end
+        end
+
+        def test_passed
+          assert true
+        end
+      end
+    end
+
+    it "retries flaky test without success" do
+      # 1 initial run of failed test + 5 retries without success + 1 run of flaky test without retries + 1 passing test = 8 spans
+      expect(test_spans).to have(8).items
+
+      failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
+      expect(failed_spans).to have(7).items
+      expect(passed_spans).to have(1).items
+
+      test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
+      expect(test_spans_by_test_name["test_flaky"]).to have(1).item
+      expect(test_spans_by_test_name["test_failed"]).to have(6).items
+      expect(test_spans_by_test_name["test_passed"]).to have(1).item
+
+      # count how many spans were marked as retries
+      retries_count = test_spans.count { |span| span.get_tag("test.is_retry") == "true" }
+      expect(retries_count).to eq(5)
 
       expect(test_suite_spans).to have(1).item
       expect(test_suite_spans.first).to have_fail_status

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -965,30 +965,106 @@ RSpec.describe "Minitest instrumentation" do
 
       Minitest::Runnable.reset
 
-      require_relative "helpers/addition_helper"
-      class SomeTestWithThreads < Minitest::Test
-        def test_with_background_thread
-          # add thread to test that code coverage is collected
-          t = Thread.new do
-            AdditionHelper.add(1, 2)
-          end
-          t.join
+      class FlakyTestSuite < Minitest::Test
+        @@max_flaky_test_failures = 4
+        @@flaky_test_failures = 0
+
+        def test_passed
           assert true
+        end
+
+        def test_flaky
+          if @@flaky_test_failures < @@max_flaky_test_failures
+            @@flaky_test_failures += 1
+            assert 1 + 1 == 3
+          else
+            assert 1 + 1 == 2
+          end
         end
       end
     end
 
-    it "does not cover the background thread" do
-      skip if PlatformHelpers.jruby?
+    it "retries flaky test" do
+      # 1 initial run of flaky test + 4 retries until pass + 1 passing test = 6 spans
+      expect(test_spans).to have(6).items
 
-      expect(test_spans).to have(1).item
-      expect(coverage_events).to have(1).item
+      failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
+      expect(failed_spans).to have(4).items # see steps.rb
+      expect(passed_spans).to have(2).items
 
-      # expect that background thread is not covered
-      cov_event = find_coverage_for_test(first_test_span)
-      expect(cov_event.coverage.keys).not_to include(
-        absolute_path("helpers/addition_helper.rb")
-      )
+      test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
+      expect(test_spans_by_test_name["test_flaky"]).to have(5).items
+
+      # count how many spans were marked as retries
+      retries_count = test_spans.count { |span| span.get_tag("test.is_retry") == "true" }
+      expect(retries_count).to eq(4)
+
+      expect(test_spans_by_test_name["test_passed"]).to have(1).item
+
+      expect(test_suite_spans).to have(1).item
+      expect(test_suite_spans.first).to have_pass_status
+
+      expect(test_session_span).to have_pass_status
+    end
+  end
+
+  context "with flaky test and test retries enabled with insufficient max retries" do
+    include_context "CI mode activated" do
+      let(:integration_name) { :minitest }
+
+      let(:flaky_test_retries_enabled) { true }
+      let(:retry_failed_tests_max_attempts) { 3 }
+    end
+
+    before do
+      Minitest.run([])
+    end
+
+    before(:context) do
+      Thread.current[:dd_coverage_collector] = nil
+
+      Minitest::Runnable.reset
+
+      class FlakyTestSuite2 < Minitest::Test
+        @@max_flaky_test_failures = 4
+        @@flaky_test_failures = 0
+
+        def test_passed
+          assert true
+        end
+
+        def test_flaky
+          if @@flaky_test_failures < @@max_flaky_test_failures
+            @@flaky_test_failures += 1
+            assert 1 + 1 == 3
+          else
+            assert 1 + 1 == 2
+          end
+        end
+      end
+    end
+
+    it "retries flaky test" do
+      # 1 initial run of flaky test + 3 retries without success + 1 passing test = 5 spans
+      expect(test_spans).to have(5).items
+
+      failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
+      expect(failed_spans).to have(4).items # see steps.rb
+      expect(passed_spans).to have(1).items
+
+      test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
+      expect(test_spans_by_test_name["test_flaky"]).to have(4).items
+
+      # count how many spans were marked as retries
+      retries_count = test_spans.count { |span| span.get_tag("test.is_retry") == "true" }
+      expect(retries_count).to eq(3)
+
+      expect(test_spans_by_test_name["test_passed"]).to have(1).item
+
+      expect(test_suite_spans).to have(1).item
+      expect(test_suite_spans.first).to have_fail_status
+
+      expect(test_session_span).to have_fail_status
     end
   end
 end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -1128,4 +1128,66 @@ RSpec.describe "Minitest instrumentation" do
       expect(test_session_span).to have_fail_status
     end
   end
+
+  context "with flaky test, test retries enabled, and threading test runner" do
+    include_context "CI mode activated" do
+      let(:integration_name) { :minitest }
+
+      let(:flaky_test_retries_enabled) { true }
+    end
+
+    before do
+      Minitest.run([])
+    end
+
+    before(:context) do
+      Minitest::Runnable.reset
+
+      class ParallelFlakyTestSuite < Minitest::Test
+        parallelize_me!
+
+        @@max_flaky_test_failures = 4
+        @@flaky_test_failures = 0
+
+        def test_passed
+          assert true
+        end
+
+        def test_flaky
+          if @@flaky_test_failures < @@max_flaky_test_failures
+            @@flaky_test_failures += 1
+            assert 1 + 1 == 3
+          else
+            assert 1 + 1 == 2
+          end
+        end
+
+        def test_failed
+          assert 1 + 1 == 4
+        end
+      end
+    end
+
+    it "retries flaky test" do
+      # 1 initial run of flaky test + 4 retries until pass + 1 failed test run + 5 retries + 1 passing test = 12 spans
+      expect(test_spans).to have(12).items
+
+      failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
+      expect(failed_spans).to have(10).items
+      expect(passed_spans).to have(2).items
+
+      test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }
+      expect(test_spans_by_test_name["test_flaky"]).to have(5).items
+
+      # count how many spans were marked as retries
+      retries_count = test_spans.count { |span| span.get_tag("test.is_retry") == "true" }
+      expect(retries_count).to eq(9)
+
+      expect(test_spans_by_test_name["test_passed"]).to have(1).item
+
+      expect(test_suite_spans).to have(12).items
+
+      expect(test_session_span).to have_fail_status
+    end
+  end
 end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -837,7 +837,7 @@ RSpec.describe "RSpec hooks" do
       expect(test_spans).to have(6).items
 
       failed_spans, passed_spans = test_spans.partition { |span| span.get_tag("test.status") == "fail" }
-      expect(failed_spans).to have(4).items # see steps.rb
+      expect(failed_spans).to have(4).items
       expect(passed_spans).to have(2).items
 
       test_spans_by_test_name = test_spans.group_by { |span| span.get_tag("test.name") }

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -797,4 +797,51 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
       end
     end
   end
+
+  describe "#set_test_finished_callback" do
+    include_context "CI mode activated"
+
+    let(:callback) { spy(:callback) }
+
+    it "sets the test finished callback which will be executed when any test is finished" do
+      test_visibility.set_test_finished_callback(callback)
+
+      ci_test = test_visibility.trace_test("my test", "my suite")
+      test_visibility.deactivate_test
+
+      expect(callback).to have_received(:call).with(ci_test)
+    end
+
+    it "only fires callback on the same thread where it was set" do
+      test_visibility.set_test_finished_callback(callback)
+
+      t = Thread.new do
+        test_visibility.trace_test("my test", "my suite")
+        test_visibility.deactivate_test
+      end
+      t.join
+
+      expect(callback).to_not have_received(:call)
+    end
+  end
+
+  describe "#remove_test_finished_callback" do
+    include_context "CI mode activated"
+
+    let(:callback) { spy(:callback) }
+
+    it "removes the callback" do
+      test_visibility.set_test_finished_callback(callback)
+
+      test_visibility.trace_test("my test", "my suite")
+      test_visibility.deactivate_test
+
+      test_visibility.remove_test_finished_callback
+
+      test_visibility.trace_test("my test", "my suite")
+      test_visibility.deactivate_test
+
+      expect(callback).to have_received(:call).once
+    end
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds [auto test retries](https://docs.datadoghq.com/tests/auto_test_retries?tab=java#explore-results-in-the-test-visibility-explorer) support for minitest

**How to test the change?**
Feature is covered by unit tests in `minitest/instrumentation_spec.rb`

Tested using Sidekiq in this commit: https://github.com/anmarchenko/sidekiq/commit/020ca88eaa8de24dcaee6428e6076963d5a5d4ab

Local test run ends successfully: 
<img width="2010" alt="image" src="https://github.com/user-attachments/assets/bd1e745e-b2b2-43e6-907f-ca7389860ed7">

New flaky test is detected by Datadog:
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/e9e699d9-203e-4880-ae04-71b031473da8">

Correct test runs are traced:
<img width="1263" alt="image" src="https://github.com/user-attachments/assets/c32a324e-707d-44f3-86e5-54ea687902eb">

Retries can be filtered using `test.is_retry` tag:
<img width="1283" alt="image" src="https://github.com/user-attachments/assets/38a6ecef-62f9-4eed-b8b1-c7d1feb3e83e">

Test session is reported as passed:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/3349d8ed-332f-4973-b96a-53ece79d8a31">
