### PR TITLE
[SDTEST-1245] Internal: send _dd.test.is_user_provided_service tag to track if test_service is configured

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -74,6 +74,9 @@ module Datadog
         # common tags that are serialized directly in msgpack header in metadata field
         METADATA_TAG_TEST_SESSION_NAME = "test_session.name"
 
+        # internal tag indicating if datadog service was configured by the user
+        TAG_USER_PROVIDED_TEST_SERVICE = "_dd.test.is_user_provided_service"
+
         # internal metric with the number of virtual CPUs
         METRIC_CPU_COUNT = "_dd.host.vcpu_count"
 

--- a/lib/datadog/ci/test_visibility/context.rb
+++ b/lib/datadog/ci/test_visibility/context.rb
@@ -11,6 +11,7 @@ require_relative "../ext/app_types"
 require_relative "../ext/environment"
 require_relative "../ext/test"
 
+require_relative "../utils/configuration"
 require_relative "../utils/test_run"
 
 require_relative "../span"
@@ -207,6 +208,10 @@ module Datadog
           ci_span.set_tags(@environment_tags)
 
           ci_span.set_metric(Ext::Test::METRIC_CPU_COUNT, Utils::TestRun.virtual_cpu_count)
+          ci_span.set_tag(
+            Ext::Test::TAG_USER_PROVIDED_TEST_SERVICE,
+            Utils::Configuration.service_name_provided_by_user?.to_s
+          )
         end
 
         # PROPAGATING CONTEXT FROM TOP-LEVEL TO THE LOWER LEVELS

--- a/lib/datadog/ci/utils/configuration.rb
+++ b/lib/datadog/ci/utils/configuration.rb
@@ -9,6 +9,10 @@ module Datadog
         def self.fetch_service_name(default)
           Datadog.configuration.service_without_fallback || CI::Git::LocalRepository.repository_name || default
         end
+
+        def self.service_name_provided_by_user?
+          !!Datadog.configuration.service_without_fallback
+        end
       end
     end
   end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -98,6 +98,8 @@ module Datadog
 
         METADATA_TAG_TEST_SESSION_NAME: "test_session.name"
 
+        TAG_USER_PROVIDED_TEST_SERVICE: "_dd.test.is_user_provided_service"
+
         METRIC_CPU_COUNT: "_dd.host.vcpu_count"
 
         TAG_CODE_COVERAGE_LINES_PCT: "test.code_coverage.lines_pct"

--- a/sig/datadog/ci/utils/configuration.rbs
+++ b/sig/datadog/ci/utils/configuration.rbs
@@ -3,6 +3,8 @@ module Datadog
     module Utils
       module Configuration
         def self.fetch_service_name: (String default) -> String
+
+        def self.service_name_provided_by_user?: () -> bool
       end
     end
   end

--- a/spec/datadog/ci/utils/configuration_spec.rb
+++ b/spec/datadog/ci/utils/configuration_spec.rb
@@ -38,4 +38,24 @@ RSpec.describe ::Datadog::CI::Utils::Configuration do
       end
     end
   end
+
+  describe ".service_name_provided_by_user?" do
+    subject { described_class.service_name_provided_by_user? }
+
+    before do
+      allow(::Datadog.configuration).to receive(:service_without_fallback).and_return(service)
+    end
+
+    context "when service is set in Datadog config" do
+      let(:service) { "service_without_fallback" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when service is not set" do
+      let(:service) { nil }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/support/contexts/ci_mode.rb
+++ b/spec/support/contexts/ci_mode.rb
@@ -13,6 +13,7 @@ require_relative "../coverage_helpers"
 RSpec.shared_context "CI mode activated" do
   include CoverageHelpers
 
+  let(:service_name) { nil }
   let(:test_command) { "command" }
   let(:logical_test_session_name) { nil }
   let(:integration_name) { :no_instrument }
@@ -109,6 +110,10 @@ RSpec.shared_context "CI mode activated" do
     allow_any_instance_of(Datadog::CI::TestRetries::UniqueTestsClient).to receive(:fetch_unique_tests).and_return(unique_tests_set)
 
     Datadog.configure do |c|
+      if service_name
+        c.service = service_name
+      end
+
       # library switch
       c.ci.enabled = ci_enabled
 


### PR DESCRIPTION
**What does this PR do?**
Sends _dd.test.is_user_provided_service tag for all spans: true if user has configured test_service, false if we send default value

**Motivation**
Internal accounting

**How to test the change?**
Unit tests are provided