### PR TITLE
[NOTICKET-1] use released Ruby 3.4.1 for memory leaks check

### DIFF
--- a/.github/workflows/test-memory-leaks.yml
+++ b/.github/workflows/test-memory-leaks.yml
@@ -7,9 +7,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.0-preview1 # TODO: Use stable version once 3.4 is out
+          ruby-version: 3.4.1
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
-          cache-version: v1 # bump this to invalidate cache
+          cache-version: v2 # bump this to invalidate cache
       - run: sudo apt-get update && (sudo apt-get install -y valgrind || sleep 5 && sudo apt-get install -y valgrind) && valgrind --version
       - run: bundle exec rake compile spec:ddcov_memcheck


### PR DESCRIPTION
**What does this PR do?**
Fixes previously failing test-memcheck job by using released Ruby version 3.4.1 instead of Ruby 3.4.0-preview

**Motivation**
CI started to fail

**How to test the change?**
CI is green