### PR TITLE
[SDTEST-301] add source location info to test suites

### DIFF
--- a/lib/datadog/ci/contrib/minitest/helpers.rb
+++ b/lib/datadog/ci/contrib/minitest/helpers.rb
@@ -6,7 +6,7 @@ module Datadog
       module Minitest
         module Helpers
           def self.test_suite_name(klass, method_name)
-            source_location = extract_source_location_from_class(klass)
+            source_location = extract_source_location_from_class(klass)&.first
             # if we are in anonymous class, fallback to the method source location
             if source_location.nil?
               source_location, = klass.instance_method(method_name).source_location
@@ -23,11 +23,11 @@ module Datadog
           end
 
           def self.extract_source_location_from_class(klass)
-            return nil if klass.nil? || klass.name.nil?
+            return [] if klass.nil? || klass.name.nil?
 
-            klass.const_source_location(klass.name)&.first
+            klass.const_source_location(klass.name)
           rescue
-            nil
+            []
           end
         end
       end

--- a/lib/datadog/ci/contrib/minitest/runnable.rb
+++ b/lib/datadog/ci/contrib/minitest/runnable.rb
@@ -20,12 +20,18 @@ module Datadog
               test_suite_name = Helpers.test_suite_name(self, method)
               source_file, line_number = Helpers.extract_source_location_from_class(self)
 
-              test_suite = test_visibility_component.start_test_suite(
-                test_suite_name,
-                tags: {
+              test_suite_tags = if source_file
+                {
                   CI::Ext::Test::TAG_SOURCE_FILE => (Git::LocalRepository.relative_to_root(source_file) if source_file),
                   CI::Ext::Test::TAG_SOURCE_START => line_number&.to_s
                 }
+              else
+                {}
+              end
+
+              test_suite = test_visibility_component.start_test_suite(
+                test_suite_name,
+                tags: test_suite_tags
               )
 
               results = super

--- a/lib/datadog/ci/contrib/minitest/runnable.rb
+++ b/lib/datadog/ci/contrib/minitest/runnable.rb
@@ -18,8 +18,15 @@ module Datadog
               return super if method.nil?
 
               test_suite_name = Helpers.test_suite_name(self, method)
+              source_file, line_number = Helpers.extract_source_location_from_class(self)
 
-              test_suite = test_visibility_component.start_test_suite(test_suite_name)
+              test_suite = test_visibility_component.start_test_suite(
+                test_suite_name,
+                tags: {
+                  CI::Ext::Test::TAG_SOURCE_FILE => (Git::LocalRepository.relative_to_root(source_file) if source_file),
+                  CI::Ext::Test::TAG_SOURCE_START => line_number&.to_s
+                }
+              )
 
               results = super
               return results unless test_suite

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -21,7 +21,13 @@ module Datadog
               return super unless top_level?
 
               suite_name = "#{description} at #{file_path}"
-              test_suite = test_visibility_component.start_test_suite(suite_name)
+              test_suite = test_visibility_component.start_test_suite(
+                suite_name,
+                tags: {
+                  CI::Ext::Test::TAG_SOURCE_FILE => Git::LocalRepository.relative_to_root(metadata[:file_path]),
+                  CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s
+                }
+              )
 
               success = super
               return success unless test_suite

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -190,6 +190,13 @@ module Datadog
         tracer_span.get_tag(Ext::Test::TAG_RUNTIME_VERSION)
       end
 
+      # Source file path where the test or test suite defined (relative to git repository root).
+      # @return [String] the source file path of the test
+      # @return [nil] if the source file path is not found
+      def source_file
+        get_tag(Ext::Test::TAG_SOURCE_FILE)
+      end
+
       def set_environment_runtime_tags
         tracer_span.set_tag(Ext::Test::TAG_OS_ARCHITECTURE, ::RbConfig::CONFIG["host_cpu"])
         tracer_span.set_tag(Ext::Test::TAG_OS_PLATFORM, ::RbConfig::CONFIG["host_os"])

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -57,13 +57,6 @@ module Datadog
         get_tag(Ext::Test::TAG_TEST_SESSION_ID)
       end
 
-      # Source file path of the test relative to git repository root.
-      # @return [String] the source file path of the test
-      # @return [nil] if the source file path is not found
-      def source_file
-        get_tag(Ext::Test::TAG_SOURCE_FILE)
-      end
-
       # Returns "true" if the test is skipped by the intelligent test runner.
       # @return [Boolean] true if the test is skipped by the intelligent test runner, false otherwise.
       def skipped_by_itr?

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -166,7 +166,7 @@ module Datadog
         end
 
         def on_test_suite_started(test_suite)
-          # set_codeowners(test_suite)
+          set_codeowners(test_suite)
 
           Telemetry.event_created(test_suite)
         end
@@ -225,10 +225,10 @@ module Datadog
           end
         end
 
-        def set_codeowners(test)
-          source = test.source_file
+        def set_codeowners(span)
+          source = span.source_file
           owners = @codeowners.list_owners(source) if source
-          test.set_tag(Ext::Test::TAG_CODEOWNERS, owners) unless owners.nil?
+          span.set_tag(Ext::Test::TAG_CODEOWNERS, owners) unless owners.nil?
         end
 
         def fix_test_suite!(test)

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -166,6 +166,8 @@ module Datadog
         end
 
         def on_test_suite_started(test_suite)
+          # set_codeowners(test_suite)
+
           Telemetry.event_created(test_suite)
         end
 

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -35,7 +35,7 @@ module Datadog
 
           def test_suite_name: (untyped test_case) -> String
 
-          def start_test_suite: (String test_suite_name) -> void
+          def start_test_suite: (String test_suite_name, ?tags: Hash[String, String]) -> void
 
           def finish_current_test_suite: () -> void
 
@@ -52,6 +52,8 @@ module Datadog
           def configuration: () -> untyped
 
           def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
+
+          def test_suite_source_file_tags: (untyped test_case) -> Hash[String, String]
         end
       end
     end

--- a/sig/datadog/ci/contrib/minitest/helpers.rbs
+++ b/sig/datadog/ci/contrib/minitest/helpers.rbs
@@ -7,7 +7,7 @@ module Datadog
 
           def self.parallel?: (untyped klass) -> bool
 
-          def self.extract_source_location_from_class: (untyped klass) -> String?
+          def self.extract_source_location_from_class: (untyped klass) -> Array[::String]
         end
       end
     end

--- a/sig/datadog/ci/span.rbs
+++ b/sig/datadog/ci/span.rbs
@@ -67,6 +67,8 @@ module Datadog
 
       def runtime_version: () -> String?
 
+      def source_file: () -> String?
+
       private
 
       def test_visibility: () -> Datadog::CI::TestVisibility::Component

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -11,7 +11,6 @@ module Datadog
       def test_session_id: () -> String?
       def skipped_by_itr?: () -> bool
       def itr_unskippable!: () -> void
-      def source_file: () -> String?
       def parameters: () -> String?
       def is_retry?: () -> bool
       def any_retry_passed?: () -> bool

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -51,7 +51,7 @@ module Datadog
 
         def fix_test_suite!: (Datadog::CI::Test test) -> void
 
-        def set_codeowners: (Datadog::CI::Test test) -> void
+        def set_codeowners: (Datadog::CI::Span span) -> void
 
         def null_span: () -> Datadog::CI::Span
 

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -209,6 +209,18 @@ RSpec.describe "Cucumber instrumentation" do
         :framework_version,
         Datadog::CI::Contrib::Cucumber::Integration.version.to_s
       )
+
+      expect(first_test_suite_span).to have_test_tag(
+        :source_file,
+        "passing.feature"
+      )
+      expect(first_test_suite_span).to have_test_tag(:source_start, "1")
+
+      expect(first_test_suite_span).to have_test_tag(
+        :codeowners,
+        "[\"@test-owner\"]"
+      )
+
       expect(first_test_suite_span).to have_pass_status
     end
 

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -475,6 +475,17 @@ RSpec.describe "Minitest instrumentation" do
             :framework_version,
             Datadog::CI::Contrib::Minitest::Integration.version.to_s
           )
+
+          expect(first_test_suite_span).to have_test_tag(
+            :source_file,
+            "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
+          )
+          expect(first_test_suite_span).to have_test_tag(:source_start, "415")
+          expect(first_test_suite_span).to have_test_tag(
+            :codeowners,
+            "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+          )
+
           expect(first_test_suite_span).to have_pass_status
         end
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -594,6 +594,10 @@ RSpec.describe "RSpec hooks" do
         "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb"
       )
       expect(first_test_suite_span).to have_test_tag(:source_start, "57")
+      expect(first_test_suite_span).to have_test_tag(
+        :codeowners,
+        "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+      )
 
       expect(first_test_suite_span).to have_pass_status
     end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -506,7 +506,7 @@ RSpec.describe "RSpec hooks" do
 
     context "with git root changed" do
       before do
-        expect(Datadog::CI::Git::LocalRepository).to receive(:root).and_return("#{Dir.pwd}/spec")
+        allow(Datadog::CI::Git::LocalRepository).to receive(:root).and_return("#{Dir.pwd}/spec")
       end
 
       it "provides source file path relative to git root" do
@@ -588,6 +588,13 @@ RSpec.describe "RSpec hooks" do
         :framework_version,
         Datadog::CI::Contrib::RSpec::Integration.version.to_s
       )
+
+      expect(first_test_suite_span).to have_test_tag(
+        :source_file,
+        "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb"
+      )
+      expect(first_test_suite_span).to have_test_tag(:source_start, "57")
+
       expect(first_test_suite_span).to have_pass_status
     end
 

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -38,6 +38,7 @@ module RSpec::Core::ExampleGroup
     def top_level?: () -> bool
     def file_path: () -> String
     def description: () -> String
+    def metadata: () -> untyped
   end
 end
 


### PR DESCRIPTION
**What does this PR do?**
Adds `test.source.file`, `test.source.start`, `test.codeowners` tags to test suites reported to Datadog

**Motivation**
We want to show source locations for test suites and attach codeowners to test suites

**How to test the change?**
Unit tests are provided

RSpec (tested using rubocop):
<img width="863" alt="image" src="https://github.com/user-attachments/assets/60c67e48-6d43-43d3-b06a-8750f6070d54">

Minitest (tested using feedbin):
<img width="889" alt="image" src="https://github.com/user-attachments/assets/0efc9cf3-53da-4151-91fd-12b55d0ec1e8">

Cucumber (tested using middleman):
<img width="908" alt="image" src="https://github.com/user-attachments/assets/d2a1b6f8-2416-43b3-a12f-c97a2d47b8a5">
