### PR TITLE
[SDTEST-292] Retry HTTP requests on 429 and 5xx responses

### DIFF
--- a/lib/datadog/ci/ext/transport.rb
+++ b/lib/datadog/ci/ext/transport.rb
@@ -12,6 +12,7 @@ module Datadog
         HEADER_CONTENT_ENCODING = "Content-Encoding"
         HEADER_EVP_SUBDOMAIN = "X-Datadog-EVP-Subdomain"
         HEADER_CONTAINER_ID = "Datadog-Container-ID"
+        HEADER_RATELIMIT_RESET = "X-RateLimit-Reset"
 
         EVP_PROXY_V2_PATH_PREFIX = "/evp_proxy/v2/"
         EVP_PROXY_V4_PATH_PREFIX = "/evp_proxy/v4/"

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -23,6 +23,7 @@ module Datadog
         DEFAULT_TIMEOUT = 30
         MAX_RETRIES = 3
         INITIAL_BACKOFF = 1
+        MAX_BACKOFF = 30
 
         def initialize(host:, port:, timeout: DEFAULT_TIMEOUT, ssl: true, compress: false)
           @host = host
@@ -78,21 +79,53 @@ module Datadog
         private
 
         def perform_http_call(path:, payload:, headers:, verb:, retries: MAX_RETRIES, backoff: INITIAL_BACKOFF)
-          adapter.call(
-            path: path, payload: payload, headers: headers, verb: verb
-          )
-        rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, SocketError, Net::HTTPBadResponse => e
-          Datadog.logger.debug("Failed to send request with #{e} (#{e.message})")
+          # retry logic as lambda to avoid duplication
+          retry_request = ->(previous_response, current_backoff) do
+            if retries.positive? && backoff <= MAX_BACKOFF
+              sleep(backoff)
 
-          if retries.positive?
-            sleep(backoff)
+              perform_http_call(
+                path: path,
+                payload: payload,
+                headers: headers,
+                verb: verb,
+                retries: retries - 1,
+                backoff: current_backoff * 2
+              )
+            else
+              Datadog.logger.error(
+                "Failed to send request after #{MAX_RETRIES - retries} retries (current backoff value #{backoff})"
+              )
 
-            perform_http_call(
-              path: path, payload: payload, headers: headers, verb: verb, retries: retries - 1, backoff: backoff * 2
+              previous_response
+            end
+          end
+
+          begin
+            response = adapter.call(
+              path: path, payload: payload, headers: headers, verb: verb
             )
-          else
-            Datadog.logger.error("Failed to send request after #{MAX_RETRIES} retries")
-            ErrorResponse.new(e)
+            return response if response.ok?
+
+            if response.code == 429
+              backoff = (response.header(Ext::Transport::HEADER_RATELIMIT_RESET) || 1).to_i
+
+              Datadog.logger.debug do
+                "Received rate limit response, retrying in #{backoff} seconds from X-RateLimit-Reset header"
+              end
+
+              retry_request.call(response, backoff)
+            elsif response.server_error?
+              Datadog.logger.debug { "Received server error response, retrying in #{backoff} seconds" }
+
+              retry_request.call(response, backoff)
+            else
+              response
+            end
+          rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError, SocketError, Net::HTTPBadResponse => e
+            Datadog.logger.debug { "Failed to send request with #{e} (#{e.message})" }
+
+            retry_request.call(ErrorResponse.new(e), backoff)
           end
         end
 

--- a/sig/datadog/ci/ext/transport.rbs
+++ b/sig/datadog/ci/ext/transport.rbs
@@ -16,6 +16,8 @@ module Datadog
 
         HEADER_CONTAINER_ID: "Datadog-Container-ID"
 
+        HEADER_RATELIMIT_RESET: "X-RateLimit-Reset"
+
         EVP_PROXY_V2_PATH_PREFIX: "/evp_proxy/v2/"
 
         EVP_PROXY_V4_PATH_PREFIX: "/evp_proxy/v4/"

--- a/sig/datadog/ci/transport/http.rbs
+++ b/sig/datadog/ci/transport/http.rbs
@@ -13,6 +13,7 @@ module Datadog
         DEFAULT_TIMEOUT: 30
         MAX_RETRIES: 3
         INITIAL_BACKOFF: 1
+        MAX_BACKOFF: 30
 
         def initialize: (host: String, port: Integer, ?ssl: bool, ?timeout: Integer, ?compress: bool) -> void
 


### PR DESCRIPTION
**What does this PR do?**
Expands failed requests retry logic for HTTP client in this library to be as follows:

1. If response HTTP code is 5xx, retry up to 3 times with exponential backoff
2. If response HTTP code is 429, retry up to 3 times, take backoff value from `X-RateLimit-Reset` response header (stop retrying if backoff value is over 30)
3. If response HTTP code is 4xx (but not 429), fail immediately without retries
4. If exception is raised due to network issues, retry up to 3 times with exponential backoff

**Motivation**
Better handling of transient server errors and rate limit hits: we have some requests failing with 429/503 according to internal telemetry

**How to test the change?**
Unit tests are provided for each of the above cases