### PR TITLE
[SDTEST-878] Optimise LocalRepository.relative_to_root helper to make test impact analysis faster

### DIFF
--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -30,6 +30,8 @@ module Datadog
           @root = git_root || Dir.pwd
         end
 
+        # ATTENTION: this function is running in a hot path
+        # and should be optimized for performance
         def self.relative_to_root(path)
           return "" if path.nil?
 
@@ -37,14 +39,17 @@ module Datadog
           return path if root_path.nil?
 
           if File.absolute_path?(path)
+            # prefix_index is where the root path ends in the given path
             prefix_index = root_path.size
 
-            # impossible case
+            # impossible case - absolute paths are returned from code coverage tool that always checks
+            # that root is a prefix of the path
             return "" if path.size < prefix_index
 
             prefix_index += 1 if path[prefix_index] == File::SEPARATOR
             res = path[prefix_index..]
           else
+            # prefix_to_root is a difference between the root path and the given path
             if @prefix_to_root == ""
               return path
             elsif @prefix_to_root

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -149,6 +149,10 @@ module Datadog
             nil
           end
 
+          def response_size
+            0
+          end
+
           def inspect
             "ErrorResponse error:#{error}"
           end

--- a/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
@@ -112,9 +112,9 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
           Datadog::CI::Git::LocalRepository.remove_instance_variable(:@prefix_to_root)
         end
 
-        allow(Datadog::CI::Git::LocalRepository).to receive(:root).and_return(
-          Dir.pwd.gsub("/#{current_folder}", "")
-        )
+        new_root = Dir.pwd.gsub("/#{current_folder}", "")
+        new_root = "/" if new_root.empty?
+        allow(Datadog::CI::Git::LocalRepository).to receive(:root).and_return(new_root)
       end
 
       after do

--- a/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
     context "when file paths are absolute" do
       let(:coverage) do
         {
-          absolute_path("./project/file.rb") => true
+          absolute_path("project/file.rb") => true
         }
       end
 

--- a/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
@@ -105,11 +105,13 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
     end
 
     context "when file paths are relative" do
+      let(:current_folder) { File.basename(Dir.pwd) }
+
       before do
         Datadog::CI::Git::LocalRepository.remove_instance_variable(:@prefix_to_root)
 
         allow(Datadog::CI::Git::LocalRepository).to receive(:root).and_return(
-          Dir.pwd.gsub("/datadog-ci-rb", "")
+          Dir.pwd.gsub("/#{current_folder}", "")
         )
       end
 
@@ -131,8 +133,8 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
             "test_suite_id" => 2,
             "span_id" => 1,
             "files" => [
-              {"filename" => "datadog-ci-rb/project/file.rb"},
-              {"filename" => "datadog-ci-rb/project/file2.rb"}
+              {"filename" => "#{current_folder}/project/file.rb"},
+              {"filename" => "#{current_folder}/project/file2.rb"}
             ]
           }
         )

--- a/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_optimisation/coverage/event_spec.rb
@@ -108,7 +108,9 @@ RSpec.describe Datadog::CI::TestOptimisation::Coverage::Event do
       let(:current_folder) { File.basename(Dir.pwd) }
 
       before do
-        Datadog::CI::Git::LocalRepository.remove_instance_variable(:@prefix_to_root)
+        if Datadog::CI::Git::LocalRepository.instance_variable_defined?(:@prefix_to_root)
+          Datadog::CI::Git::LocalRepository.remove_instance_variable(:@prefix_to_root)
+        end
 
         allow(Datadog::CI::Git::LocalRepository).to receive(:root).and_return(
           Dir.pwd.gsub("/#{current_folder}", "")


### PR DESCRIPTION
**What does this PR do?**
Applies some heuristics to avoid calling `Pathname#relative_path_from` function when determining what would be path relative to the git root for the given filepath:
- If given filepath is absolute, we use the fact that absolute paths are pre-filtered already and they always contain root as prefix, so we only need to slice the string to get the suffix (`path[prefix_length..]`)
- If given filepath is relative, we compute `Pathname#relative_path_from` once and then we store the difference between the relative filepath and the computed relative path from root in the `@prefix_to_root` cached variable. We can do it because all relative paths are computed relative to the `Dir.pwd` which doesn't change in the lifetime of the process. After we have `@prefix_to_root` cache, we prepend it to every filepath we get (or just return the filepath if the tests are running from the git root).

**Motivation**
Profiling rubocop test suite with Datadog continuous profiler showed that big part of CPU time is spent in `Datadog::CI::Git::LocalRepository.relative_to_root` function:
![profile-before](https://github.com/user-attachments/assets/1ab35392-17bf-4182-973a-58b4a0e99a43)

**How to test the change?**
Unit tests are provided.

[Benchmark results](https://github.com/DataDog/test-environment/pull/329):
- Middleman overhead 34,1% (down from 40%)
- Rubocop overhead 64% (down from 128%) - **2x improvement**