### PR TITLE
[SDTEST-1304] Fix inline comments handling when parsing CODEOWNERS files

### DIFF
--- a/lib/datadog/ci/codeowners/matcher.rb
+++ b/lib/datadog/ci/codeowners/matcher.rb
@@ -42,7 +42,7 @@ module Datadog
 
           File.open(codeowners_file_path, "r") do |f|
             f.each_line do |line|
-              line.strip!
+              line.strip!&.sub!(/#.*$/, "")
 
               next if line.empty?
               next if comment?(line)

--- a/spec/datadog/ci/codeowners/matcher_spec.rb
+++ b/spec/datadog/ci/codeowners/matcher_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Datadog::CI::Codeowners::Matcher do
           <<-CODEOWNERS
             # Comment line
             /path/to/*.rb @owner3
-            /path/to/file.rb @owner1 @owner2
+            /path/to/file.rb @owner1 @owner2 #This is an inline comment.
           CODEOWNERS
         end
 


### PR DESCRIPTION
**What does this PR do?**

Fixes a bug with handling of inline comments in CODEOWNERS:
```
/path/to/file.rb @owner1 @owner2 #This is an inline comment.
```

Before this fix it produced the following list of owners:
```ruby
["@owner1", "@owner2", "#This", "is", "an", "inline", "comment."]
```

After the fix:
```ruby
["@owner1", "@owner2"]
```


**How to test the change?**
Unit tests