### PR TITLE
[SDTEST-1129] extract ciqueue instrumentation

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -414,6 +414,7 @@ require_relative "ci/contrib/rspec/integration"
 
 # Test runners (instrumented automatically when corresponding frameworks are instrumented)
 require_relative "ci/contrib/knapsack/integration"
+require_relative "ci/contrib/ciqueue/integration"
 
 # Additional test libraries (auto instrumented later on test session start)
 require_relative "ci/contrib/selenium/integration"

--- a/lib/datadog/ci/contrib/ciqueue/integration.rb
+++ b/lib/datadog/ci/contrib/ciqueue/integration.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../integration"
+require_relative "patcher"
+
+module Datadog
+  module CI
+    module Contrib
+      module Ciqueue
+        # ci-queue test runner instrumentation
+        # https://github.com/Shopify/ci-queue
+        class Integration < Contrib::Integration
+          MINIMUM_VERSION = Gem::Version.new("0.9.0")
+
+          def version
+            Gem.loaded_specs["ci-queue"]&.version
+          end
+
+          def loaded?
+            !defined?(::RSpec::Queue::Runner).nil?
+          end
+
+          def compatible?
+            super && version >= MINIMUM_VERSION
+          end
+
+          def patcher
+            Patcher
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/ciqueue/patcher.rb
+++ b/lib/datadog/ci/contrib/ciqueue/patcher.rb
@@ -1,15 +1,12 @@
 # frozen_string_literal: true
 
 require_relative "../patcher"
-
-require_relative "example"
-require_relative "example_group"
-require_relative "runner"
+require_relative "../rspec/runner"
 
 module Datadog
   module CI
     module Contrib
-      module RSpec
+      module Ciqueue
         # Patcher enables patching of 'rspec' module.
         module Patcher
           include Datadog::CI::Contrib::Patcher
@@ -17,9 +14,7 @@ module Datadog
           module_function
 
           def patch
-            ::RSpec::Core::Runner.include(Runner)
-            ::RSpec::Core::Example.include(Example)
-            ::RSpec::Core::ExampleGroup.include(ExampleGroup)
+            ::RSpec::Queue::Runner.include(Contrib::RSpec::Runner)
           end
         end
       end

--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -13,7 +13,7 @@ module Datadog
           MINIMUM_VERSION = Gem::Version.new("3.0.0")
 
           def dependants
-            %i[knapsack]
+            %i[knapsack ciqueue]
           end
 
           def version

--- a/sig/datadog/ci/contrib/ciqueue/integration.rbs
+++ b/sig/datadog/ci/contrib/ciqueue/integration.rbs
@@ -1,0 +1,19 @@
+module Datadog
+  module CI
+    module Contrib
+      module Ciqueue
+        class Integration < Contrib::Integration
+          MINIMUM_VERSION: untyped
+
+          def version: () -> untyped
+
+          def loaded?: () -> bool
+
+          def compatible?: () -> bool
+
+          def patcher: () -> singleton(Patcher)
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/ciqueue/patcher.rbs
+++ b/sig/datadog/ci/contrib/ciqueue/patcher.rbs
@@ -1,0 +1,13 @@
+module Datadog
+  module CI
+    module Contrib
+      module Ciqueue
+        module Patcher
+          include Datadog::CI::Contrib::Patcher
+
+          def self?.patch: () -> void
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Similarly to https://github.com/DataDog/datadog-ci-rb/pull/253 we extract ci-queue to its own integration.

**Motivation**
Needed by auto-instrumentation feature

**How to test the change?**
Covered by existing unit tests