### PR TITLE
[SDTEST-228] Send auto_injected: true to internal telemetry when auto instrumentation was used

### DIFF
--- a/lib/datadog/ci/auto_instrument.rb
+++ b/lib/datadog/ci/auto_instrument.rb
@@ -1,3 +1,8 @@
 require "datadog/ci"
 
+if RUBY_ENGINE == "jruby"
+  Datadog.logger.error("Auto instrumentation is not supported on JRuby. Please use manual instrumentation instead.")
+  return
+end
+
 Datadog::CI::Contrib::Instrumentation.auto_instrument

--- a/lib/datadog/ci/contrib/instrumentation.rb
+++ b/lib/datadog/ci/contrib/instrumentation.rb
@@ -9,6 +9,7 @@ module Datadog
         class InvalidIntegrationError < StandardError; end
 
         @registry = {}
+        @auto_instrumented = false
 
         def self.registry
           @registry
@@ -18,6 +19,10 @@ module Datadog
           @registry[integration_name(integration_class)] = integration_class.new
         end
 
+        def self.auto_instrumented?
+          @auto_instrumented
+        end
+
         # Auto instrumentation of all integrations.
         #
         # Registers a :script_compiled tracepoint to watch for new Ruby files being loaded.
@@ -25,6 +30,7 @@ module Datadog
         # Only the integrations that are available in the environment are checked.
         def self.auto_instrument
           Datadog.logger.debug("Auto instrumenting all integrations...")
+          @auto_instrumented = true
 
           auto_instrumented_integrations = fetch_auto_instrumented_integrations
           if auto_instrumented_integrations.empty?

--- a/lib/datadog/ci/test_visibility/telemetry.rb
+++ b/lib/datadog/ci/test_visibility/telemetry.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "../contrib/instrumentation"
 require_relative "../ext/app_types"
 require_relative "../ext/environment"
 require_relative "../ext/telemetry"
@@ -33,7 +34,7 @@ module Datadog
             Ext::Telemetry::METRIC_TEST_SESSION,
             1,
             {
-              Ext::Telemetry::TAG_AUTO_INJECTED => "false", # ruby doesn't support auto injection yet
+              Ext::Telemetry::TAG_AUTO_INJECTED => Contrib::Instrumentation.auto_instrumented?.to_s,
               Ext::Telemetry::TAG_PROVIDER => test_session.ci_provider || Ext::Telemetry::Provider::UNSUPPORTED
             }
           )

--- a/sig/datadog/ci/contrib/instrumentation.rbs
+++ b/sig/datadog/ci/contrib/instrumentation.rbs
@@ -7,11 +7,15 @@ module Datadog
 
         self.@registry: Hash[Symbol, untyped]
 
+        self.@auto_instrumented: bool
+
         self.@configure_once: Datadog::Core::Utils::OnlyOnce
 
         def self.registry: () -> Hash[Symbol, untyped]
 
         def self.auto_instrument: () -> void
+
+        def self.auto_instrumented?: () -> bool
 
         def self.instrument: (Symbol integration_name, ?::Hash[untyped, untyped] options) { (?) -> untyped } -> void
 

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -457,10 +457,7 @@ RSpec.describe "Minitest instrumentation" do
 
           # test_session metric has auto_injected false
           test_session_started_metric = telemetry_metric(:inc, "test_session")
-          expect(test_session_started_metric.tags).to eq(
-            "provider" => "unsupported",
-            "auto_injected" => "false"
-          )
+          expect(test_session_started_metric.tags["auto_injected"]).to eq("false")
         end
 
         it "creates a test module span" do

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -404,6 +404,8 @@ RSpec.describe "Minitest instrumentation" do
     end
 
     context "run minitest suite" do
+      include_context "Telemetry spy"
+
       before do
         Minitest.run([])
       end
@@ -452,6 +454,13 @@ RSpec.describe "Minitest instrumentation" do
           expect(test_session_span).to have_test_tag(:code_coverage_lines_pct)
 
           expect(test_session_span).to have_pass_status
+
+          # test_session metric has auto_injected false
+          test_session_started_metric = telemetry_metric(:inc, "test_session")
+          expect(test_session_started_metric.tags).to eq(
+            "provider" => "unsupported",
+            "auto_injected" => "false"
+          )
         end
 
         it "creates a test module span" do
@@ -486,7 +495,7 @@ RSpec.describe "Minitest instrumentation" do
             :source_file,
             "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
           )
-          expect(first_test_suite_span).to have_test_tag(:source_start, "417")
+          expect(first_test_suite_span).to have_test_tag(:source_start, "419")
           expect(first_test_suite_span).to have_test_tag(
             :codeowners,
             "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"

--- a/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe "Minitest auto instrumentation" do
   include_context "CI mode activated" do
     let(:integration_name) { :no_instrument }
   end
+  include_context "Telemetry spy"
 
   before do
     require_relative "../../../../../lib/datadog/ci/auto_instrument"
@@ -34,5 +35,12 @@ RSpec.describe "Minitest auto instrumentation" do
     expect(test_spans).to have_unique_tag_values_count(:test_session_id, 1)
     expect(test_spans).to have_unique_tag_values_count(:test_module_id, 1)
     expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 1)
+
+    # test_session metric has auto_injected tag
+    test_session_started_metric = telemetry_metric(:inc, "test_session")
+    expect(test_session_started_metric.tags).to eq(
+      "provider" => "unsupported",
+      "auto_injected" => "true"
+    )
   end
 end

--- a/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest_auto_instrument/instrumentation_spec.rb
@@ -38,9 +38,6 @@ RSpec.describe "Minitest auto instrumentation" do
 
     # test_session metric has auto_injected tag
     test_session_started_metric = telemetry_metric(:inc, "test_session")
-    expect(test_session_started_metric.tags).to eq(
-      "provider" => "unsupported",
-      "auto_injected" => "true"
-    )
+    expect(test_session_started_metric.tags["auto_injected"]).to eq("true")
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Adds a couple of small fixes to auto instrumentation:
- `test_session` telemetry metric has now auto_injected tag set to true when auto instrumentation was used
- when auto instrumentation is used on JRuby, we print error message and bail out of instrumenting tests
