### PR TITLE
[SDTEST-1410] bump CI dependencies: Ruby 3.4, Ubuntu 24.04

### DIFF
--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -9,7 +9,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.event.pull_request.merged == true && github.event.pull_request.milestone == null
     steps:
       - name: Checkout code

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -23,14 +23,14 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Patch version
         if: ${{ matrix.type != 'final' }}
@@ -107,7 +107,7 @@ jobs:
         type:
           - final
           - dev
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Test gem
     needs:
       - build
@@ -122,7 +122,7 @@ jobs:
           find pkg
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - name: Install gem
         run: |
           gem install pkg/*.gem
@@ -132,7 +132,7 @@ jobs:
       matrix:
         type:
           - dev
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Push gem
     needs:
       - test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,24 +8,24 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - name: Install dependencies
         run: bundle install
       - run: bundle exec standardrb
 
   typecheck:
     name: Type checking
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Check for stale signature files
         run: bundle exec rake rbs:stale

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -4,7 +4,7 @@ name: Datadog Static Analysis
 
 jobs:
   static-analysis:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Datadog Static Analyzer
     steps:
       - name: Checkout

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,13 +5,15 @@ on:
 
 jobs:
   build_and_run_integration_test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         ruby_image:
           - ruby:3.0
           - ruby:3.1
           - ruby:3.2
+          - ruby:3.3
+          - ruby:3.4
     steps:
       - name: Checkout datadog-ci
         uses: actions/checkout@v4

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,6 @@ jobs:
           - ruby:3.1
           - ruby:3.2
           - ruby:3.3
-          - ruby:3.4
     steps:
       - name: Checkout datadog-ci
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write
@@ -21,5 +21,5 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: '3.3'
+          ruby-version: '3.4'
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/test-memory-leaks.yml
+++ b/.github/workflows/test-memory-leaks.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4.1
+          ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           bundler: latest
           cache-version: v2 # bump this to invalidate cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: "${{ github.ref != 'refs/heads/master' }}"
 jobs:
   compute_tasks:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -67,7 +67,7 @@ jobs:
     name: 'ruby-3.4: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +90,7 @@ jobs:
     name: 'ruby-3.3: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -113,7 +113,7 @@ jobs:
     name: 'ruby-3.2: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -136,7 +136,7 @@ jobs:
     name: 'ruby-3.1: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -159,7 +159,7 @@ jobs:
     name: 'ruby-3.0: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -182,7 +182,7 @@ jobs:
     name: 'ruby-2.7: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -205,7 +205,7 @@ jobs:
     name: 'jruby-9.4: ${{ matrix.task }} (${{ matrix.group }})'
     needs:
     - compute_tasks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -24,13 +24,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true
       - name: Generate YARD documentation
         run: bundle exec rake docs

--- a/tasks/github.rake
+++ b/tasks/github.rake
@@ -7,7 +7,7 @@ require_relative 'appraisal_conversion'
 namespace :github do
   namespace :actions do
     task :test_template do |t|
-      ubuntu = "ubuntu-22.04"
+      ubuntu = "ubuntu-24.04"
 
       runtimes = [
         "ruby:3.4",


### PR DESCRIPTION
**What does this PR do?**
Github Actions will now use Ubuntu 24.04 and Ruby 3.4 for the library's own CI

**Motivation**
Use newer versions of Ruby and Ubuntu

**How to test the change?**
If CI is green, it works