### PR TITLE
[SDTEST-1618] Internal: library capabilities tags

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -401,6 +401,14 @@ module Datadog
       def test_optimisation
         components.test_optimisation
       end
+
+      def test_management
+        components.test_management
+      end
+
+      def test_retries
+        components.test_retries
+      end
     end
   end
 end

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -83,7 +83,7 @@ module Datadog
           TAG_TEST_IMPACT_ANALYSIS = "_dd.library_capabilities.test_impact_analysis"
           TAG_EARLY_FLAKE_DETECTION = "_dd.library_capabilities.early_flake_detection"
           TAG_AUTO_TEST_RETRIES = "_dd.library_capabilities.auto_test_retries"
-          TAG_TEST_MANAGEMENT_QUARATINE = "_dd.library_capabilities.test_management.quarantine"
+          TAG_TEST_MANAGEMENT_QUARANTINE = "_dd.library_capabilities.test_management.quarantine"
           TAG_TEST_MANAGEMENT_DISABLE = "_dd.library_capabilities.test_management.disable"
           TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX = "_dd.library_capabilities.test_management.attempt_to_fix"
         end
@@ -92,8 +92,8 @@ module Datadog
         TAG_SPAN_KIND = "span.kind"
         SPAN_KIND_TEST = "test"
 
-        # common tags that are serialized directly in msgpack header in metadata field
-        METADATA_TAG_TEST_SESSION_NAME = "test_session.name"
+        # DD_TEST_SESSION_NAME value
+        TAG_TEST_SESSION_NAME = "test_session.name"
 
         # internal tag indicating if datadog service was configured by the user
         TAG_USER_PROVIDED_TEST_SERVICE = "_dd.test.is_user_provided_service"

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -78,6 +78,16 @@ module Datadog
         TAG_HAS_FAILED_ALL_RETRIES = "test.has_failed_all_retries" # true if test was retried and none of the retries passed
         TAG_ATTEMPT_TO_FIX_PASSED = "test.test_management.attempt_to_fix_passed" # true if test was marked as "attempted to fix" and all of the retries passed
 
+        # a set of tag indicating which capabilities (features) are supported by the library
+        module LibraryCapabilities
+          TAG_TEST_IMPACT_ANALYSIS = "_dd.library_capabilities.test_impact_analysis"
+          TAG_EARLY_FLAKE_DETECTION = "_dd.library_capabilities.early_flake_detection"
+          TAG_AUTO_TEST_RETRIES = "_dd.library_capabilities.auto_test_retries"
+          TAG_TEST_MANAGEMENT_QUARATINE = "_dd.library_capabilities.test_management.quarantine"
+          TAG_TEST_MANAGEMENT_DISABLE = "_dd.library_capabilities.test_management.disable"
+          TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX = "_dd.library_capabilities.test_management.attempt_to_fix"
+        end
+
         # internal APM tag to mark a span as a test span
         TAG_SPAN_KIND = "span.kind"
         SPAN_KIND_TEST = "test"

--- a/lib/datadog/ci/test_retries/component.rb
+++ b/lib/datadog/ci/test_retries/component.rb
@@ -31,13 +31,13 @@ module Datadog
         )
           no_retries_strategy = Strategy::NoRetry.new
 
-          retry_failed_strategy = Strategy::RetryFailed.new(
+          @retry_failed_strategy = Strategy::RetryFailed.new(
             enabled: retry_failed_tests_enabled,
             max_attempts: retry_failed_tests_max_attempts,
             total_limit: retry_failed_tests_total_limit
           )
 
-          retry_new_strategy = Strategy::RetryNew.new(
+          @retry_new_strategy = Strategy::RetryNew.new(
             enabled: retry_new_tests_enabled
           )
 
@@ -49,8 +49,8 @@ module Datadog
           # order is important, we apply the first matching strategy
           @retry_strategies = [
             retry_flaky_fixed_strategy,
-            retry_new_strategy,
-            retry_failed_strategy,
+            @retry_new_strategy,
+            @retry_failed_strategy,
             no_retries_strategy
           ]
           @mutex = Mutex.new
@@ -118,6 +118,14 @@ module Datadog
 
         def should_retry?
           !!current_retry_driver&.should_retry?
+        end
+
+        def auto_test_retries_feature_enabled
+          @retry_failed_strategy.enabled
+        end
+
+        def early_flake_detection_feature_enabled
+          @retry_new_strategy.enabled
         end
 
         private

--- a/lib/datadog/ci/test_visibility/capabilities.rb
+++ b/lib/datadog/ci/test_visibility/capabilities.rb
@@ -18,7 +18,7 @@ module Datadog
 
           [
             Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
-            Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_QUARATINE,
+            Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_QUARANTINE,
             Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_DISABLE
           ].each do |tag|
             tags[tag] = test_management_tag_value

--- a/lib/datadog/ci/test_visibility/capabilities.rb
+++ b/lib/datadog/ci/test_visibility/capabilities.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative "../ext/test"
+
+module Datadog
+  module CI
+    module TestVisibility
+      # Generates internal tags for library capabilities
+      module Capabilities
+        def self.tags
+          tags = {}
+
+          test_optimisation = Datadog::CI.send(:test_optimisation)
+          tags[Ext::Test::LibraryCapabilities::TAG_TEST_IMPACT_ANALYSIS] = test_optimisation.enabled.to_s
+
+          test_management = Datadog::CI.send(:test_management)
+          test_management_tag_value = test_management.enabled.to_s
+
+          [
+            Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX,
+            Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_QUARATINE,
+            Ext::Test::LibraryCapabilities::TAG_TEST_MANAGEMENT_DISABLE
+          ].each do |tag|
+            tags[tag] = test_management_tag_value
+          end
+
+          test_retries = Datadog::CI.send(:test_retries)
+          tags[Ext::Test::LibraryCapabilities::TAG_AUTO_TEST_RETRIES] = test_retries.auto_test_retries_feature_enabled.to_s
+          tags[Ext::Test::LibraryCapabilities::TAG_EARLY_FLAKE_DETECTION] = test_retries.early_flake_detection_feature_enabled.to_s
+
+          tags
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_visibility/context.rb
+++ b/lib/datadog/ci/test_visibility/context.rb
@@ -208,10 +208,6 @@ module Datadog
           ci_span.set_tags(@environment_tags)
 
           ci_span.set_metric(Ext::Test::METRIC_CPU_COUNT, Utils::TestRun.virtual_cpu_count)
-          ci_span.set_tag(
-            Ext::Test::TAG_USER_PROVIDED_TEST_SERVICE,
-            Utils::Configuration.service_name_provided_by_user?.to_s
-          )
         end
 
         # PROPAGATING CONTEXT FROM TOP-LEVEL TO THE LOWER LEVELS

--- a/lib/datadog/ci/test_visibility/transport.rb
+++ b/lib/datadog/ci/test_visibility/transport.rb
@@ -12,6 +12,7 @@ require_relative "../ext/telemetry"
 require_relative "../ext/transport"
 require_relative "../transport/event_platform_transport"
 require_relative "../transport/telemetry"
+require_relative "../utils/configuration"
 
 module Datadog
   module CI
@@ -120,10 +121,13 @@ module Datadog
 
           Ext::AppTypes::CI_SPAN_TYPES.each do |ci_span_type|
             packer.write(ci_span_type)
-            packer.write_map_header(1 + library_capabilities_tags.count)
+            packer.write_map_header(2 + library_capabilities_tags.count)
 
-            packer.write(Ext::Test::METADATA_TAG_TEST_SESSION_NAME)
+            packer.write(Ext::Test::TAG_TEST_SESSION_NAME)
             packer.write(test_visibility&.logical_test_session_name)
+
+            packer.write(Ext::Test::TAG_USER_PROVIDED_TEST_SERVICE)
+            packer.write(Utils::Configuration.service_name_provided_by_user?.to_s)
 
             library_capabilities_tags.each do |tag, value|
               packer.write(tag)

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -34,5 +34,9 @@ module Datadog
     def self.test_visibility: () -> (Datadog::CI::TestVisibility::Component | Datadog::CI::TestVisibility::NullComponent)
 
     def self.test_optimisation: () -> Datadog::CI::TestOptimisation::Component?
+
+    def self.test_retries: () -> Datadog::CI::TestRetries::Component?
+
+    def self.test_management: () -> (Datadog::CI::TestManagement::Component | Datadog::CI::TestManagement::NullComponent)
   end
 end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -96,7 +96,7 @@ module Datadog
 
         EARLY_FLAKE_FAULTY: "faulty"
 
-        METADATA_TAG_TEST_SESSION_NAME: "test_session.name"
+        TAG_TEST_SESSION_NAME: "test_session.name"
 
         TAG_USER_PROVIDED_TEST_SERVICE: "_dd.test.is_user_provided_service"
 
@@ -120,7 +120,7 @@ module Datadog
           TAG_TEST_IMPACT_ANALYSIS: "_dd.library_capabilities.test_impact_analysis"
           TAG_EARLY_FLAKE_DETECTION: "_dd.library_capabilities.early_flake_detection"
           TAG_AUTO_TEST_RETRIES: "_dd.library_capabilities.auto_test_retries"
-          TAG_TEST_MANAGEMENT_QUARATINE: "_dd.library_capabilities.test_management.quarantine"
+          TAG_TEST_MANAGEMENT_QUARANTINE: "_dd.library_capabilities.test_management.quarantine"
           TAG_TEST_MANAGEMENT_DISABLE: "_dd.library_capabilities.test_management.disable"
           TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX: "_dd.library_capabilities.test_management.attempt_to_fix"
         end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -116,6 +116,15 @@ module Datadog
 
         TAG_ATTEMPT_TO_FIX_PASSED: "test.test_management.attempt_to_fix_passed"
 
+        module LibraryCapabilities
+          TAG_TEST_IMPACT_ANALYSIS: "_dd.library_capabilities.test_impact_analysis"
+          TAG_EARLY_FLAKE_DETECTION: "_dd.library_capabilities.early_flake_detection"
+          TAG_AUTO_TEST_RETRIES: "_dd.library_capabilities.auto_test_retries"
+          TAG_TEST_MANAGEMENT_QUARATINE: "_dd.library_capabilities.test_management.quarantine"
+          TAG_TEST_MANAGEMENT_DISABLE: "_dd.library_capabilities.test_management.disable"
+          TAG_TEST_MANAGEMENT_ATTEMPT_TO_FIX: "_dd.library_capabilities.test_management.attempt_to_fix"
+        end
+
         module Status
           PASS: "pass"
 

--- a/sig/datadog/ci/test_retries/component.rbs
+++ b/sig/datadog/ci/test_retries/component.rbs
@@ -8,6 +8,10 @@ module Datadog
 
         @retry_strategies: Array[Datadog::CI::TestRetries::Strategy::Base]
 
+        @retry_failed_strategy: Datadog::CI::TestRetries::Strategy::RetryFailed
+
+        @retry_new_strategy: Datadog::CI::TestRetries::Strategy::RetryNew
+
         def initialize: (retry_failed_tests_enabled: bool, retry_failed_tests_max_attempts: Integer, retry_failed_tests_total_limit: Integer, retry_new_tests_enabled: bool, retry_flaky_fixed_tests_enabled: bool, retry_flaky_fixed_tests_max_attempts: Integer) -> void
 
         def configure: (Datadog::CI::Remote::LibrarySettings library_settings, Datadog::CI::TestSession test_session) -> void
@@ -25,6 +29,10 @@ module Datadog
         def should_retry?: () -> bool
 
         def tag_last_retry: (Datadog::CI::Test test) -> void
+
+        def auto_test_retries_feature_enabled: () -> bool
+
+        def early_flake_detection_feature_enabled: () -> bool
 
         private
 

--- a/sig/datadog/ci/test_visibility/capabilities.rbs
+++ b/sig/datadog/ci/test_visibility/capabilities.rbs
@@ -1,0 +1,9 @@
+module Datadog
+  module CI
+    module TestVisibility
+      module Capabilities
+        def self.tags: () -> Hash[String, String]
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -35,17 +35,6 @@ RSpec.describe "Minitest instrumentation" do
 
       expect(span.service).to eq("datadog-ci-rb")
     end
-
-    it "sets user_provided_service tag to false" do
-      klass = Class.new(Minitest::Test) do
-        def test_foo
-        end
-      end
-
-      klass.new(:test_foo).run
-
-      expect(span).to have_test_tag(:user_provided_test_service, "false")
-    end
   end
 
   context "with service name configured and code coverage enabled" do
@@ -100,14 +89,11 @@ RSpec.describe "Minitest instrumentation" do
         :source_file,
         "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
-      expect(span).to have_test_tag(:source_start, "73")
+      expect(span).to have_test_tag(:source_start, "62")
       expect(span).to have_test_tag(
         :codeowners,
         "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
       )
-
-      # test service is provided by user in the configuration
-      expect(span).to have_test_tag(:user_provided_test_service, "true")
     end
 
     it "creates spans for several tests" do
@@ -507,7 +493,7 @@ RSpec.describe "Minitest instrumentation" do
             :source_file,
             "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
           )
-          expect(first_test_suite_span).to have_test_tag(:source_start, "434")
+          expect(first_test_suite_span).to have_test_tag(:source_start, "420")
           expect(first_test_suite_span).to have_test_tag(
             :codeowners,
             "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -20,6 +20,9 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
 
   before do
     allow(Datadog.logger).to receive(:warn)
+
+    # this is needed to configure all the components correctky
+    Datadog::CI.start_test_session
   end
 
   let(:dd_env) { nil }
@@ -51,12 +54,45 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
 
           Datadog::CI::Ext::AppTypes::CI_SPAN_TYPES.each do |type|
             type_metadata = payload["metadata"][type]
-            expect(type_metadata).to include("test_session.name" => logical_test_session_name)
+            expect(type_metadata).to include(
+              "test_session.name" => logical_test_session_name,
+              "_dd.library_capabilities.test_impact_analysis" => "false",
+              "_dd.library_capabilities.early_flake_detection" => "false",
+              "_dd.library_capabilities.auto_test_retries" => "false",
+              "_dd.library_capabilities.test_management.quarantine" => "false",
+              "_dd.library_capabilities.test_management.disable" => "false",
+              "_dd.library_capabilities.test_management.attempt_to_fix" => "false"
+            )
           end
 
           events = payload["events"]
           expect(events.count).to eq(1)
           expect(events.first["content"]["resource"]).to include("calculator_tests")
+        end
+      end
+
+      context "with test management feature enabled" do
+        before do
+          allow_any_instance_of(Datadog::CI::TestManagement::Component).to receive(:enabled).and_return(true)
+        end
+        it "marks test management feature as enabled in library capabilities tags" do
+          subject
+
+          expect(api).to have_received(:citestcycle_request) do |args|
+            payload = MessagePack.unpack(args[:payload])
+            Datadog::CI::Ext::AppTypes::CI_SPAN_TYPES.each do |type|
+              type_metadata = payload["metadata"][type]
+              expect(type_metadata).to include(
+                "test_session.name" => logical_test_session_name,
+                "_dd.library_capabilities.test_impact_analysis" => "false",
+                "_dd.library_capabilities.early_flake_detection" => "false",
+                "_dd.library_capabilities.auto_test_retries" => "false",
+                "_dd.library_capabilities.test_management.quarantine" => "true",
+                "_dd.library_capabilities.test_management.disable" => "true",
+                "_dd.library_capabilities.test_management.attempt_to_fix" => "true"
+              )
+            end
+          end
         end
       end
 

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
   include_context "CI mode activated" do
     let(:integration_name) { :rspec }
     let(:logical_test_session_name) { "logical_test_session_name" }
+    let(:service_name) { "custom-service" }
   end
 
   subject(:transport) do
@@ -61,7 +62,8 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
               "_dd.library_capabilities.auto_test_retries" => "false",
               "_dd.library_capabilities.test_management.quarantine" => "false",
               "_dd.library_capabilities.test_management.disable" => "false",
-              "_dd.library_capabilities.test_management.attempt_to_fix" => "false"
+              "_dd.library_capabilities.test_management.attempt_to_fix" => "false",
+              "_dd.test.is_user_provided_service" => "true"
             )
           end
 


### PR DESCRIPTION
**What does this PR do?**
Adds interna-only tags that indicate which features this library provides. 

These tags will be used by Datadog UI to help users see if a feature is supported by their version of datadog-ci gem.

**How to test the change?**
Unit tests are provided