### PR TITLE
[SDTEST-579] make itr_enabled config parameter true by default

### DIFF
--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -59,7 +59,7 @@ module Datadog
               option :itr_enabled do |o|
                 o.type :bool
                 o.env CI::Ext::Settings::ENV_ITR_ENABLED
-                o.default false
+                o.default true
               end
 
               option :git_metadata_upload_enabled do |o|

--- a/spec/datadog/ci/configuration/settings_spec.rb
+++ b/spec/datadog/ci/configuration/settings_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe Datadog::CI::Configuration::Settings do
       describe "#itr_enabled" do
         subject(:itr_enabled) { settings.ci.itr_enabled }
 
-        it { is_expected.to be false }
+        it { is_expected.to be true }
 
         context "when #{Datadog::CI::Ext::Settings::ENV_ITR_ENABLED}" do
           around do |example|
@@ -234,7 +234,7 @@ RSpec.describe Datadog::CI::Configuration::Settings do
           context "is not defined" do
             let(:enable) { nil }
 
-            it { is_expected.to be false }
+            it { is_expected.to be true }
           end
 
           context "is set to true" do
@@ -253,10 +253,10 @@ RSpec.describe Datadog::CI::Configuration::Settings do
 
       describe "#itr_enabled=" do
         it "updates the #enabled setting" do
-          expect { settings.ci.itr_enabled = true }
+          expect { settings.ci.itr_enabled = false }
             .to change { settings.ci.itr_enabled }
-            .from(false)
-            .to(true)
+            .from(true)
+            .to(false)
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**
As ITR is out of beta for Ruby, now it can be enabled or disabled using Datadog test service settings page.

Environment variable `DD_CIVISIBILITY_ITR_ENABLED` can still be used as a killswitch to forcefully disable ITR from the library side.

**How to test the change?**
Unit tests