### PR TITLE
Bump maximum ruby version to 3.5

### DIFF
--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -22,7 +22,7 @@ module Datadog
       # To allow testing with the next unreleased version of Ruby, the version check is performed
       # as `< #{MAXIMUM_RUBY_VERSION}`, meaning prereleases of MAXIMUM_RUBY_VERSION are allowed
       # but not stable MAXIMUM_RUBY_VERSION releases.
-      MAXIMUM_RUBY_VERSION = "3.4"
+      MAXIMUM_RUBY_VERSION = "3.5"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
Changes the MAXIMUM_RUBY_VERSION from 3.4 to 3.5

**Motivation**
<!-- What inspired you to submit this pull request? -->
There's an issue asking for Ruby 3.4 to be supported. I'm curious if tests pass with this change.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->
Full regression testing