### PR TITLE
ci: pin all GitHub Actions by SHA and update via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      gh-actions-packages:
+        patterns:
+          - "*"

--- a/.github/workflows/add-milestone-to-pull-requests.yml
+++ b/.github/workflows/add-milestone-to-pull-requests.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Checkout code
         # Checks out the branch that the pull request is merged into
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
 
@@ -26,7 +26,7 @@ jobs:
 
       - name: Get project milestones
         id: milestones
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -39,7 +39,7 @@ jobs:
 
       - name: Update Pull Request
         # Update the merged pull request with the milestone starts with the major version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/build-gem.yml
+++ b/.github/workflows/build-gem.yml
@@ -27,8 +27,8 @@ jobs:
     name: Build gem (${{ matrix.type }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
@@ -120,7 +120,7 @@ jobs:
       - name: List gem
         run: |
           find pkg
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
       - name: Install gem

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,8 +10,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
       - name: Install dependencies
@@ -22,8 +22,8 @@ jobs:
     name: Type checking
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,7 +40,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -8,7 +8,7 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check code meets quality and security standards
         id: datadog-static-analysis
         uses: DataDog/datadog-static-analyzer-github-action@v1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,11 +15,11 @@ jobs:
           - ruby:3.3
     steps:
       - name: Checkout datadog-ci
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2.10.0
       - name: Run test
         working-directory: integration/app
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,10 +16,10 @@ jobs:
     environment: release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           bundler-cache: true
           ruby-version: '3.4'
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1

--- a/.github/workflows/test-memory-leaks.yml
+++ b/.github/workflows/test-memory-leaks.yml
@@ -4,8 +4,8 @@ jobs:
   test-memcheck:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       ruby-27-matrix: "${{ steps.set-matrix.outputs.ruby-27 }}"
       jruby-94-matrix: "${{ steps.set-matrix.outputs.jruby-94 }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - run: bundle install
     - id: set-matrix
       run: |
@@ -56,7 +56,7 @@ jobs:
         echo "$matrix_json"
         # Set the output
         echo "${{ matrix.engine.alias }}=$(echo "$matrix_json")" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: bundled-lock-${{ github.run_id }}-${{ matrix.engine.alias }}
         retention-days: 1
@@ -77,10 +77,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-34
     - run: bundle install && bundle exec rake compile_ext
@@ -100,10 +100,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-33
     - run: bundle install && bundle exec rake compile_ext
@@ -123,10 +123,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-32
     - run: bundle install && bundle exec rake compile_ext
@@ -146,10 +146,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-31
     - run: bundle install && bundle exec rake compile_ext
@@ -169,10 +169,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-30
     - run: bundle install && bundle exec rake compile_ext
@@ -192,10 +192,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-ruby-27
     - run: bundle install && bundle exec rake compile_ext
@@ -215,10 +215,10 @@ jobs:
       env:
         BUNDLE_GEMFILE: "${{ matrix.gemfile }}"
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Configure Git
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: bundled-lock-${{ github.run_id }}-jruby-94
     - run: bundle install && bundle exec rake compile_ext

--- a/.github/workflows/yard.yml
+++ b/.github/workflows/yard.yml
@@ -27,20 +27,20 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@8711a86ab6f9aa72890da4123b2ef7283b6b22b6 # v1.217.0
         with:
           ruby-version: '3.4'
           bundler-cache: true
       - name: Generate YARD documentation
         run: bundle exec rake docs
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@b8130d9ab958b325bbde9786d62f2c97a9885a0e # v3.0.7
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@84bb4cd4b733d5c320c9c9cfbc354937524f4d64 # v1.0.10
         with:
           # Upload generated YARD directory
           path: 'doc/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@de14547edc9944350dc0481aa5b7afb08e75f254 # v2.0.5


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->
- **Add dependabot for github actions**
- **Pin actions by hash**

**Motivation**
<!-- What inspired you to submit this pull request? -->
Pinning 3rd-party GitHub Actions by commit SHA makes them less vulnerable to compromise of the 3rd party. To avoid outdating and non-verbosity, versions are commented after the SHA and updating via dependabot is introduced that will automatically update the commented version tag as well.

In case of a false commit SHA, this change could break the corresponding workflow. Typically, this does not cause major interruptions, but it can for example affect a release pipeline and require restart causing delays.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->