### PR TITLE
Bump to version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [1.5.0] - 2024-09-18
+
+### Added
+* Retry new tests - parse remote configuration and fetch unique known tests ([#227][])
+* early flake detection support for rspec and minitest ([#229][])
+* Early flake detection support for Cucumber ([#231][])
+
+### Fixed
+* Minor telemetry fixes ([#226][])
+
 ## [1.4.1] - 2024-08-28
 
 ### Fixed
@@ -315,7 +325,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.4.1...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.5.0...main
+[1.5.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.4.1...v1.5.0
 [1.4.1]: https://github.com/DataDog/datadog-ci-rb/compare/v1.4.0...v1.4.1
 [1.4.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.2.0...v1.3.0
@@ -453,3 +464,7 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#220]: https://github.com/DataDog/datadog-ci-rb/issues/220
 [#221]: https://github.com/DataDog/datadog-ci-rb/issues/221
 [#224]: https://github.com/DataDog/datadog-ci-rb/issues/224
+[#226]: https://github.com/DataDog/datadog-ci-rb/issues/226
+[#227]: https://github.com/DataDog/datadog-ci-rb/issues/227
+[#229]: https://github.com/DataDog/datadog-ci-rb/issues/229
+[#231]: https://github.com/DataDog/datadog-ci-rb/issues/231

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.4.1)
+    datadog-ci (1.5.0)
       datadog (~> 2.3)
       msgpack
 

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,8 +4,8 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 4
-      PATCH = 1
+      MINOR = 5
+      PATCH = 0
       PRE = nil
       BUILD = nil
       # PRE and BUILD above are modified for dev gems during gem build GHA workflow


### PR DESCRIPTION
### Added
* Retry new tests - parse remote configuration and fetch unique known tests (#227)
* early flake detection support for rspec and minitest (#229)
* Early flake detection support for Cucumber (#231)

### Fixed
* Minor telemetry fixes (#226)
