### PR TITLE
[SDTEST-228] Auto instrumentation

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -10,5 +10,7 @@ ignore:
       - Style/Alias
   - spec/datadog/ci/contrib/minitest/instrumentation_spec.rb:
       - Lint/ConstantDefinitionInBlock
+  - spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb:
+      - Lint/ConstantDefinitionInBlock
   - spec/datadog/ci/contrib/timecop/instrumentation_spec.rb:
       - Lint/ConstantDefinitionInBlock

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Datadog Test Visibility for Ruby
+# Datadog Test Optimization for Ruby
 
 [![Gem Version](https://badge.fury.io/rb/datadog-ci.svg)](https://badge.fury.io/rb/datadog-ci)
 [![YARD documentation](https://img.shields.io/badge/YARD-documentation-blue)](https://datadoghq.dev/datadog-ci-rb/)
-[![codecov](https://codecov.io/gh/DataDog/datadog-ci-rb/branch/main/graph/badge.svg)](https://app.codecov.io/gh/DataDog/datadog-ci-rb/branch/main)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/DataDog/datadog-ci-rb/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/DataDog/datadog-ci-rb/tree/main)
 
 Datadog's Ruby Library for instrumenting your tests.
 Learn more on our [official website](https://docs.datadoghq.com/tests/) and check out our [documentation for this library](https://docs.datadoghq.com/tests/setup/ruby/?tab=cloudciprovideragentless).
@@ -11,12 +9,12 @@ Learn more on our [official website](https://docs.datadoghq.com/tests/) and chec
 ## Features
 
 - [Test Visibility](https://docs.datadoghq.com/tests/) - collect metrics and results for your tests
-- [Intelligent test runner](https://docs.datadoghq.com/intelligent_test_runner/) - save time by selectively running only tests affected by code changes
-- [Auto test retries](https://docs.datadoghq.com/tests/auto_test_retries/?tab=ruby) - retrying failing tests up to N times to avoid failing your build due to flaky tests
-- [Early flake detection](https://docs.datadoghq.com/tests/early_flake_detection?tab=ruby) - Datadog’s test flakiness solution that identifies flakes early by running newly added tests multiple times
+- [Test impact analysis](https://docs.datadoghq.com/tests/test_impact_analysis/) - save time by selectively running only tests affected by code changes
+- [Flaky test management](https://docs.datadoghq.com/tests/flaky_test_management/) - track, alert, search your flaky tests in Datadog UI
+- [Auto test retries](https://docs.datadoghq.com/tests/flaky_test_management/auto_test_retries/?tab=ruby) - retrying failing tests up to N times to avoid failing your build due to flaky tests
+- [Early flake detection](https://docs.datadoghq.com/tests/flaky_test_management/early_flake_detection/?tab=ruby) - Datadog’s test flakiness solution that identifies flakes early by running newly added tests multiple times
 - [Search and manage CI tests](https://docs.datadoghq.com/tests/search/)
 - [Enhance developer workflows](https://docs.datadoghq.com/tests/developer_workflows)
-- [Flaky test management](https://docs.datadoghq.com/tests/guides/flaky_test_management/)
 - [Add custom measures to your tests](https://docs.datadoghq.com/tests/guides/add_custom_measures/?tab=ruby)
 - [Browser tests integration with Datadog RUM](https://docs.datadoghq.com/tests/browser_tests)
 
@@ -37,7 +35,7 @@ If you used [test visibility for Ruby](https://docs.datadoghq.com/tests/setup/ru
 ## Setup
 
 - [Test visibility setup](https://docs.datadoghq.com/tests/setup/ruby/?tab=cloudciprovideragentless)
-- [Intelligent test runner setup](https://docs.datadoghq.com/intelligent_test_runner/setup/ruby) (test visibility setup is required before setting up intelligent test runner)
+- [Test impact analysis setup](https://docs.datadoghq.com/tests/test_impact_analysis/setup/ruby/?tab=cloudciprovideragentless) (test visibility setup is required before setting up test impact analysis)
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,9 @@ TEST_METADATA = {
   "minitest" => {
     "minitest-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby"
   },
+  "minitest_auto_instrument" => {
+    "minitest-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby"
+  },
   "activesupport" => {
     "activesupport-4" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby",
     "activesupport-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby",
@@ -149,6 +152,7 @@ namespace :spec do
     rspec
     minitest
     minitest_shoulda_context
+    minitest_auto_instrument
     activesupport
     ci_queue_minitest
     ci_queue_rspec

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ TEST_METADATA = {
     "minitest-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby"
   },
   "minitest_auto_instrument" => {
-    "minitest-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby"
+    "minitest-5" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby"
   },
   "activesupport" => {
     "activesupport-4" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ✅ jruby",

--- a/Rakefile
+++ b/Rakefile
@@ -79,6 +79,9 @@ TEST_METADATA = {
   "knapsack_rspec" => {
     "knapsack_pro-7-rspec-3" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby"
   },
+  "knapsack_auto_instrument" => {
+    "knapsack_pro-7-rspec-3" => "✅ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ✅ 3.4 / ❌ jruby"
+  },
   "selenium" => {
     "selenium-4-capybara-3" => "❌ 2.7 / ✅ 3.0 / ✅ 3.1 / ✅ 3.2 / ✅ 3.3 / ❌ 3.4 / ✅ jruby"
   },
@@ -157,6 +160,7 @@ namespace :spec do
     ci_queue_minitest
     ci_queue_rspec
     knapsack_rspec
+    knapsack_auto_instrument
     selenium timecop
   ].each do |contrib|
     desc "" # "Explicitly hiding from `rake -T`"

--- a/exe/ddcirb
+++ b/exe/ddcirb
@@ -2,4 +2,6 @@
 
 require "datadog/ci/cli/cli"
 
-Datadog::CI::CLI.exec(ARGV.first)
+command = ARGV.shift
+
+Datadog::CI::CLI.exec(command, ARGV)

--- a/lib/datadog/ci/auto_instrument.rb
+++ b/lib/datadog/ci/auto_instrument.rb
@@ -1,0 +1,3 @@
+require "datadog/ci"
+
+Datadog::CI::Contrib::Instrumentation.auto_instrument

--- a/lib/datadog/ci/cli/cli.rb
+++ b/lib/datadog/ci/cli/cli.rb
@@ -1,14 +1,17 @@
 require "datadog"
 require "datadog/ci"
 
+require_relative "command/exec"
 require_relative "command/skippable_tests_percentage"
 require_relative "command/skippable_tests_percentage_estimate"
 
 module Datadog
   module CI
     module CLI
-      def self.exec(action)
+      def self.exec(action, args = [])
         case action
+        when "exec"
+          Command::Exec.new(args).exec
         when "skipped-tests", "skippable-tests"
           Command::SkippableTestsPercentage.new.exec
         when "skipped-tests-estimate", "skippable-tests-estimate"
@@ -17,6 +20,7 @@ module Datadog
           puts("Usage: bundle exec ddcirb [command] [options]. Available commands:")
           puts("  skippable-tests - calculates the exact percentage of skipped tests and prints it to stdout or file")
           puts("  skippable-tests-estimate - estimates the percentage of skipped tests and prints it to stdout or file")
+          puts("  exec YOUR_TEST_COMMAND - automatically instruments your test command with Datadog and executes it")
         end
       end
     end

--- a/lib/datadog/ci/cli/command/exec.rb
+++ b/lib/datadog/ci/cli/command/exec.rb
@@ -1,0 +1,29 @@
+require_relative "base"
+require_relative "../../test_optimisation/skippable_percentage/estimator"
+
+module Datadog
+  module CI
+    module CLI
+      module Command
+        class Exec < Base
+          def initialize(args)
+            super()
+
+            @args = args
+          end
+
+          def exec
+            rubyopts = [
+              "-rdatadog/ci/auto_instrument"
+            ]
+
+            existing_rubyopt = ENV["RUBYOPT"]
+            ENV["RUBYOPT"] = existing_rubyopt ? "#{existing_rubyopt} #{rubyopts.join(" ")}" : rubyopts.join(" ")
+
+            Kernel.exec(*@args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/contrib/cucumber/integration.rb
+++ b/lib/datadog/ci/contrib/cucumber/integration.rb
@@ -17,7 +17,7 @@ module Datadog
           end
 
           def loaded?
-            !defined?(::Cucumber).nil? && !defined?(::Cucumber::Runtime).nil?
+            !defined?(::Cucumber).nil? && !defined?(::Cucumber::Runtime).nil? && !defined?(::Cucumber::Configuration).nil?
           end
 
           def compatible?

--- a/lib/datadog/ci/contrib/instrumentation.rb
+++ b/lib/datadog/ci/contrib/instrumentation.rb
@@ -46,6 +46,7 @@ module Datadog
 
           script_compiled_tracepoint = TracePoint.new(:script_compiled) do
             auto_instrumented_integrations.each do |integration|
+              next if integration.patched?
               next unless integration.loaded?
 
               Datadog.logger.debug("#{integration.class} is loaded")

--- a/lib/datadog/ci/contrib/instrumentation.rb
+++ b/lib/datadog/ci/contrib/instrumentation.rb
@@ -41,7 +41,7 @@ module Datadog
               "Auto instrumentation was requested, but no available integrations were found. " \
               "Tests will be run without Datadog instrumentation."
             )
-            nil
+            return
           end
 
           script_compiled_tracepoint = TracePoint.new(:script_compiled) do

--- a/lib/datadog/ci/contrib/integration.rb
+++ b/lib/datadog/ci/contrib/integration.rb
@@ -93,9 +93,7 @@ module Datadog
 
         # @!visibility private
         def patch
-          # @type var patcher_klass: untyped
-          patcher_klass = patcher
-          if !patchable? || patcher_klass.nil?
+          if !patchable? || patcher.nil?
             return {
               ok: false,
               available: available?,
@@ -105,8 +103,12 @@ module Datadog
             }
           end
 
-          patcher_klass.patch
+          patcher.patch
           {ok: true}
+        end
+
+        def patched?
+          patcher&.patched?
         end
 
         # Can the patch for this integration be applied automatically?

--- a/lib/datadog/ci/contrib/minitest/integration.rb
+++ b/lib/datadog/ci/contrib/minitest/integration.rb
@@ -17,7 +17,8 @@ module Datadog
           end
 
           def loaded?
-            !defined?(::Minitest).nil?
+            !defined?(::Minitest).nil? && !defined?(::Minitest::Runnable).nil? && !defined?(::Minitest::Test).nil? &&
+              !defined?(::Minitest::CompositeReporter).nil?
           end
 
           def compatible?

--- a/lib/datadog/ci/contrib/patcher.rb
+++ b/lib/datadog/ci/contrib/patcher.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "datadog/core/utils/only_once"
-require "datadog/core/telemetry/logger"
 
 module Datadog
   module CI
@@ -42,7 +41,6 @@ module Datadog
           # @param e [Exception]
           def on_patch_error(e)
             Datadog.logger.error("Failed to apply #{patch_name} patch. Cause: #{e} Location: #{Array(e.backtrace).first}")
-            Datadog::Core::Telemetry::Logger.report(e, description: "Failed to apply #{patch_name} patch")
 
             @patch_error_result = {
               type: e.class.name,

--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -22,7 +22,9 @@ module Datadog
 
           def loaded?
             !defined?(::RSpec).nil? && !defined?(::RSpec::Core).nil? &&
-              !defined?(::RSpec::Core::Example).nil?
+              !defined?(::RSpec::Core::Example).nil? &&
+              !defined?(::RSpec::Core::Runner).nil? &&
+              !defined?(::RSpec::Core::ExampleGroup).nil?
           end
 
           def compatible?

--- a/lib/datadog/ci/test_retries/strategy/retry_new.rb
+++ b/lib/datadog/ci/test_retries/strategy/retry_new.rb
@@ -101,7 +101,7 @@ module Datadog
             end
             @total_limit = (tests_count * percentage_limit / 100.0).ceil
             Datadog.logger.debug do
-              "Retry new tests total limit is [#{@total_limit}] (#{percentage_limit}%) of #{tests_count}"
+              "Retry new tests total limit is [#{@total_limit}] (#{percentage_limit}% of #{tests_count})"
             end
           end
 

--- a/sig/datadog/ci/cli/cli.rbs
+++ b/sig/datadog/ci/cli/cli.rbs
@@ -1,7 +1,7 @@
 module Datadog
   module CI
     module CLI
-      def self.exec: (String action) -> void
+      def self.exec: (String action, ?Array[String] args) -> void
     end
   end
 end

--- a/sig/datadog/ci/cli/command/exec.rbs
+++ b/sig/datadog/ci/cli/command/exec.rbs
@@ -1,0 +1,15 @@
+module Datadog
+  module CI
+    module CLI
+      module Command
+        class Exec < Base
+          @args: Array[String]
+
+          def initialize: (Array[String] args) -> void
+
+          def exec: () -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/datadog/ci/contrib/instrumentation.rbs
+++ b/sig/datadog/ci/contrib/instrumentation.rbs
@@ -11,13 +11,16 @@ module Datadog
 
         def self.instrument: (Symbol integration_name, ?::Hash[untyped, untyped] options) { (?) -> untyped } -> void
 
+        def self.instrument_on_session_start: () -> void
+
         def self.fetch_integration: (Symbol name) -> untyped
 
         def self.integration_name: (Class) -> Symbol
 
         def self.register_integration: (Class integration) -> void
 
-        def self.instrument_on_session_start: () -> void
+        def self.patch_integration: (Contrib::Integration integration, ?with_dependencies: bool) -> void
+
       end
     end
   end

--- a/sig/datadog/ci/contrib/instrumentation.rbs
+++ b/sig/datadog/ci/contrib/instrumentation.rbs
@@ -7,6 +7,8 @@ module Datadog
 
         self.@registry: Hash[Symbol, untyped]
 
+        self.@configure_once: Datadog::Core::Utils::OnlyOnce
+
         def self.registry: () -> Hash[Symbol, untyped]
 
         def self.auto_instrument: () -> void
@@ -23,6 +25,11 @@ module Datadog
 
         def self.patch_integration: (Contrib::Integration integration, ?with_dependencies: bool) -> void
 
+        def self.fetch_auto_instrumented_integrations: () -> Array[Contrib::Integration]
+
+        def self.auto_configure_datadog: () -> void
+
+        def self.configure_once: () -> Datadog::Core::Utils::OnlyOnce
       end
     end
   end

--- a/sig/datadog/ci/contrib/instrumentation.rbs
+++ b/sig/datadog/ci/contrib/instrumentation.rbs
@@ -9,6 +9,8 @@ module Datadog
 
         def self.registry: () -> Hash[Symbol, untyped]
 
+        def self.auto_instrument: () -> void
+
         def self.instrument: (Symbol integration_name, ?::Hash[untyped, untyped] options) { (?) -> untyped } -> void
 
         def self.instrument_on_session_start: () -> void

--- a/sig/datadog/ci/contrib/integration.rbs
+++ b/sig/datadog/ci/contrib/integration.rbs
@@ -20,7 +20,9 @@ module Datadog
 
         def enabled: () -> bool
 
-        def patcher: () -> Datadog::Tracing::Contrib::Patcher?
+        def patcher: () -> untyped
+
+        def patched?: () -> bool?
 
         def patch: () -> Hash[Symbol, bool]
 

--- a/sig/datadog/ci/contrib/integration.rbs
+++ b/sig/datadog/ci/contrib/integration.rbs
@@ -24,6 +24,8 @@ module Datadog
 
         def patch: () -> Hash[Symbol, bool]
 
+        def dependants: () -> Array[Symbol]
+
         def late_instrument?: () -> bool
 
         def new_configuration: () -> Datadog::CI::Contrib::Settings

--- a/spec/datadog/ci/cli/cli_spec.rb
+++ b/spec/datadog/ci/cli/cli_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Datadog::CI::CLI do
           Usage: bundle exec ddcirb [command] [options]. Available commands:
             skippable-tests - calculates the exact percentage of skipped tests and prints it to stdout or file
             skippable-tests-estimate - estimates the percentage of skipped tests and prints it to stdout or file
+            exec YOUR_TEST_COMMAND - automatically instruments your test command with Datadog and executes it
         USAGE
       end
     end

--- a/spec/datadog/ci/contrib/knapsack_auto_instrument/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/knapsack_auto_instrument/instrumentation_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe "Knapsack Pro runner when Datadog::CI is auto instrumented" do
+  let(:integration) { Datadog::CI::Contrib::Instrumentation.fetch_integration(:rspec) }
+
+  include_context "CI mode activated" do
+    let(:integration_name) { :no_instrument }
+  end
+
+  before do
+    require_relative "../../../../../lib/datadog/ci/auto_instrument"
+
+    require "fileutils"
+    require "knapsack_pro"
+
+    expect(Datadog::CI).to receive(:start_test_session).never
+    expect(Datadog::CI).to receive(:start_test_module).never
+    expect(Datadog::CI).to receive(:start_test_suite).never
+    expect(Datadog::CI).to receive(:start_test).never
+
+    allow_any_instance_of(Datadog::Core::Remote::Negotiation).to(
+      receive(:endpoint?).with("/evp_proxy/v4/").and_return(true)
+    )
+
+    allow(Datadog::CI::Utils::TestRun).to receive(:command).and_return("knapsack:queue:rspec")
+
+    allow_any_instance_of(KnapsackPro::Runners::Queue::RSpecRunner).to receive(:test_file_paths).and_return(
+      ["./spec/datadog/ci/contrib/knapsack_rspec/suite_under_test/some_test_rspec.rb"],
+      []
+    )
+
+    # raise to prevent Knapsack from running Kernel.exit(0)
+    allow(KnapsackPro::Report).to receive(:save_node_queue_to_api).and_raise(ArgumentError)
+  end
+
+  it "instruments this rspec session" do
+    with_new_rspec_environment do
+      ClimateControl.modify(
+        "KNAPSACK_PRO_CI_NODE_BUILD_ID" => "144",
+        "KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" => "example_token",
+        "KNAPSACK_PRO_FIXED_QUEUE_SPLIT" => "true",
+        "KNAPSACK_PRO_QUEUE_ID" => nil
+      ) do
+        KnapsackPro::Adapters::RSpecAdapter.bind
+        KnapsackPro::Runners::Queue::RSpecRunner.run("", devnull, devnull)
+      rescue ArgumentError
+        # suppress invalid API key error
+      end
+    end
+
+    # test session and module traced
+    expect(test_session_span).not_to be_nil
+    expect(test_session_span).to have_test_tag(:framework, "rspec")
+    expect(test_session_span).to have_test_tag(:framework_version, integration.version.to_s)
+
+    expect(test_module_span).not_to be_nil
+
+    # test session and module are failed
+    expect([test_session_span, test_module_span]).to all have_fail_status
+
+    # single test suite span
+    expect(test_suite_spans).to have(1).item
+    expect(test_suite_spans.first).to have_test_tag(:status, Datadog::CI::Ext::Test::Status::FAIL)
+    expect(test_suite_spans.first).to have_test_tag(
+      :suite,
+      "SomeTest at ./spec/datadog/ci/contrib/knapsack_rspec/suite_under_test/some_test_rspec.rb"
+    )
+
+    # there is test span for every test case
+    expect(test_spans).to have(2).items
+    # test spans belong to a single test suite
+    expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 1)
+    expect(test_spans).to have_tag_values_no_order(
+      :status,
+      [Datadog::CI::Ext::Test::Status::FAIL, Datadog::CI::Ext::Test::Status::PASS]
+    )
+
+    # every test span is connected to test module and test session
+    expect(test_spans).to all have_test_tag(:test_module_id)
+    expect(test_spans).to all have_test_tag(:test_session_id)
+  end
+end

--- a/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe "Minitest auto instrumentation" do
+  include_context "CI mode activated" do
+    let(:integration_name) { :no_instrument }
+  end
+
+  before do
+    require_relative "../../../../../lib/datadog/ci/auto_instrument"
+
+    require "minitest"
+
+    class SomeTest < Minitest::Test
+      def test_pass
+        assert true
+      end
+
+      def test_pass_other
+        assert true
+      end
+    end
+
+    Minitest.run([])
+  end
+
+  it "instruments test session" do
+    expect(test_session_span).not_to be_nil
+    expect(test_module_span).not_to be_nil
+
+    expect(first_test_suite_span).not_to be_nil
+    expect(first_test_suite_span.name).to eq(
+      "SomeTest at spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb"
+    )
+
+    expect(test_spans).to have(2).items
+    expect(test_spans).to have_unique_tag_values_count(:test_session_id, 1)
+    expect(test_spans).to have_unique_tag_values_count(:test_module_id, 1)
+    expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 1)
+  end
+end


### PR DESCRIPTION
**What does this PR do?**
Allows Ruby test runs to be autoinstrumented without code changes (via RUBYOPT env variable or datadog-ci CLI).

Example using RUBYOPT:
`RUBYOPT="-rbundler/setup -rdatadog/ci/auto_instrument" bundle exec rake test`

Example using ddcirb CLI tool:
`bundle exec ddcirb exec bundle exec rake test`

**Motivation**
Easier onboarding

**How to test the change?**
There are integration tests provided, also tested using a number of open source projects' forks