### PR TITLE
Bump to version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## [Unreleased]
 
+## [1.4.0] - 2024-08-26
+
+### Added
+
+* Auto test retries for cucumber ([#212][])
+* Auto test retries for RSpec ([#213][])
+* Auto test retries for minitest ([#214][])
+* implement auto test retries RFC ([#219][])
+
+### Changed
+
+* Skip Before/After hooks in cucumber when scenario is skipped by intelligent test runner ([#211][])
+* gem datadog 2.3 is now minimal required version ([#220][])
+* Enable agentless telemetry when library is running in agentless mode ([#221][])
+* Add Ruby 3.4 to the testing matrix ([#217][])
+* add different fallbacks for unshallowing remotes ([#218][])
+* make itr_enabled config parameter true by default ([#216][])
+* RSpec - don't report test errors if rspec process is quitting ([#215][])
+
 ## [1.3.0] - 2024-07-30
 
 ### Added
@@ -290,7 +309,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.3.0...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.4.0...main
+[1.4.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.0.1...v1.1.0
@@ -414,3 +434,14 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#205]: https://github.com/DataDog/datadog-ci-rb/issues/205
 [#206]: https://github.com/DataDog/datadog-ci-rb/issues/206
 [#207]: https://github.com/DataDog/datadog-ci-rb/issues/207
+[#211]: https://github.com/DataDog/datadog-ci-rb/issues/211
+[#212]: https://github.com/DataDog/datadog-ci-rb/issues/212
+[#213]: https://github.com/DataDog/datadog-ci-rb/issues/213
+[#214]: https://github.com/DataDog/datadog-ci-rb/issues/214
+[#215]: https://github.com/DataDog/datadog-ci-rb/issues/215
+[#216]: https://github.com/DataDog/datadog-ci-rb/issues/216
+[#217]: https://github.com/DataDog/datadog-ci-rb/issues/217
+[#218]: https://github.com/DataDog/datadog-ci-rb/issues/218
+[#219]: https://github.com/DataDog/datadog-ci-rb/issues/219
+[#220]: https://github.com/DataDog/datadog-ci-rb/issues/220
+[#221]: https://github.com/DataDog/datadog-ci-rb/issues/221

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.3.0)
+    datadog-ci (1.4.0)
       datadog (~> 2.3)
       msgpack
 

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,7 +4,7 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 3
+      MINOR = 4
       PATCH = 0
       PRE = nil
       BUILD = nil


### PR DESCRIPTION
### Added

* Auto test retries for cucumber (#212)
* Auto test retries for RSpec (#213)
* Auto test retries for minitest (#214)
* implement auto test retries RFC (#219)

### Changed

* Skip Before/After hooks in cucumber when scenario is skipped by intelligent test runner (#211)
* gem datadog 2.3 is now minimal required version (#220)
* Enable agentless telemetry when library is running in agentless mode (#221)
* Add Ruby 3.4 to the testing matrix (#217)
* add different fallbacks for unshallowing remotes (#218)
* make itr_enabled config parameter true by default (#216)
* RSpec - don't report test errors if rspec process is quitting (#215)
