### PR TITLE
[SDTEST-666] RSpec - don't report test errors if rspec process is quitting

### DIFF
--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -62,7 +62,12 @@ module Datadog
                   # before each run remove any previous exception
                   @exception = nil
 
-                  super
+                  result = super
+
+                  # In case when test job is canceled and RSpec is quitting we don't want to report the last test
+                  # before RSpec context unwinds. This test might have some unrelated errors that we don't want to
+                  # report.
+                  return result if ::RSpec.world.wants_to_quit
 
                   case execution_result.status
                   when :passed

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -951,8 +951,11 @@ RSpec.describe "RSpec hooks" do
     it "retries test until it passes" do
       rspec_session_run(with_canceled_test: true)
 
-      expect(test_spans).to have(1).item
-      expect(test_spans).to all have_pass_status
+      expect(test_spans).to have(2).items
+      test_spans.each do |test_span|
+        expect(test_span).not_to have_test_tag(:status, "fail")
+        expect(test_span.status).to eq(0)
+      end
     end
   end
 end

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -1,5 +1,6 @@
 module RSpec
   def self.configuration: () -> RSpec::Core::Configuration
+  def self.world: () -> RSpec::Core::World
 end
 
 module RSpec::Core
@@ -45,4 +46,8 @@ end
 
 class RSpec::Core::Configuration
   def dry_run?: () -> bool
+end
+
+class RSpec::Core::World
+  def wants_to_quit: () -> bool
 end


### PR DESCRIPTION
**What does this PR do?**
When rspec process is being killed by INT signal, it still runs the current test until the end. 
If some resources (e.g. databases) are being decomissioned before the test ends, then datadog-ci traces this error and sends it to the backend. This might create noise for the users because of irrelevant errors.

This PR checks `RSpec.world.wants_to_quit` variable after running each test. If RSpec is quitting, we do not set error for the current span.

**Motivation**
Customer reports that datadog-ci reports test failures when infrastructure (db) is down after CI job is canceled .

**How to test the change?**
Unit test is provided