### PR TITLE
[SDTEST-1376] set the max payload size for events to 4.5MB

### DIFF
--- a/lib/datadog/ci/transport/event_platform_transport.rb
+++ b/lib/datadog/ci/transport/event_platform_transport.rb
@@ -11,7 +11,7 @@ module Datadog
   module CI
     module Transport
       class EventPlatformTransport
-        DEFAULT_MAX_PAYLOAD_SIZE = 4 * 1024 * 1024
+        DEFAULT_MAX_PAYLOAD_SIZE = 4.5 * 1024 * 1024
 
         attr_reader :api,
           :max_payload_size

--- a/lib/datadog/ci/transport/event_platform_transport.rb
+++ b/lib/datadog/ci/transport/event_platform_transport.rb
@@ -11,7 +11,7 @@ module Datadog
   module CI
     module Transport
       class EventPlatformTransport
-        DEFAULT_MAX_PAYLOAD_SIZE = 5 * 1024 * 1024
+        DEFAULT_MAX_PAYLOAD_SIZE = 4 * 1024 * 1024
 
         attr_reader :api,
           :max_payload_size

--- a/sig/datadog/ci/transport/event_platform_transport.rbs
+++ b/sig/datadog/ci/transport/event_platform_transport.rbs
@@ -2,15 +2,15 @@ module Datadog
   module CI
     module Transport
       class EventPlatformTransport
-        DEFAULT_MAX_PAYLOAD_SIZE: Integer
+        DEFAULT_MAX_PAYLOAD_SIZE: Numeric
 
         attr_reader api: Datadog::CI::Transport::Api::Base
-        attr_reader max_payload_size: Integer
+        attr_reader max_payload_size: Numeric
 
         @api: Datadog::CI::Transport::Api::Base
-        @max_payload_size: Integer
+        @max_payload_size: Numeric
 
-        def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Integer) -> void
+        def initialize: (api: Datadog::CI::Transport::Api::Base, ?max_payload_size: Numeric) -> void
 
         def send_events: (Array[untyped] events) -> ::Array[Datadog::CI::Transport::Adapters::Net::Response]
 


### PR DESCRIPTION
**What does this PR do?**

Decreases the max payload size for events (test visibility and test impact analysis) to 4.5MB.

Maximal event size for Datadog intake is 5MB but we need to leave some buffer for package headers.

**Motivation**
Elevated rate of 413 (Request entity too large) errors seen in internal telemetry for Ruby library

**How to test the change?**
Not needed