### PR TITLE
[SDTEST-865] Send internal vCPU count metric

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -71,6 +71,9 @@ module Datadog
         # common tags that are serialized directly in msgpack header in metadata field
         METADATA_TAG_TEST_SESSION_NAME = "test_session.name"
 
+        # internal metric with the number of virtual CPUs
+        METRIC_CPU_COUNT = "_dd.host.vcpu_count"
+
         # tags that are common for the whole session and can be inherited from the test session
         INHERITABLE_TAGS = [TAG_FRAMEWORK, TAG_FRAMEWORK_VERSION].freeze
 

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -114,6 +114,13 @@ module Datadog
         tracer_span.clear_tag(key)
       end
 
+      # Gets metric value by key.
+      # @param [String] key the key of the metric.
+      # @return [Numeric] value the value of the metric.
+      def get_metric(key)
+        tracer_span.get_metric(key)
+      end
+
       # Sets metric value by key.
       # @param [String] key the key of the metric.
       # @param [Numeric] value the value of the metric.

--- a/lib/datadog/ci/test_visibility/context.rb
+++ b/lib/datadog/ci/test_visibility/context.rb
@@ -11,6 +11,8 @@ require_relative "../ext/app_types"
 require_relative "../ext/environment"
 require_relative "../ext/test"
 
+require_relative "../utils/test_run"
+
 require_relative "../span"
 require_relative "../test"
 require_relative "../test_session"
@@ -203,6 +205,8 @@ module Datadog
 
           ci_span.set_tags(tags)
           ci_span.set_tags(@environment_tags)
+
+          ci_span.set_metric(Ext::Test::METRIC_CPU_COUNT, Utils::TestRun.virtual_cpu_count)
         end
 
         # PROPAGATING CONTEXT FROM TOP-LEVEL TO THE LOWER LEVELS

--- a/lib/datadog/ci/utils/test_run.rb
+++ b/lib/datadog/ci/utils/test_run.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "etc"
+
 module Datadog
   module CI
     module Utils
@@ -33,6 +35,12 @@ module Datadog
             res[tag.sub("test.configuration.", "")] = value
           end
           res
+        end
+
+        def self.virtual_cpu_count
+          return @virtual_cpu_count if defined?(@virtual_cpu_count)
+
+          @virtual_cpu_count = ::Etc.nprocessors
         end
       end
     end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -98,6 +98,8 @@ module Datadog
 
         METADATA_TAG_TEST_SESSION_NAME: "test_session.name"
 
+        METRIC_CPU_COUNT: "_dd.host.vcpu_count"
+
         module Status
           PASS: "pass"
 

--- a/sig/datadog/ci/span.rbs
+++ b/sig/datadog/ci/span.rbs
@@ -35,6 +35,8 @@ module Datadog
 
       def clear_tag: (String key) -> void
 
+      def get_metric: (String key) -> Numeric?
+
       def set_metric: (String key, untyped value) -> void
 
       def set_tags: (Hash[untyped, untyped] tags) -> void

--- a/sig/datadog/ci/utils/test_run.rbs
+++ b/sig/datadog/ci/utils/test_run.rbs
@@ -3,6 +3,7 @@ module Datadog
     module Utils
       module TestRun
         self.@command: String
+        self.@virtual_cpu_count: Integer
 
         def self.command: () -> String
 
@@ -11,7 +12,13 @@ module Datadog
         def self.test_parameters: (?arguments: Hash[untyped, untyped], ?metadata: Hash[untyped, untyped]) -> String
 
         def self.custom_configuration: (Hash[String, String]? env_tags) -> Hash[String, String]
+
+        def self.virtual_cpu_count: () -> Integer
       end
     end
   end
+end
+
+module Etc
+  def self.nprocessors: () -> Integer
 end

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
         expect(span_under_test).to have_test_tag(tag)
       end
       expect(span_under_test).to have_test_tag(:command, test_command)
+      expect(span_under_test.get_metric(Datadog::CI::Ext::Test::METRIC_CPU_COUNT)).to eq(Etc.nprocessors)
     end
   end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v1_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV1 do
           }
         )
         expect(metrics).to eq(
-          {"_dd.top_level" => 1.0, "memory_allocations" => 16}
+          {"_dd.top_level" => 1.0, "memory_allocations" => 16, "_dd.host.vcpu_count" => Etc.nprocessors}
         )
       end
     end

--- a/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_v2_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestV2 do
         expect(meta["_test.session_id"]).to be_nil
         expect(meta["_test.module_id"]).to be_nil
 
-        expect(metrics).to eq({"_dd.top_level" => 1, "memory_allocations" => 16})
+        expect(metrics).to eq({"_dd.top_level" => 1, "memory_allocations" => 16, "_dd.host.vcpu_count" => Etc.nprocessors})
       end
     end
 

--- a/spec/datadog/ci/utils/test_run_spec.rb
+++ b/spec/datadog/ci/utils/test_run_spec.rb
@@ -58,4 +58,10 @@ RSpec.describe ::Datadog::CI::Utils::TestRun do
       it { is_expected.to eq({"tag1" => "value1", "tag2" => "value2"}) }
     end
   end
+
+  describe ".virtual_cpu_count" do
+    subject { described_class.virtual_cpu_count }
+
+    it { is_expected.to eq(::Etc.nprocessors) }
+  end
 end


### PR DESCRIPTION
**What does this PR do?**
Sends internal metric `_dd.host.vcpu_count` for all test visibility events. This metric contains value of the virtual processors that are available to the Ruby process that runs the test suite.

**Motivation**
It enables Datadog backend to compute the infrastructure cost savings provided by ITR.

**How to test the change?**
Unit tests are provided.

Tested using middleman on staging (with internal feature flag that show hidden event metadata):
<img width="422" alt="image" src="https://github.com/user-attachments/assets/c76120e6-e63d-4a85-8074-cd52f30cb854">
