### PR TITLE
[SDTEST-60] Report total lines coverage percentage to Datadog

### DIFF
--- a/Steepfile
+++ b/Steepfile
@@ -31,4 +31,5 @@ target :lib do
   library "capybara"
   library "timecop"
   library "webmock"
+  library "simplecov"
 end

--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -410,6 +410,7 @@ require_relative "ci/contrib/cucumber/integration"
 require_relative "ci/contrib/rspec/integration"
 require_relative "ci/contrib/minitest/integration"
 require_relative "ci/contrib/selenium/integration"
+require_relative "ci/contrib/simplecov/integration"
 
 # Configuration extensions
 require_relative "ci/configuration/extensions"

--- a/lib/datadog/ci/contrib/simplecov/configuration/settings.rb
+++ b/lib/datadog/ci/contrib/simplecov/configuration/settings.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "datadog/core"
+
+require_relative "../ext"
+require_relative "../../settings"
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module Configuration
+          # Custom settings for the Simplecov integration
+          # @public_api
+          class Settings < Datadog::CI::Contrib::Settings
+            option :enabled do |o|
+              o.type :bool
+              o.env Ext::ENV_ENABLED
+              o.default true
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/simplecov/ext.rb
+++ b/lib/datadog/ci/contrib/simplecov/ext.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        # Simplecov integration constants
+        # @public_api
+        module Ext
+          ENV_ENABLED = "DD_CIVISIBILITY_SIMPLECOV_INSTRUMENTATION_ENABLED"
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/simplecov/integration.rb
+++ b/lib/datadog/ci/contrib/simplecov/integration.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative "../integration"
+require_relative "configuration/settings"
+require_relative "patcher"
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        # Description of Simplecov integration
+        class Integration
+          include Datadog::CI::Contrib::Integration
+
+          MINIMUM_VERSION = Gem::Version.new("0.18.0")
+
+          register_as :simplecov
+
+          def self.version
+            Gem.loaded_specs["simplecov"]&.version
+          end
+
+          def self.loaded?
+            !defined?(::SimpleCov).nil?
+          end
+
+          def self.compatible?
+            super && version >= MINIMUM_VERSION
+          end
+
+          # additional instrumentations for test helpers are auto instrumented on test session start
+          def auto_instrument?
+            true
+          end
+
+          def new_configuration
+            Configuration::Settings.new
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/simplecov/patcher.rb
+++ b/lib/datadog/ci/contrib/simplecov/patcher.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "datadog/tracing/contrib/patcher"
+
+require_relative "result_extractor"
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        # Patcher enables patching of 'SimpleCov' module.
+        module Patcher
+          include Datadog::Tracing::Contrib::Patcher
+
+          module_function
+
+          def target_version
+            Integration.version
+          end
+
+          def patch
+            ::SimpleCov.include(ResultExtractor)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/simplecov/result_extractor.rb
+++ b/lib/datadog/ci/contrib/simplecov/result_extractor.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "coverage"
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module ResultExtractor
+          def self.included(base)
+            base.singleton_class.prepend(ClassMethods)
+          end
+
+          module ClassMethods
+            def __dd_peek_result
+              return nil unless datadog_configuration[:enabled]
+
+              result = ::SimpleCov::UselessResultsRemover.call(
+                ::SimpleCov::ResultAdapter.call(::Coverage.peek_result)
+              )
+
+              ::SimpleCov::Result.new(add_not_loaded_files(result))
+            end
+
+            def datadog_configuration
+              Datadog.configuration.ci[:simplecov]
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/simplecov/result_extractor.rb
+++ b/lib/datadog/ci/contrib/simplecov/result_extractor.rb
@@ -13,7 +13,10 @@ module Datadog
 
           module ClassMethods
             def __dd_peek_result
-              return nil unless datadog_configuration[:enabled]
+              unless datadog_configuration[:enabled]
+                Datadog.logger.debug("SimpleCov instrumentation is disabled")
+                return nil
+              end
 
               result = ::SimpleCov::UselessResultsRemover.call(
                 ::SimpleCov::ResultAdapter.call(::Coverage.peek_result)

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -64,6 +64,9 @@ module Datadog
         TAG_EARLY_FLAKE_ENABLED = "test.early_flake.enabled" # true if early flake detection is enabled
         TAG_EARLY_FLAKE_ABORT_REASON = "test.early_flake.abort_reason" # reason why early flake detection was aborted
 
+        # Tags for total code coverage
+        TAG_CODE_COVERAGE_LINES_PCT = "test.code_coverage.lines_pct"
+
         # internal APM tag to mark a span as a test span
         TAG_SPAN_KIND = "span.kind"
         SPAN_KIND_TEST = "test"

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -4,6 +4,7 @@ require "rbconfig"
 
 require_relative "context"
 require_relative "telemetry"
+require_relative "total_coverage"
 
 require_relative "../codeowners/parser"
 require_relative "../contrib/contrib"
@@ -187,6 +188,8 @@ module Datadog
 
         def on_test_session_finished(test_session)
           test_optimisation.write_test_session_tags(test_session)
+
+          TotalCoverage.extract_lines_pct(test_session)
 
           Telemetry.event_finished(test_session)
         end

--- a/lib/datadog/ci/test_visibility/total_coverage.rb
+++ b/lib/datadog/ci/test_visibility/total_coverage.rb
@@ -7,12 +7,26 @@ module Datadog
     module TestVisibility
       module TotalCoverage
         def self.extract_lines_pct(test_session)
-          return unless defined?(::SimpleCov)
-          return unless ::SimpleCov.running
-          return unless ::SimpleCov.respond_to?(:__dd_peek_result)
+          unless defined?(::SimpleCov)
+            Datadog.logger.debug("SimpleCov is not loaded, skipping code coverage extraction")
+            return
+          end
+
+          unless ::SimpleCov.running
+            Datadog.logger.debug("SimpleCov is not running, skipping code coverage extraction")
+            return
+          end
+
+          unless ::SimpleCov.respond_to?(:__dd_peek_result)
+            Datadog.logger.debug("SimpleCov is not patched, skipping code coverage extraction")
+            return
+          end
 
           result = ::SimpleCov.__dd_peek_result
-          return unless result
+          unless result
+            Datadog.logger.debug("SimpleCov result is nil, skipping code coverage extraction")
+            return
+          end
 
           test_session.set_tag(Ext::Test::TAG_CODE_COVERAGE_LINES_PCT, result.covered_percent)
         end

--- a/lib/datadog/ci/test_visibility/total_coverage.rb
+++ b/lib/datadog/ci/test_visibility/total_coverage.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../ext/test"
+
+module Datadog
+  module CI
+    module TestVisibility
+      module TotalCoverage
+        def self.extract_lines_pct(test_session)
+          return unless defined?(::SimpleCov)
+          return unless ::SimpleCov.running
+          return unless ::SimpleCov.respond_to?(:__dd_peek_result)
+
+          result = ::SimpleCov.__dd_peek_result
+          return unless result
+
+          test_session.set_tag(Ext::Test::TAG_CODE_COVERAGE_LINES_PCT, result.covered_percent)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/simplecov/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/simplecov/configuration/settings.rbs
@@ -1,0 +1,12 @@
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module Configuration
+          class Settings < Datadog::CI::Contrib::Settings
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/simplecov/ext.rbs
+++ b/sig/datadog/ci/contrib/simplecov/ext.rbs
@@ -1,0 +1,11 @@
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module Ext
+          ENV_ENABLED: "DD_CIVISIBILITY_SIMPLECOV_INSTRUMENTATION_ENABLED"
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/simplecov/integration.rbs
+++ b/sig/datadog/ci/contrib/simplecov/integration.rbs
@@ -1,0 +1,26 @@
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        class Integration
+          extend Datadog::CI::Contrib::Integration::ClassMethods
+          include Datadog::CI::Contrib::Integration::InstanceMethods
+
+          MINIMUM_VERSION: Gem::Version
+
+          def self.version: () -> untyped
+
+          def self.loaded?: () -> bool
+
+          def self.compatible?: () -> bool
+
+          def auto_instrument?: () -> bool
+
+          def new_configuration: () -> untyped
+
+          def patcher: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/simplecov/patcher.rbs
+++ b/sig/datadog/ci/contrib/simplecov/patcher.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module Patcher
+          include Datadog::Tracing::Contrib::Patcher
+
+          def self?.target_version: () -> untyped
+
+          def self?.patch: () -> untyped
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
+++ b/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
@@ -1,0 +1,23 @@
+module Coverage
+  def self.peek_result: () -> untyped
+end
+
+module Datadog
+  module CI
+    module Contrib
+      module Simplecov
+        module ResultExtractor
+          def self.included: (untyped base) -> untyped
+
+          module ClassMethods
+            include ::SimpleCov
+
+            def __dd_peek_result: () -> ::SimpleCov::Result?
+
+            def datadog_configuration: () -> untyped
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -100,6 +100,8 @@ module Datadog
 
         METRIC_CPU_COUNT: "_dd.host.vcpu_count"
 
+        TAG_CODE_COVERAGE_LINES_PCT: "test.code_coverage.lines_pct"
+
         module Status
           PASS: "pass"
 

--- a/sig/datadog/ci/test_visibility/total_coverage.rbs
+++ b/sig/datadog/ci/test_visibility/total_coverage.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module CI
+    module TestVisibility
+      module TotalCoverage
+        def self.extract_lines_pct: (Datadog::CI::TestSession test_session) -> void
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -180,10 +180,14 @@ RSpec.describe "Cucumber instrumentation" do
       )
       expect(test_session_span).to have_pass_status
 
+      # ITR
       expect(test_session_span).to have_test_tag(:itr_test_skipping_enabled, "true")
       expect(test_session_span).to have_test_tag(:itr_test_skipping_type, "test")
       expect(test_session_span).to have_test_tag(:itr_tests_skipped, "false")
       expect(test_session_span).to have_test_tag(:itr_test_skipping_count, 0)
+
+      # Total code coverage
+      expect(test_session_span).to have_test_tag(:code_coverage_lines_pct)
     end
 
     it "creates test module span" do

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -440,10 +440,14 @@ RSpec.describe "Minitest instrumentation" do
             Datadog::CI::Contrib::Minitest::Integration.version.to_s
           )
 
+          # ITR
           expect(test_session_span).to have_test_tag(:itr_test_skipping_enabled, "true")
           expect(test_session_span).to have_test_tag(:itr_test_skipping_type, "test")
           expect(test_session_span).to have_test_tag(:itr_tests_skipped, "false")
           expect(test_session_span).to have_test_tag(:itr_test_skipping_count, 0)
+
+          # Total code coverage
+          expect(test_session_span).to have_test_tag(:code_coverage_lines_pct)
 
           expect(test_session_span).to have_pass_status
         end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -554,6 +554,9 @@ RSpec.describe "RSpec hooks" do
       expect(test_session_span).not_to have_test_tag(:itr_tests_skipped)
       expect(test_session_span).not_to have_test_tag(:itr_test_skipping_count)
 
+      # Total code coverage
+      expect(test_session_span).to have_test_tag(:code_coverage_lines_pct)
+
       expect(test_session_span).to have_pass_status
     end
 

--- a/vendor/rbs/simplecov/0/simplecov.rbs
+++ b/vendor/rbs/simplecov/0/simplecov.rbs
@@ -1,0 +1,21 @@
+module SimpleCov
+  def self.running: () -> bool
+
+  def add_not_loaded_files: (untyped result) -> untyped
+
+  def self.__dd_peek_result: () -> SimpleCov::Result?
+end
+
+class SimpleCov::Result
+  def initialize: (untyped result) -> void
+
+  def covered_percent: () -> Float
+end
+
+class SimpleCov::UselessResultsRemover
+  def self.call: (untyped result) -> untyped
+end
+
+class SimpleCov::ResultAdapter
+  def self.call: (untyped result) -> untyped
+end


### PR DESCRIPTION
**What does this PR do?**
Adds support for [total code coverage reporting](https://docs.datadoghq.com/tests/code_coverage) feature. 

Supported code coverage library: `gem "simplecov" >= 0.18.0`

**Motivation**
Achieving feature parity across Datadog libraries

**How to test the change?**

Tested using rubocop project:
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/24554d8e-8ffc-4069-b963-c4310042e5e0">

... and middleman:
<img width="1342" alt="image" src="https://github.com/user-attachments/assets/4f540876-4e7c-4fcc-8168-d0dbc6f5aade">
