### PR TITLE
[SDTEST-1375] Use logical test session name as part of test session span's resource instead of test command

### DIFF
--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -25,7 +25,7 @@ module Datadog
       # Return the test session's name which is equal to test command used
       # @return [String] the command for this test session.
       def name
-        get_tag(Ext::Test::TAG_COMMAND)
+        test_visibility.logical_test_session_name || "test_session"
       end
 
       # Return the test session's command used to run the tests

--- a/lib/datadog/ci/test_visibility/serializers/base.rb
+++ b/lib/datadog/ci/test_visibility/serializers/base.rb
@@ -238,6 +238,10 @@ module Datadog
           def to_integer(value)
             value&.to_i
           end
+
+          def test_visibility
+            @test_visibility ||= Datadog::CI.send(:test_visibility)
+          end
         end
       end
     end

--- a/lib/datadog/ci/test_visibility/serializers/test_session.rb
+++ b/lib/datadog/ci/test_visibility/serializers/test_session.rb
@@ -31,7 +31,7 @@ module Datadog
           end
 
           def resource
-            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_session.#{@span.get_tag(Ext::Test::TAG_COMMAND)}"
+            "#{@span.get_tag(Ext::Test::TAG_FRAMEWORK)}.test_session.#{test_visibility.logical_test_session_name}"
           end
 
           private

--- a/sig/datadog/ci/test_visibility/serializers/base.rbs
+++ b/sig/datadog/ci/test_visibility/serializers/base.rbs
@@ -93,6 +93,8 @@ module Datadog
           def to_integer: (String? value) -> Integer?
 
           def content_fields_count: () -> Integer
+
+          def test_visibility: () -> Datadog::CI::TestVisibility::Component
         end
       end
     end

--- a/spec/datadog/ci/test_session_spec.rb
+++ b/spec/datadog/ci/test_session_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Datadog::CI::TestSession do
   let(:tracer_span) { Datadog::Tracing::SpanOperation.new("session") }
-  let(:test_visibility) { spy("test_visibility") }
+  let(:test_visibility) { spy("test_visibility", logical_test_session_name: "my_test_session") }
 
   before { allow_any_instance_of(described_class).to receive(:test_visibility).and_return(test_visibility) }
   subject(:ci_test_session) { described_class.new(tracer_span) }
@@ -36,11 +36,7 @@ RSpec.describe Datadog::CI::TestSession do
   describe "#name" do
     subject(:name) { ci_test_session.name }
 
-    before do
-      tracer_span.set_tag(Datadog::CI::Ext::Test::TAG_COMMAND, "test command")
-    end
-
-    it { is_expected.to eq("test command") }
+    it { is_expected.to eq("my_test_session") }
   end
 
   describe "#test_command" do

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
 
         it "returns a new CI test_session span" do
           expect(subject).to be_kind_of(Datadog::CI::TestSession)
-          expect(subject.name).to eq(test_command)
+          expect(subject.name).to eq(test_visibility.logical_test_session_name)
           expect(subject.service).to eq(service)
           expect(subject.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
         end

--- a/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
         produce_test_session_trace
       end
 
+      let(:logical_test_session_name) { "logical_test_session_name" }
+      before do
+        expect_any_instance_of(Datadog::CI::TestVisibility::Component).to(
+          receive(:logical_test_session_name).and_return(logical_test_session_name)
+        )
+      end
+
       it "serializes test event to messagepack" do
         expect_event_header(type: Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION)
 
@@ -22,7 +29,7 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
             "name" => "rspec.test_session",
             "service" => "rspec-test-suite",
             "type" => Datadog::CI::Ext::AppTypes::TYPE_TEST_SESSION,
-            "resource" => "rspec.test_session.#{test_command}"
+            "resource" => "rspec.test_session.#{logical_test_session_name}"
           }
         )
 
@@ -37,23 +44,6 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
         )
 
         expect(meta["_test.session_id"]).to be_nil
-      end
-
-      context "logical test session name is provided" do
-        let(:logical_test_session_name) { "logical_test_session_name" }
-        before do
-          expect_any_instance_of(Datadog::CI::TestVisibility::Component).to(
-            receive(:logical_test_session_name).and_return(logical_test_session_name)
-          )
-        end
-
-        it "uses logical test session name as part of span's resource instead of command" do
-          expect(content).to include(
-            {
-              "resource" => "rspec.test_session.#{logical_test_session_name}"
-            }
-          )
-        end
       end
     end
 

--- a/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
+++ b/spec/datadog/ci/test_visibility/serializers/test_session_spec.rb
@@ -38,6 +38,23 @@ RSpec.describe Datadog::CI::TestVisibility::Serializers::TestSession do
 
         expect(meta["_test.session_id"]).to be_nil
       end
+
+      context "logical test session name is provided" do
+        let(:logical_test_session_name) { "logical_test_session_name" }
+        before do
+          expect_any_instance_of(Datadog::CI::TestVisibility::Component).to(
+            receive(:logical_test_session_name).and_return(logical_test_session_name)
+          )
+        end
+
+        it "uses logical test session name as part of span's resource instead of command" do
+          expect(content).to include(
+            {
+              "resource" => "rspec.test_session.#{logical_test_session_name}"
+            }
+          )
+        end
+      end
     end
 
     context "trace a failed test" do


### PR DESCRIPTION
**What does this PR do?**
Previously we used test command as part of span resource name (we show it in the trace view). 

It would be more correct to use logical test session name for this purpose: it can be configured by the user with DD_TEST_SESSION_NAME env variable. By default, it is constructed from CI job name + test command.

Note: this doesn't change the test session's fingerprint, only the presentation in trace view

**Motivation**
Step by step prepare to the future use of DD_TEST_SESSION_NAME as a logical name for test sessions

**How to test the change?**
Unit tests are provided