### PR TITLE
[SDTEST-741] Add telemetry logs

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "datadog/core/telemetry/ext"
-require "datadog/core/telemetry/logging"
 
 require_relative "../ext/settings"
 require_relative "../git/tree_uploader"
@@ -63,7 +62,6 @@ module Datadog
               "NOTE: if you didn't disable tracing intentionally, add `c.tracing.enabled = true` to " \
               "your Datadog.configure block."
             )
-            Core::Telemetry::Logger.error("Tracing is disabled => test optimization is disabled")
             settings.ci.enabled = false
             return
           end
@@ -172,7 +170,6 @@ module Datadog
                 "Agentless mode was enabled but DD_API_KEY is not set: CI visibility is disabled. " \
                 "Please make sure to set valid api key in DD_API_KEY environment variable"
               end
-              Core::Telemetry::Logger.error("DD_API_KEY not set => test optimization is disabled")
 
               # Tests are running without CI visibility enabled
               settings.ci.enabled = false

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "datadog/core/telemetry/ext"
+require "datadog/core/telemetry/logging"
 
 require_relative "../ext/settings"
 require_relative "../git/tree_uploader"
@@ -62,6 +63,7 @@ module Datadog
               "NOTE: if you didn't disable tracing intentionally, add `c.tracing.enabled = true` to " \
               "your Datadog.configure block."
             )
+            Core::Telemetry::Logger.error("Tracing is disabled => test optimization is disabled")
             settings.ci.enabled = false
             return
           end
@@ -170,6 +172,7 @@ module Datadog
                 "Agentless mode was enabled but DD_API_KEY is not set: CI visibility is disabled. " \
                 "Please make sure to set valid api key in DD_API_KEY environment variable"
               end
+              Core::Telemetry::Logger.error("DD_API_KEY not set => test optimization is disabled")
 
               # Tests are running without CI visibility enabled
               settings.ci.enabled = false

--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "datadog/core/telemetry/logging"
+
 require_relative "git"
 require_relative "environment/extractor"
 
@@ -73,6 +75,7 @@ module Datadog
           return if !repo_url.nil? && !repo_url.empty?
 
           Datadog.logger.error("DD_GIT_REPOSITORY_URL is not set or empty; no repo URL was automatically extracted")
+          Core::Telemetry::Logger.error("DD_GIT_REPOSITORY_URL is not set or empty; no repo URL was automatically extracted")
         end
 
         def validate_git_sha(git_sha)
@@ -89,6 +92,7 @@ module Datadog
           end
 
           Datadog.logger.error(message)
+          Core::Telemetry::Logger.error(message)
         end
       end
     end

--- a/lib/datadog/ci/ext/environment/providers/github_actions.rb
+++ b/lib/datadog/ci/ext/environment/providers/github_actions.rb
@@ -2,6 +2,7 @@
 
 require "json"
 
+require "datadog/core/telemetry/logging"
 require "datadog/core/utils/url"
 
 require_relative "base"
@@ -96,6 +97,8 @@ module Datadog
               result
             rescue => e
               Datadog.logger.error("Failed to extract additional tags from GitHub Actions: #{e}")
+              Core::Telemetry::Logger.report(e, description: "Failed to extract additional tags from GitHub Actions")
+
               {}
             end
 

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -2,6 +2,7 @@
 
 require "pp"
 
+require "datadog/core/telemetry/logging"
 require "datadog/core/utils/forking"
 
 require_relative "../ext/test"
@@ -224,6 +225,7 @@ module Datadog
           Datadog.logger.debug("Loaded Datadog code coverage collector, using coverage mode: #{code_coverage_mode}")
         rescue LoadError => e
           Datadog.logger.error("Failed to load coverage collector: #{e}. Code coverage will not be collected.")
+          Core::Telemetry::Logger.report(e, description: "Failed to load coverage collector")
 
           @code_coverage_enabled = false
         end

--- a/sig/datadog/ci/test_visibility/transport.rbs
+++ b/sig/datadog/ci/test_visibility/transport.rbs
@@ -5,6 +5,9 @@ module Datadog
         attr_reader serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
         attr_reader dd_env: String?
 
+        self.@log_once: Datadog::Core::Utils::OnlyOnce
+        def self.log_once: () -> Datadog::Core::Utils::OnlyOnce
+
         @dd_env: String?
         @serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
 


### PR DESCRIPTION
**What does this PR do?**
Send error logs to Datadog's internal telemetry in some cases

**Motivation**
Improve our ability to troubleshoot library errors
