### PR TITLE
[SDTEST-482] Use correct monotonic clock time if Timecop.mock_process_clock is set

### DIFF
--- a/sig/datadog/ci/configuration/components.rbs
+++ b/sig/datadog/ci/configuration/components.rbs
@@ -40,6 +40,8 @@ module Datadog
 
         def configure_telemetry: (untyped settings) -> void
 
+        def configure_time_providers: (untyped settings) -> void
+
         def timecop?: () -> bool
       end
     end

--- a/spec/datadog/ci/contrib/timecop/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/timecop/instrumentation_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe "Minitest instrumentation" do
     Minitest::Runnable.reset
 
     Timecop.freeze(time_1990)
+    Timecop.mock_process_clock = true
 
     class SomeTest < Minitest::Test
       def test_pass
@@ -25,6 +26,9 @@ RSpec.describe "Minitest instrumentation" do
 
   it "does not set frozen time when setting start time for traces" do
     expect(first_test_span.start_time).not_to eq(time_1990)
+    expect(first_test_span.duration).not_to eq(0)
+
     expect(test_session_span.start_time).not_to eq(time_1990)
+    expect(test_session_span.duration).not_to eq(0)
   end
 end

--- a/vendor/rbs/timecop/0/timecop.rbs
+++ b/vendor/rbs/timecop/0/timecop.rbs
@@ -2,5 +2,9 @@ class Time
   def self.now_without_mock_time: () -> Time
 end
 
+module Process
+  def self.clock_gettime_without_mock: (untyped clock, untyped unit) -> Numeric
+end
+
 class Timecop
 end


### PR DESCRIPTION
**What does this PR do?**
Automatically configures correct monotonic clock provider for tracing module if timecop library mocked monotonic time. 

**Motivation**
Timecop v0.9.9 allows to [mock monotonic clock](https://github.com/travisjeffery/timecop/pull/419), which might affect displayed tests duration in Datadog UI.

**How to test the change?**
Unit test is provided