### PR TITLE
[SDTEST-1408] test that MAXIMUM_RUBY_VERSION is same for datadog and datadog-ci gems

### DIFF
--- a/spec/datadog/ci/release_gem_spec.rb
+++ b/spec/datadog/ci/release_gem_spec.rb
@@ -1,5 +1,14 @@
 RSpec.describe "gem release process" do
   context "datadog-ci.gemspec" do
+    context "maximum Ruby version" do
+      it "is the same as for gem datadog" do
+        datadog_version = ::Datadog::VERSION::MAXIMUM_RUBY_VERSION
+        datadog_ci_version = ::Datadog::CI::VERSION::MAXIMUM_RUBY_VERSION
+
+        expect(datadog_ci_version).to eq(datadog_version)
+      end
+    end
+
     context "files" do
       subject(:files) { Gem::Specification.load("datadog-ci.gemspec").files }
 


### PR DESCRIPTION
**What does this PR do?**
Tests that MAXIMUM_RUBY_VERSION is same for datadog and datadog-ci gems so that we don't forget to bump it for both of them.

**Motivation**
See issue https://github.com/DataDog/datadog-ci-rb/issues/273

**How to test the change?**
This is a unit test