### PR TITLE
Make --spec-path option available to skipped-tests-estimate cli command

### DIFF
--- a/lib/datadog/ci/cli/command/base.rb
+++ b/lib/datadog/ci/cli/command/base.rb
@@ -27,6 +27,7 @@ module Datadog
 
               opts.on("-f", "--file FILENAME", "Output result to file FILENAME")
               opts.on("--verbose", "Verbose output to stdout")
+              opts.on("--spec-path=[SPEC_PATH]", "Relative path to the spec directory, example: spec")
 
               command_options(opts)
             end.parse!(into: ddcirb_options)

--- a/lib/datadog/ci/cli/command/skippable_tests_percentage.rb
+++ b/lib/datadog/ci/cli/command/skippable_tests_percentage.rb
@@ -18,7 +18,6 @@ module Datadog
 
           def command_options(opts)
             opts.on("--rspec-opts=[OPTIONS]", "Command line options to pass to RSpec")
-            opts.on("--spec-path=[SPEC_PATH]", "Relative path to the spec directory, example: spec")
           end
         end
       end

--- a/spec/datadog/ci/cli/cli_spec.rb
+++ b/spec/datadog/ci/cli/cli_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/datadog/ci/cli/cli"
+
+RSpec.describe Datadog::CI::CLI do
+  describe ".exec" do
+    subject(:exec) { described_class.exec(action) }
+
+    context "when action is 'skippable-tests'" do
+      let(:action) { "skippable-tests" }
+
+      it "executes the skippable tests percentage command" do
+        expect(Datadog::CI::CLI::Command::SkippableTestsPercentage).to receive(:new).and_call_original
+        expect_any_instance_of(Datadog::CI::CLI::Command::SkippableTestsPercentage).to receive(:exec)
+
+        exec
+      end
+    end
+
+    context "when action is 'skippable-tests-estimate'" do
+      let(:action) { "skippable-tests-estimate" }
+
+      it "executes the skippable tests percentage estimate command" do
+        expect(Datadog::CI::CLI::Command::SkippableTestsPercentageEstimate).to receive(:new).and_call_original
+        expect_any_instance_of(Datadog::CI::CLI::Command::SkippableTestsPercentageEstimate).to receive(:exec)
+
+        exec
+      end
+    end
+
+    context "when action is not recognised" do
+      let(:action) { "not-recognised" }
+
+      it "prints the usage information" do
+        expect { exec }.to output(<<~USAGE).to_stdout
+          Usage: bundle exec ddcirb [command] [options]. Available commands:
+            skippable-tests - calculates the exact percentage of skipped tests and prints it to stdout or file
+            skippable-tests-estimate - estimates the percentage of skipped tests and prints it to stdout or file
+        USAGE
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/cli/command/skippable_tests_percentage_estimate_spec.rb
+++ b/spec/datadog/ci/cli/command/skippable_tests_percentage_estimate_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "../../../../../lib/datadog/ci/cli/command/skippable_tests_percentage_estimate"
+
+RSpec.describe Datadog::CI::CLI::Command::SkippableTestsPercentageEstimate do
+  subject(:command) { described_class.new }
+
+  describe "#exec" do
+    subject(:exec) { command.exec }
+
+    # inputs
+    let(:verbose) { false }
+    let(:spec_path) { "spec" }
+    let(:argv) { [] }
+
+    # outputs
+    let(:failed) { false }
+    let(:result) { "result" }
+    let(:action) { double("action", call: result, failed: failed) }
+
+    before do
+      allow(::Datadog::CI::TestOptimisation::SkippablePercentage::Estimator).to receive(:new).with(
+        verbose: verbose,
+        spec_path: spec_path
+      ).and_return(action)
+
+      stub_const("ARGV", argv)
+    end
+
+    context "when no CLI options are given" do
+      let(:argv) { [] }
+
+      it "executes the action, validates it, and outputs the result" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when file option is given" do
+      let(:argv) { ["-f", "output.txt"] }
+
+      it "writes the result to the file" do
+        expect(File).to receive(:write).with("output.txt", "result")
+
+        exec
+      end
+    end
+
+    context "when verbose option is given" do
+      let(:argv) { ["--verbose"] }
+      let(:verbose) { true }
+
+      it "passes the verbose option to the action" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when spec-path option is given" do
+      let(:argv) { ["--spec-path=spec/models"] }
+      let(:spec_path) { "spec/models" }
+
+      it "passes the spec-path option to the action" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when the action fails" do
+      let(:failed) { true }
+
+      it "exits with status 1" do
+        expect { exec }.to raise_error(SystemExit)
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/cli/command/skippable_tests_percentage_spec.rb
+++ b/spec/datadog/ci/cli/command/skippable_tests_percentage_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative "../../../../../lib/datadog/ci/cli/command/skippable_tests_percentage"
+
+RSpec.describe Datadog::CI::CLI::Command::SkippableTestsPercentage do
+  subject(:command) { described_class.new }
+
+  describe "#exec" do
+    subject(:exec) { command.exec }
+
+    # inputs
+    let(:rspec_options) { [] }
+    let(:verbose) { false }
+    let(:spec_path) { "spec" }
+    let(:argv) { [] }
+
+    # outputs
+    let(:failed) { false }
+    let(:result) { "result" }
+    let(:action) { double("action", call: result, failed: failed) }
+
+    before do
+      allow(::Datadog::CI::TestOptimisation::SkippablePercentage::Calculator).to receive(:new).with(
+        rspec_cli_options: rspec_options,
+        verbose: verbose,
+        spec_path: spec_path
+      ).and_return(action)
+
+      stub_const("ARGV", argv)
+    end
+
+    context "when no CLI options are given" do
+      let(:argv) { [] }
+
+      it "executes the action, validates it, and outputs the result" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when file option is given" do
+      let(:argv) { ["-f", "output.txt"] }
+
+      it "writes the result to the file" do
+        expect(File).to receive(:write).with("output.txt", "result")
+
+        exec
+      end
+    end
+
+    context "when verbose option is given" do
+      let(:argv) { ["--verbose"] }
+      let(:verbose) { true }
+
+      it "passes the verbose option to the action" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when rspec-opts option is given" do
+      let(:argv) { ["--rspec-opts=--color --format progress"] }
+      let(:rspec_options) { ["--color", "--format", "progress"] }
+
+      it "passes the rspec-opts option to the action" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when spec-path option is given" do
+      let(:argv) { ["--spec-path=spec/models"] }
+      let(:spec_path) { "spec/models" }
+
+      it "passes the spec-path option to the action" do
+        expect { exec }.to output("result").to_stdout
+      end
+    end
+
+    context "when the action fails" do
+      let(:failed) { true }
+
+      it "exits with status 1" do
+        expect { exec }.to raise_error(SystemExit)
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Adds option --spec-path to skipped-tests-estimate CLI command

**Motivation**
Because of the bug this option isn't available now (but it should be)

**How to test the change?**
Added more unit tests