### PR TITLE
Pin ubuntu 22.04

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null
     steps:
       - name: Checkout code

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -23,7 +23,7 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
@@ -107,7 +107,7 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Test gem
     needs:
       - build
@@ -132,7 +132,7 @@ jobs:
       matrix:
         type:
           - dev
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Push gem
     needs:
       - test

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/datadog-sca.yml
+++ b/.github/workflows/datadog-sca.yml
@@ -4,7 +4,7 @@ name: Datadog Software Composition Analysis
 
 jobs:
   software-composition-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Datadog SBOM Generation and Upload
     steps:
       - name: Checkout

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ name: Datadog Static Analysis
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Datadog Static Analyzer
     steps:
       - name: Checkout

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build_and_run_integration_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         ruby_image:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       contents: write

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -24,7 +24,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
**Motivation:**

https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/#ubuntu-latest-upcoming-breaking-changes

>We will migrate the ubuntu-latest label to ubuntu 24 starting on December 5, 2024 and ending on January 17, 2025. The ubuntu 24 image has a different set of tools and packages than ubuntu 22. We have made cuts to the list of packages so that we can maintain our SLA for free disk space. This may break your workflows if you depend on certain packages that have been removed. Please review this [list](https://github.com/actions/runner-images/issues/10636) to see if you are using any affected packages.

**What does this PR do?**

Pin to ubuntu 22 instead of `latest`