### PR TITLE
[SDTEST-755] attempt to fix datadog_cov crash when doing allocation profiling

### DIFF
--- a/ext/datadog_cov/datadog_cov.c
+++ b/ext/datadog_cov/datadog_cov.c
@@ -249,7 +249,7 @@ static int process_instantiated_klass(st_data_t key, st_data_t _value, st_data_t
   }
 
   VALUE filename = RARRAY_AREF(source_location, 0);
-  if (filename == Qnil)
+  if (filename == Qnil || !RB_TYPE_P(filename, T_STRING))
   {
     return ST_CONTINUE;
   }

--- a/spec/ddcov/app/model/my_model_❤️.rb
+++ b/spec/ddcov/app/model/my_model_❤️.rb
@@ -1,0 +1,2 @@
+class MyModel❤️
+end

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -3,6 +3,7 @@
 require "datadog_cov.#{RUBY_VERSION}_#{RUBY_PLATFORM}"
 
 require_relative "app/model/my_model"
+require_relative "app/model/my_model_❤️"
 require_relative "app/model/my_struct"
 require_relative "calculator/calculator"
 require_relative "calculator/code_with_❤️"
@@ -355,6 +356,93 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::DDCov do
           coverage = subject.stop
           expect(coverage.size).to eq(1)
           expect(coverage.keys).to include(absolute_path("app/model/my_struct.rb"))
+        end
+
+        it "tracks coverage for objects defined with emojis" do
+          subject.start
+
+          MyModel❤️.new
+
+          coverage = subject.stop
+          expect(coverage.size).to eq(1)
+          expect(coverage.keys).to include(absolute_path("app/model/my_model_❤️.rb"))
+        end
+
+        context "Object.const_source_location is redefined in tests" do
+          context "returns invalid values" do
+            before do
+              allow(Object).to receive(:const_source_location).and_return([-1, -1])
+            end
+
+            it "does not break" do
+              subject.start
+
+              User.new("john doe", "johndoe@mail.test")
+
+              coverage = subject.stop
+              expect(coverage.size).to eq(0)
+            end
+          end
+
+          context "returns nil" do
+            before do
+              allow(Object).to receive(:const_source_location).and_return(nil)
+            end
+
+            it "does not break" do
+              subject.start
+
+              User.new("john doe", "johndoe@mail.test")
+
+              coverage = subject.stop
+              expect(coverage.size).to eq(0)
+            end
+          end
+
+          context "returns empty array" do
+            before do
+              allow(Object).to receive(:const_source_location).and_return([])
+            end
+
+            it "does not break" do
+              subject.start
+
+              User.new("john doe", "johndoe@mail.test")
+
+              coverage = subject.stop
+              expect(coverage.size).to eq(0)
+            end
+          end
+
+          context "returns empty nested array" do
+            before do
+              allow(Object).to receive(:const_source_location).and_return([[]])
+            end
+
+            it "does not break" do
+              subject.start
+
+              User.new("john doe", "johndoe@mail.test")
+
+              coverage = subject.stop
+              expect(coverage.size).to eq(0)
+            end
+          end
+
+          context "raises" do
+            before do
+              allow(Object).to receive(:const_source_location).and_raise(StandardError)
+            end
+
+            it "does not break" do
+              subject.start
+
+              User.new("john doe", "johndoe@mail.test")
+
+              coverage = subject.stop
+              expect(coverage.size).to eq(0)
+            end
+          end
         end
 
         context "Data structs available since Ruby 3.2" do


### PR DESCRIPTION
**What does this PR do?**
Fixes potential crash from the test impact analysis native extension when `Object.const_source_location` unexpectedly returns weird values. Adds more testing for these cases.

**Motivation**
We got reports of datadog_cov native extension crashes via telemetry crashtracker: while the root cause is unknown yet, this fix is an attempt to mitigate one of the possible causes

**How to test the change?**
Unit tests are provided