### PR TITLE
[SDTEST-635] Enable agentless telemetry when library is running in agentless mode

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -266,10 +266,12 @@ module Datadog
           # for test visibility we want to enable it by default unless explicitly disabled
           # NOTE: before agentless mode is released, we only enable telemetry when running with Datadog Agent
           env_telemetry_enabled = ENV[Core::Telemetry::Ext::ENV_ENABLED]
-          settings.telemetry.enabled = !settings.ci.agentless_mode_enabled &&
-            (env_telemetry_enabled.nil? || Utils::Parsing.convert_to_bool(env_telemetry_enabled))
+          settings.telemetry.enabled = env_telemetry_enabled.nil? || Utils::Parsing.convert_to_bool(env_telemetry_enabled)
 
           return unless settings.telemetry.enabled
+
+          settings.telemetry.agentless_enabled = true if settings.ci.agentless_mode_enabled
+          settings.telemetry.shutdown_timeout_seconds = 60.0
 
           begin
             require "datadog/core/environment/identity"

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -50,6 +50,13 @@ RSpec.describe Datadog::CI::Configuration::Components do
 
           negotiation = double(:negotiation)
 
+          telemetry_double = instance_double(
+            Datadog::Core::Telemetry::Component,
+            emit_closing!: nil,
+            stop!: nil
+          )
+          allow(Datadog::Core::Telemetry::Component).to receive(:build).and_return(telemetry_double)
+
           allow(Datadog::Core::Remote::Negotiation)
             .to receive(:new)
             .and_return(negotiation)
@@ -76,6 +83,7 @@ RSpec.describe Datadog::CI::Configuration::Components do
             .to receive(:async=).and_call_original
 
           allow(settings.telemetry).to receive(:enabled=).and_call_original
+          allow(settings.telemetry).to receive(:agentless_enabled=).and_call_original
 
           allow(Datadog::CI::Ext::Environment)
             .to receive(:tags).and_return({})
@@ -246,8 +254,9 @@ RSpec.describe Datadog::CI::Configuration::Components do
               context "when api key is set" do
                 let(:api_key) { "api_key" }
 
-                it "disables telemetry" do
-                  expect(settings.telemetry).to have_received(:enabled=).with(false)
+                it "enables telemetry by default" do
+                  expect(settings.telemetry).to have_received(:enabled=).with(true)
+                  expect(settings.telemetry).to have_received(:agentless_enabled=).with(true)
                 end
 
                 it "sets async for test mode and constructs transport with CI intake API" do


### PR DESCRIPTION
**What does this PR do?**
Instead of disabling telemetry

**Motivation**
Agentless mode for telemetry was released in datadog gem v2.3

**How to test the change?**
Tested using sidekiq fork locally