### PR TITLE
[NOTICKET-1] bump maximum Ruby version to 3.5

### DIFF
--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -22,7 +22,7 @@ module Datadog
       # To allow testing with the next unreleased version of Ruby, the version check is performed
       # as `< #{MAXIMUM_RUBY_VERSION}`, meaning prereleases of MAXIMUM_RUBY_VERSION are allowed
       # but not stable MAXIMUM_RUBY_VERSION releases.
-      MAXIMUM_RUBY_VERSION = "3.4"
+      MAXIMUM_RUBY_VERSION = "3.5"
     end
   end
 end


### PR DESCRIPTION
**What does this PR do?**
Bumps maximum Ruby version to 3.5

Closes https://github.com/DataDog/datadog-ci-rb/issues/273

**Motivation**
Ruby 3.4 is released

**How to test the change?**
Ruby 3.4 is tested by unit tests since some time