### PR TITLE
[SDTEST-740] Minor telemetry fixes

### DIFF
--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -70,6 +70,12 @@ module Datadog
         get_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR) == "true"
       end
 
+      # Returns "true" if test span represents a retry.
+      # @return [Boolean] true if this test is a retry, false otherwise.
+      def is_retry?
+        get_tag(Ext::Test::TAG_IS_RETRY) == "true"
+      end
+
       # Marks this test as unskippable by the intelligent test runner.
       # This must be done before the test execution starts.
       #

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -99,12 +99,15 @@ module Datadog
 
         def start_coverage(test)
           return if !enabled? || !code_coverage?
+          return if test.is_retry?
+
           Telemetry.code_coverage_started(test)
           coverage_collector&.start
         end
 
         def stop_coverage(test)
           return if !enabled? || !code_coverage?
+          return if test.is_retry?
 
           Telemetry.code_coverage_finished(test)
 

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -109,12 +109,14 @@ module Datadog
           Telemetry.code_coverage_finished(test)
 
           coverage = coverage_collector&.stop
+
+          # if test was skipped, we discard coverage data
+          return if test.skipped?
+
           if coverage.nil? || coverage.empty?
             Telemetry.code_coverage_is_empty
             return
           end
-
-          return if test.skipped?
 
           test_source_file = test.source_file
 

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -99,7 +99,6 @@ module Datadog
 
         def start_coverage(test)
           return if !enabled? || !code_coverage?
-          return if test.is_retry?
 
           Telemetry.code_coverage_started(test)
           coverage_collector&.start
@@ -107,7 +106,6 @@ module Datadog
 
         def stop_coverage(test)
           return if !enabled? || !code_coverage?
-          return if test.is_retry?
 
           Telemetry.code_coverage_finished(test)
 

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -11,6 +11,7 @@ module Datadog
       def itr_unskippable!: () -> void
       def source_file: () -> String?
       def parameters: () -> String?
+      def is_retry?: () -> bool
 
       private
 

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -333,6 +333,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
         expect { subject }
           .not_to change { component.skipped_tests_count }
       end
+
+      it_behaves_like "emits no metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_ITR_SKIPPED
     end
 
     context "test is skipped by ITR" do
@@ -363,6 +365,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
         expect { subject }
           .not_to change { component.skipped_tests_count }
       end
+
+      it_behaves_like "emits no metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_ITR_SKIPPED
     end
   end
 

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -166,19 +166,6 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
       end
 
       it_behaves_like "emits telemetry metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_STARTED, 1
-
-      context "when test is a retry" do
-        before do
-          test_span.set_tag(Datadog::CI::Ext::Test::TAG_IS_RETRY, "true")
-        end
-
-        it "does not start coverage" do
-          expect(component).not_to receive(:coverage_collector)
-
-          subject
-          expect(component.stop_coverage(test_span)).to be_nil
-        end
-      end
     end
 
     context "when JRuby and code coverage is enabled" do
@@ -234,7 +221,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
       end
 
       it_behaves_like "emits telemetry metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FINISHED, 1
-      it_behaves_like "emits telemetry metric", :distribution, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, 6.0
+      it_behaves_like "emits telemetry metric", :distribution, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, 5.0
     end
 
     context "when test is skipped" do

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
       end
 
       it_behaves_like "emits telemetry metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FINISHED, 1
-      it_behaves_like "emits telemetry metric", :distribution, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, 5.0
+      it_behaves_like "emits telemetry metric", :distribution, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_FILES, 6.0
     end
 
     context "when test is skipped" do
@@ -252,11 +252,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
       it_behaves_like "emits no metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_IS_EMPTY
     end
 
-    context "when test is skipped and coverage is empty" do
+    context "when test is skipped and coverage is not collected" do
       before do
-        allow_any_instance_of(Datadog::CI::TestOptimisation::Coverage::DDCov).to receive(:stop).and_return(nil)
-
-        component.start_coverage(test_span)
         test_span.skipped!
       end
 

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -235,6 +235,24 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
         expect(subject).to be_nil
         expect(writer).not_to have_received(:write)
       end
+
+      it_behaves_like "emits no metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_IS_EMPTY
+    end
+
+    context "when test is skipped and coverage is empty" do
+      before do
+        allow_any_instance_of(Datadog::CI::TestOptimisation::Coverage::DDCov).to receive(:stop).and_return(nil)
+
+        component.start_coverage(test_span)
+        test_span.skipped!
+      end
+
+      it "does not write coverage event" do
+        expect(subject).to be_nil
+        expect(writer).not_to have_received(:write)
+      end
+
+      it_behaves_like "emits no metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_IS_EMPTY
     end
 
     context "when coverage was not collected" do

--- a/spec/datadog/ci/test_optimisation/component_spec.rb
+++ b/spec/datadog/ci/test_optimisation/component_spec.rb
@@ -166,6 +166,19 @@ RSpec.describe Datadog::CI::TestOptimisation::Component do
       end
 
       it_behaves_like "emits telemetry metric", :inc, Datadog::CI::Ext::Telemetry::METRIC_CODE_COVERAGE_STARTED, 1
+
+      context "when test is a retry" do
+        before do
+          test_span.set_tag(Datadog::CI::Ext::Test::TAG_IS_RETRY, "true")
+        end
+
+        it "does not start coverage" do
+          expect(component).not_to receive(:coverage_collector)
+
+          subject
+          expect(component.stop_coverage(test_span)).to be_nil
+        end
+      end
     end
 
     context "when JRuby and code coverage is enabled" do

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -322,4 +322,24 @@ RSpec.describe Datadog::CI::Test do
       expect(ci_test.parameters).to eq(parameters)
     end
   end
+
+  describe "#is_retry?" do
+    subject(:is_retry) { ci_test.is_retry? }
+
+    context "when tag is set" do
+      before do
+        allow(tracer_span).to(
+          receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_IS_RETRY).and_return("true")
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when tag is not set" do
+      before { allow(tracer_span).to receive(:get_tag).with(Datadog::CI::Ext::Test::TAG_IS_RETRY).and_return(nil) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/support/contexts/telemetry_spy.rb
+++ b/spec/support/contexts/telemetry_spy.rb
@@ -38,6 +38,15 @@ RSpec.shared_context "Telemetry spy" do
     end
   end
 
+  shared_examples_for "emits no metric" do |metric_type, metric_name|
+    it "emits no :#{metric_type} metric #{metric_name}" do
+      subject
+
+      metric = telemetry_metric(metric_type, metric_name)
+      expect(metric).to be_nil
+    end
+  end
+
   def telemetry_metric(type, name)
     @metrics[type].find { |m| m.name == name }
   end


### PR DESCRIPTION
**What does this PR do?**
- Sends `code_coverage_is_empty` telemetry metric only when code coverage is empty and test was not skipped
- Adds additional unit tests for skipped tests metric

**How to test the change?**
Unit tests are provided