### PR TITLE
[SDTEST-1229] Skip before(:all) context hooks when all examples are skipped

### DIFF
--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -39,7 +39,7 @@ module Datadog
                   },
                   service: datadog_configuration[:service_name]
                 ) do |test_span|
-                  test_span&.itr_unskippable! if metadata[CI::Ext::Test::ITR_UNSKIPPABLE_OPTION]
+                  test_span&.itr_unskippable! if datadog_unskippable?
 
                   metadata[:skip] = CI::Ext::Test::ITR_TEST_SKIP_REASON if test_span&.skipped_by_itr?
 
@@ -149,6 +149,10 @@ module Datadog
               @datadog_test_parameters = Utils::TestRun.test_parameters(
                 metadata: {"scoped_id" => metadata[:scoped_id]}
               )
+            end
+
+            def datadog_unskippable?
+              !!metadata[CI::Ext::Test::ITR_UNSKIPPABLE_OPTION]
             end
 
             def test_visibility_component

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -89,6 +89,18 @@ module Datadog
               super(::RSpec::Core::NullReporter)
             end
 
+            def datadog_test_id
+              @datadog_test_id ||= Utils::TestRun.datadog_test_id(
+                datadog_test_name,
+                datadog_test_suite_name,
+                datadog_test_parameters
+              )
+            end
+
+            def datadog_unskippable?
+              !!metadata[CI::Ext::Test::ITR_UNSKIPPABLE_OPTION]
+            end
+
             private
 
             def fetch_top_level_example_group
@@ -149,10 +161,6 @@ module Datadog
               @datadog_test_parameters = Utils::TestRun.test_parameters(
                 metadata: {"scoped_id" => metadata[:scoped_id]}
               )
-            end
-
-            def datadog_unskippable?
-              !!metadata[CI::Ext::Test::ITR_UNSKIPPABLE_OPTION]
             end
 
             def test_visibility_component

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -21,38 +21,21 @@ module Datadog
               return super if ::RSpec.configuration.dry_run? && !datadog_configuration[:dry_run_enabled]
               return super unless datadog_configuration[:enabled]
 
-              test_name = full_description.strip
-              if metadata[:description].empty?
-                # for unnamed it blocks this appends something like "example at ./spec/some_spec.rb:10"
-                test_name << " #{description}"
-              end
-
-              test_suite_description = fetch_top_level_example_group[:description]
-              suite_name = "#{test_suite_description} at #{metadata[:example_group][:rerun_file_path]}"
-
-              # remove example group description from test name to avoid duplication
-              test_name = test_name.sub(test_suite_description, "").strip
-
-              if ci_queue?
-                suite_name = "#{suite_name} (ci-queue running example [#{test_name}])"
-                ci_queue_test_span = test_visibility_component.start_test_suite(suite_name)
-              end
+              test_suite_span = test_visibility_component.start_test_suite(datadog_test_suite_name) if ci_queue?
 
               # don't report test to RSpec::Core::Reporter until retries are done
               @skip_reporting = true
 
               test_retries_component.with_retries do
                 test_visibility_component.trace_test(
-                  test_name,
-                  suite_name,
+                  datadog_test_name,
+                  datadog_test_suite_name,
                   tags: {
                     CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                     CI::Ext::Test::TAG_FRAMEWORK_VERSION => datadog_integration.version.to_s,
                     CI::Ext::Test::TAG_SOURCE_FILE => Git::LocalRepository.relative_to_root(metadata[:file_path]),
                     CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s,
-                    CI::Ext::Test::TAG_PARAMETERS => Utils::TestRun.test_parameters(
-                      metadata: {"scoped_id" => metadata[:scoped_id]}
-                    )
+                    CI::Ext::Test::TAG_PARAMETERS => datadog_test_parameters
                   },
                   service: datadog_configuration[:service_name]
                 ) do |test_span|
@@ -87,8 +70,8 @@ module Datadog
                 end
               end
 
-              # this is a special case for ci-queue, we need to finish the test suite span
-              ci_queue_test_span&.finish
+              # this is a special case for ci-queue, we need to finish the test suite span created for a single test
+              test_suite_span&.finish
 
               # after retries are done, we can finally report the test to RSpec
               @skip_reporting = false
@@ -127,6 +110,45 @@ module Datadog
 
             def datadog_configuration
               Datadog.configuration.ci[:rspec]
+            end
+
+            def datadog_test_suite_description
+              @datadog_test_suite_description ||= fetch_top_level_example_group[:description]
+            end
+
+            def datadog_test_name
+              return @datadog_test_name if defined?(@datadog_test_name)
+
+              test_name = full_description.strip
+              if metadata[:description].empty?
+                # for unnamed it blocks this appends something like "example at ./spec/some_spec.rb:10"
+                test_name << " #{description}"
+              end
+
+              # remove example group description from test name to avoid duplication
+              test_name = test_name.sub(datadog_test_suite_description, "").strip
+
+              @datadog_test_name = test_name
+            end
+
+            def datadog_test_suite_name
+              return @datadog_test_suite_name if defined?(@datadog_test_suite_name)
+
+              suite_name = "#{datadog_test_suite_description} at #{metadata[:example_group][:rerun_file_path]}"
+
+              if ci_queue?
+                suite_name = "#{suite_name} (ci-queue running example [#{datadog_test_name}])"
+              end
+
+              @datadog_test_suite_name = suite_name
+            end
+
+            def datadog_test_parameters
+              return @datadog_test_parameters if defined?(@datadog_test_parameters)
+
+              @datadog_test_parameters = Utils::TestRun.test_parameters(
+                metadata: {"scoped_id" => metadata[:scoped_id]}
+              )
             end
 
             def test_visibility_component

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -29,6 +29,9 @@ module Datadog
                 }
               )
 
+              # try skipping the whole example group
+              metadata[:skip] = true
+
               success = super
               return success unless test_suite
 

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -30,7 +30,10 @@ module Datadog
               )
 
               # try skipping the whole example group
-              metadata[:skip] = true
+              # all_skipped = descendant_filtered_examples.all? do |example|
+              # end
+              all_skipped = false
+              metadata[:skip] = true if all_skipped
 
               success = super
               return success unless test_suite

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -17,6 +17,11 @@ module Datadog
         get_tag(Ext::Test::TAG_NAME)
       end
 
+      # @return [String] the test id according to Datadog's test impact analysis.
+      def datadog_test_id
+        @datadog_test_id ||= Utils::TestRun.datadog_test_id(name, test_suite_name, parameters)
+      end
+
       # Finishes the current test.
       # @return [void]
       def finish
@@ -140,22 +145,18 @@ module Datadog
 
       # @internal
       def any_retry_passed?
-        !!test_suite&.any_test_retry_passed?(test_id)
+        !!test_suite&.any_test_retry_passed?(datadog_test_id)
       end
 
       private
 
-      def test_id
-        @test_id ||= Utils::TestRun.datadog_test_id(name, test_suite_name, parameters)
-      end
-
       def record_test_result(datadog_status)
         # if this test was already executed in this test suite, mark it as retried
-        if test_suite&.test_executed?(test_id)
+        if test_suite&.test_executed?(datadog_test_id)
           set_tag(Ext::Test::TAG_IS_RETRY, "true")
         end
 
-        test_suite&.record_test_result(test_id, datadog_status)
+        test_suite&.record_test_result(datadog_test_id, datadog_status)
       end
     end
   end

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -144,11 +144,16 @@ module Datadog
           event
         end
 
+        def skippable?(test)
+          return false if !enabled? || !skipping_tests?
+
+          @skippable_tests.include?(test.datadog_test_id)
+        end
+
         def mark_if_skippable(test)
           return if !enabled? || !skipping_tests?
 
-          datadog_test_id = Utils::TestRun.datadog_test_id(test.name, test.test_suite_name, test.parameters)
-          if @skippable_tests.include?(datadog_test_id)
+          if skippable?(test)
             if forked?
               Datadog.logger.warn { "Intelligent test runner is not supported for forking test runners yet" }
               return
@@ -156,9 +161,9 @@ module Datadog
 
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
 
-            Datadog.logger.debug { "Marked test as skippable: #{datadog_test_id}" }
+            Datadog.logger.debug { "Marked test as skippable: #{test.datadog_test_id}" }
           else
-            Datadog.logger.debug { "Test is not skippable: #{datadog_test_id}" }
+            Datadog.logger.debug { "Test is not skippable: #{test.datadog_test_id}" }
           end
         end
 

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -9,11 +9,15 @@ module Datadog
 
             @datadog_test_suite_description: String
 
+            @datadog_test_id: String
             @datadog_test_name: String
             @datadog_test_suite_name: String
             @datadog_test_parameters: String
 
             def run: (untyped example_group_instance, untyped reporter) -> untyped
+
+            def datadog_test_id: () -> String
+            def datadog_unskippable?: () -> bool
 
             private
 
@@ -28,7 +32,6 @@ module Datadog
             def datadog_test_name: () -> String
             def datadog_test_suite_name: () -> String
             def datadog_test_parameters: () -> String
-            def datadog_unskippable?: () -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -28,6 +28,7 @@ module Datadog
             def datadog_test_name: () -> String
             def datadog_test_suite_name: () -> String
             def datadog_test_parameters: () -> String
+            def datadog_unskippable?: () -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -7,6 +7,12 @@ module Datadog
           module InstanceMethods : ::RSpec::Core::Example
             @skip_reporting: bool
 
+            @datadog_test_suite_description: String
+
+            @datadog_test_name: String
+            @datadog_test_suite_name: String
+            @datadog_test_parameters: String
+
             def run: (untyped example_group_instance, untyped reporter) -> untyped
 
             private
@@ -17,6 +23,11 @@ module Datadog
             def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
             def test_retries_component: () -> Datadog::CI::TestRetries::Component
             def ci_queue?: () -> bool
+
+            def datadog_test_suite_description: () -> String
+            def datadog_test_name: () -> String
+            def datadog_test_suite_name: () -> String
+            def datadog_test_parameters: () -> String
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -12,9 +12,13 @@ module Datadog
 
             private
 
+            def all_examples_skipped_by_datadog?: () -> bool
+
             def datadog_configuration: () -> untyped
 
-            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component
+            def test_visibility_component: () -> Datadog::CI::TestVisibility::Component?
+
+            def test_optimisation_component: () -> Datadog::CI::TestOptimisation::Component?
           end
         end
       end

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -1,8 +1,9 @@
 module Datadog
   module CI
     class Test < Span
-      @test_id: String
+      @datadog_test_id: String
 
+      def datadog_test_id: () -> String
       def finish: () -> void
       def test_suite: () -> Datadog::CI::TestSuite?
       def test_suite_id: () -> String?
@@ -17,7 +18,6 @@ module Datadog
 
       private
 
-      def test_id: () -> String
       def record_test_result: (String datadog_status) -> void
     end
   end

--- a/sig/datadog/ci/test_optimisation/component.rbs
+++ b/sig/datadog/ci/test_optimisation/component.rbs
@@ -45,6 +45,8 @@ module Datadog
 
         def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::TestOptimisation::Coverage::Event?
 
+        def skippable?: (Datadog::CI::Test test) -> bool
+
         def mark_if_skippable: (Datadog::CI::Test test) -> void
 
         def count_skipped_test: (Datadog::CI::Test test) -> void

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -757,6 +757,12 @@ RSpec.describe "RSpec instrumentation" do
         expect(itr_skipped_test).to have_test_tag(:itr_skipped_by_itr, "true")
       end
 
+      it "runs context hooks" do
+        rspec_session_run(with_failed_test: true)
+
+        expect(before_all_spy).to have_received(:call)
+      end
+
       it "sends test session level tags" do
         rspec_session_run(with_failed_test: true)
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -818,6 +818,20 @@ RSpec.describe "RSpec instrumentation" do
         expect(before_context_spy).not_to have_received(:call)
       end
 
+      it "runs top-level hook when there is a test not skipped by datadog, but it skips hooks for the context where all tests are skipped" do
+        rspec_session_run(with_failed_test: true, with_test_outside_context: true)
+
+        expect(before_all_spy).to have_received(:call)
+        expect(before_context_spy).not_to have_received(:call)
+      end
+
+      it "runs context hook if any test is marked unskippable" do
+        rspec_session_run(with_failed_test: true, unskippable: {test: true})
+
+        expect(before_all_spy).to have_received(:call)
+        expect(before_context_spy).to have_received(:call)
+      end
+
       context "but some tests are unskippable" do
         context "when a test is unskippable" do
           it "runs the test and adds forced run tag" do

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -209,9 +209,9 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
       end
 
       context "when chunking is used" do
-        # one test event is approximately 1000 bytes currently
+        # one test event is approximately 1200 bytes currently
         # ATTENTION: might break if more data is added to test spans in #produce_test_trace method
-        let(:max_payload_size) { 2000 }
+        let(:max_payload_size) { 2500 }
 
         it "sends events in two chunks" do
           responses = subject

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -46,6 +46,7 @@ module RSpec::Core::ExampleGroup
     def file_path: () -> String
     def description: () -> String
     def metadata: () -> untyped
+    def descendant_filtered_examples: () -> Array[untyped]
   end
 end
 


### PR DESCRIPTION
**What does this PR do?**
Closes #256

Improves handling of RSpec context hooks when tests are skipped by test impact analysis: now we will skip context hooks if we know that all examples in the context are going to be skipped by Datadog.

**Motivation**
See #256

**Additional Notes**
This PR doesn't address another limitation of context hooks with test impact analysis: when we collect impacted files for test (aka per test code coverage), we don't cover context hooks (because they cannot be attributed to any single test). This can lead to skipping tests that should not be skipped. I reprioritised the issue with context hooks coverage higher because there is new evidence that context hooks are being used by our customers.

**How to test the change?**
Unit tests are provided