### PR TITLE
[NOTICKET-1] Bump to version 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+## [1.11.0] - 2025-01-02
+
+### Changed
+
+* bump maximum Ruby version to 3.4 ([#275][])
+* Use logical test session name as part of test session span's resource instead of test command ([#271][])
+
+### Fixed
+
+* set the max payload size for events to 4.5MB ([#272][])
+* Fix inline comments handling when parsing CODEOWNERS files ([#267][])
+
 ## [1.10.0] - 2024-12-05
 
 ### Added
@@ -368,7 +380,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.10.0...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.11.0...main
+[1.11.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.8.1...v1.9.0
 [1.8.1]: https://github.com/DataDog/datadog-ci-rb/compare/v1.8.0...v1.8.1
@@ -530,3 +543,7 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#250]: https://github.com/DataDog/datadog-ci-rb/issues/250
 [#259]: https://github.com/DataDog/datadog-ci-rb/issues/259
 [#262]: https://github.com/DataDog/datadog-ci-rb/issues/262
+[#267]: https://github.com/DataDog/datadog-ci-rb/issues/267
+[#271]: https://github.com/DataDog/datadog-ci-rb/issues/271
+[#272]: https://github.com/DataDog/datadog-ci-rb/issues/272
+[#275]: https://github.com/DataDog/datadog-ci-rb/issues/275

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.10.0)
+    datadog-ci (1.11.0)
       datadog (~> 2.4)
       msgpack
 

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,7 +4,7 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 10
+      MINOR = 11
       PATCH = 0
       PRE = nil
       BUILD = nil


### PR DESCRIPTION
### Changed

* bump maximum Ruby version to 3.5 (#275)
* Use logical test session name as part of test session span's resource instead of test command (#271)

### Fixed

* set the max payload size for events to 4.5MB (#272)
* Fix inline comments handling when parsing CODEOWNERS files (#267)

