### PR TITLE
[NO-TICKET] fix permissions for milestone action

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -7,6 +7,7 @@ jobs:
   add_milestone:
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null


### PR DESCRIPTION
**What does this PR do?**
Fixes "Add milestone" github action by adding missing permission

**Motivation**
"Add milestone" was broken since default permissions were updated for the repository
