### PR TITLE
[SDTEST-161] add parallel testing support to minitest framework

### DIFF
--- a/lib/datadog/ci/contrib/minitest/helpers.rb
+++ b/lib/datadog/ci/contrib/minitest/helpers.rb
@@ -22,10 +22,13 @@ module Datadog
             end
 
             test_visibility_component = Datadog.send(:components).test_visibility
-            test_visibility_component.start_test_suite(
+            test_suite = test_visibility_component.start_test_suite(
               test_suite_name,
               tags: test_suite_tags
             )
+            test_suite&.set_expected_tests!(klass.runnable_methods)
+
+            test_suite
           end
 
           def self.test_suite_name(klass, method_name)

--- a/lib/datadog/ci/contrib/minitest/helpers.rb
+++ b/lib/datadog/ci/contrib/minitest/helpers.rb
@@ -5,6 +5,29 @@ module Datadog
     module Contrib
       module Minitest
         module Helpers
+          def self.start_test_suite(klass)
+            method = klass.runnable_methods.first
+            return nil if method.nil?
+
+            test_suite_name = test_suite_name(klass, method)
+            source_file, line_number = extract_source_location_from_class(klass)
+
+            test_suite_tags = if source_file
+              {
+                CI::Ext::Test::TAG_SOURCE_FILE => (Git::LocalRepository.relative_to_root(source_file) if source_file),
+                CI::Ext::Test::TAG_SOURCE_START => line_number&.to_s
+              }
+            else
+              {}
+            end
+
+            test_visibility_component = Datadog.send(:components).test_visibility
+            test_visibility_component.start_test_suite(
+              test_suite_name,
+              tags: test_suite_tags
+            )
+          end
+
           def self.test_suite_name(klass, method_name)
             source_location = extract_source_location_from_class(klass)&.first
             # if we are in anonymous class, fallback to the method source location

--- a/lib/datadog/ci/contrib/minitest/runnable.rb
+++ b/lib/datadog/ci/contrib/minitest/runnable.rb
@@ -14,25 +14,7 @@ module Datadog
               return super unless datadog_configuration[:enabled]
               return super if Helpers.parallel?(self)
 
-              method = runnable_methods.first
-              return super if method.nil?
-
-              test_suite_name = Helpers.test_suite_name(self, method)
-              source_file, line_number = Helpers.extract_source_location_from_class(self)
-
-              test_suite_tags = if source_file
-                {
-                  CI::Ext::Test::TAG_SOURCE_FILE => (Git::LocalRepository.relative_to_root(source_file) if source_file),
-                  CI::Ext::Test::TAG_SOURCE_START => line_number&.to_s
-                }
-              else
-                {}
-              end
-
-              test_suite = test_visibility_component.start_test_suite(
-                test_suite_name,
-                tags: test_suite_tags
-              )
+              test_suite = Helpers.start_test_suite(self)
 
               results = super
               return results unless test_suite

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -9,8 +9,6 @@ module Datadog
     module Contrib
       module Minitest
         module Runner
-          DD_ESTIMATED_TESTS_PER_SUITE = 5
-
           def self.included(base)
             base.singleton_class.prepend(ClassMethods)
           end
@@ -21,15 +19,15 @@ module Datadog
 
               return unless datadog_configuration[:enabled]
 
-              # minitest does not store the total number of tests, so we can't pass it to the test session
-              # instead, we use the number of test suites * DD_ESTIMATED_TESTS_PER_SUITE as a rough estimate
+              tests_count = ::Minitest::Runnable.runnables.sum { |runnable| runnable.runnable_methods.size }
+
               test_visibility_component.start_test_session(
                 tags: {
                   CI::Ext::Test::TAG_FRAMEWORK => Ext::FRAMEWORK,
                   CI::Ext::Test::TAG_FRAMEWORK_VERSION => datadog_integration.version.to_s
                 },
                 service: datadog_configuration[:service_name],
-                estimated_total_tests_count: (DD_ESTIMATED_TESTS_PER_SUITE * ::Minitest::Runnable.runnables.size).to_i
+                estimated_total_tests_count: tests_count
               )
               test_visibility_component.start_test_module(Ext::FRAMEWORK)
             end

--- a/lib/datadog/ci/contrib/minitest/runner.rb
+++ b/lib/datadog/ci/contrib/minitest/runner.rb
@@ -41,6 +41,12 @@ module Datadog
                 result = super
               end
 
+              # get the current test suite and mark this method as done, so we can check if all tests were executed
+              # for this test suite
+              test_suite_name = Helpers.test_suite_name(klass, method_name)
+              test_suite = test_visibility_component.active_test_suite(test_suite_name)
+              test_suite&.expected_test_done!(method_name)
+
               result
             end
 

--- a/lib/datadog/ci/contrib/minitest/test.rb
+++ b/lib/datadog/ci/contrib/minitest/test.rb
@@ -22,14 +22,11 @@ module Datadog
               super
               return unless datadog_configuration[:enabled]
 
-              test_suite_name = Helpers.test_suite_name(self.class, name)
               if Helpers.parallel?(self.class)
-                test_suite_name = "#{test_suite_name} (#{name} concurrently)"
-
-                # for parallel execution we need to start a new test suite for each test
-                test_visibility_component.start_test_suite(test_suite_name)
+                Helpers.start_test_suite(self.class)
               end
 
+              test_suite_name = Helpers.test_suite_name(self.class, name)
               source_file, line_number = method(name).source_location
 
               test_span = test_visibility_component.trace_test(
@@ -55,10 +52,6 @@ module Datadog
 
               # remove failures if test passed at least once on retries or quarantined
               self.failures = [] if test_span.should_ignore_failures?
-
-              if Helpers.parallel?(self.class)
-                finish_with_result(test_span.test_suite, result_code)
-              end
 
               super
             end

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "drb"
+
 require "datadog/core/environment/platform"
 
 require_relative "ext/test"
@@ -12,6 +14,8 @@ module Datadog
     #
     # @public_api
     class Span
+      include DRb::DRbUndumped
+
       attr_reader :tracer_span
 
       def initialize(tracer_span)

--- a/lib/datadog/ci/test_suite.rb
+++ b/lib/datadog/ci/test_suite.rb
@@ -84,6 +84,24 @@ module Datadog
         end
       end
 
+      # @internal
+      def set_expected_tests!(expected_tests)
+        synchronize do
+          return if @expected_tests_set
+
+          @expected_tests_set = Set.new(expected_tests)
+        end
+      end
+
+      # @internal
+      def expected_test_done!(test_name)
+        synchronize do
+          @expected_tests_set.delete(test_name)
+
+          finish if @expected_tests_set.empty?
+        end
+      end
+
       private
 
       def set_status_from_stats!

--- a/lib/datadog/ci/test_visibility/context.rb
+++ b/lib/datadog/ci/test_visibility/context.rb
@@ -172,14 +172,10 @@ module Datadog
         end
 
         def incr_total_tests_count
-          p "incr_total_tests_count"
-          p Process.pid
           @mutex.synchronize { @total_tests_count += 1 }
         end
 
         def incr_tests_skipped_by_tia_count
-          p "incr_tests_skipped_by_tia_count"
-          p Process.pid
           @mutex.synchronize { @tests_skipped_by_tia_count += 1 }
         end
 

--- a/lib/datadog/ci/test_visibility/store/global.rb
+++ b/lib/datadog/ci/test_visibility/store/global.rb
@@ -59,6 +59,13 @@ module Datadog
             end
           end
 
+          def stop_all_test_suites
+            @mutex.synchronize do
+              @test_suites.each_value(&:finish)
+              @test_suites.clear
+            end
+          end
+
           def inheritable_session_tags
             @mutex.synchronize do
               test_session = @test_session

--- a/lib/datadog/ci/test_visibility/store/global.rb
+++ b/lib/datadog/ci/test_visibility/store/global.rb
@@ -6,8 +6,6 @@ module Datadog
       module Store
         # This context is shared between threads and represents the current test session and test module.
         class Global
-          attr_reader :total_tests_count, :tests_skipped_by_tia_count
-
           def initialize
             # we are using Monitor instead of Mutex because it is reentrant
             @mutex = Monitor.new
@@ -15,9 +13,6 @@ module Datadog
             @test_session = nil
             @test_module = nil
             @test_suites = {}
-
-            @total_tests_count = 0
-            @tests_skipped_by_tia_count = 0
           end
 
           def fetch_or_activate_test_suite(test_suite_name, &block)
@@ -85,14 +80,6 @@ module Datadog
 
           def deactivate_test_suite!(test_suite_name)
             @mutex.synchronize { @test_suites.delete(test_suite_name) }
-          end
-
-          def incr_total_tests_count
-            @mutex.synchronize { @total_tests_count += 1 }
-          end
-
-          def incr_tests_skipped_by_tia_count
-            @mutex.synchronize { @tests_skipped_by_tia_count += 1 }
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/helpers.rbs
+++ b/sig/datadog/ci/contrib/minitest/helpers.rbs
@@ -3,6 +3,8 @@ module Datadog
     module Contrib
       module Minitest
         module Helpers
+          def self.start_test_suite: (untyped klass) -> Datadog::CI::TestSuite?
+
           def self.test_suite_name: (untyped klass, String? method_name) -> ::String
 
           def self.parallel?: (untyped klass) -> bool

--- a/sig/datadog/ci/contrib/minitest/runner.rbs
+++ b/sig/datadog/ci/contrib/minitest/runner.rbs
@@ -3,8 +3,6 @@ module Datadog
     module Contrib
       module Minitest
         module Runner
-          DD_ESTIMATED_TESTS_PER_SUITE: Integer
-
           def self.included: (untyped base) -> untyped
 
           module ClassMethods : ::Minitest

--- a/sig/datadog/ci/test_suite.rbs
+++ b/sig/datadog/ci/test_suite.rbs
@@ -2,6 +2,7 @@ module Datadog
   module CI
     class TestSuite < ConcurrentSpan
       @execution_stats_per_test: Hash[String, Hash[String, Integer]]
+      @expected_tests_set: Set[String]
 
       def record_test_result: (String test_id, String datadog_test_status) -> void
 
@@ -14,6 +15,10 @@ module Datadog
       def all_executions_failed?: (String) -> bool
 
       def all_executions_passed?: (String) -> bool
+
+      def set_expected_tests!: (Enumerable[String] tests) -> void
+
+      def expected_test_done!: (String test_name) -> void
 
       private
 

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -2,10 +2,16 @@ module Datadog
   module CI
     module TestVisibility
       class Component
+        include Datadog::Core::Utils::Forking
+
         @test_suite_level_visibility_enabled: bool
 
         @codeowners: Datadog::CI::Codeowners::Matcher
         @context: Datadog::CI::TestVisibility::Context
+        @context_client: Datadog::CI::TestVisibility::Context
+
+        @context_service: untyped
+        @context_service_uri: String
 
         @known_tests_enabled: bool
         @known_tests: Set[String]
@@ -108,7 +114,22 @@ module Datadog
         def remote: () -> Datadog::CI::Remote::Component
 
         def test_management: () -> Datadog::CI::TestManagement::Component
+
+        def start_drb_service: () -> void
+
+        def maybe_remote_context: () -> Datadog::CI::TestVisibility::Context
       end
     end
   end
+end
+
+module DRb
+  def self.start_service: (?String uri, ?Object obj) -> untyped
+
+  module DRbUndumped
+  end
+end
+
+class DRbObject
+  def self.new_with_uri: (String uri) -> untyped
 end

--- a/sig/datadog/ci/test_visibility/context.rbs
+++ b/sig/datadog/ci/test_visibility/context.rbs
@@ -13,7 +13,7 @@ module Datadog
 
         def initialize: () -> void
 
-        def trace_test: (String span_name, String test_suite_name, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
+        def trace_test: (String span_name, Datadog::CI::TestSuite? test_suite, ?service: String?, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Test span) -> untyped } -> untyped
 
         def trace: (String span_name, ?type: String, ?tags: Hash[untyped, untyped]) ?{ (Datadog::CI::Span span) -> untyped } -> untyped
 
@@ -51,6 +51,8 @@ module Datadog
 
         def incr_tests_skipped_by_tia_count: () -> void
 
+        def stop_all_test_suites: () -> void
+
         private
 
         def build_test: (Datadog::Tracing::SpanOperation tracer_span, Hash[untyped, untyped] tags) -> Datadog::CI::Test
@@ -71,7 +73,7 @@ module Datadog
 
         def set_session_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestSession | Datadog::Tracing::SpanOperation? test_session) -> void
 
-        def set_suite_context: (Hash[untyped, untyped] tags, ?span: Datadog::Tracing::SpanOperation, ?name: String) -> void
+        def set_suite_context: (Hash[untyped, untyped] tags, ?test_suite: Datadog::Tracing::SpanOperation? | Datadog::CI::TestSuite?) -> void
 
         def set_module_context: (Hash[untyped, untyped] tags, ?Datadog::CI::TestModule | Datadog::Tracing::SpanOperation? test_module) -> void
 

--- a/sig/datadog/ci/test_visibility/context.rbs
+++ b/sig/datadog/ci/test_visibility/context.rbs
@@ -2,15 +2,14 @@ module Datadog
   module CI
     module TestVisibility
       class Context
-        include Datadog::Core::Utils::Forking
+        @mutex: Mutex
 
         @local_context: Datadog::CI::TestVisibility::Store::Local
         @global_context: Datadog::CI::TestVisibility::Store::Global
-        @global_context_client: Datadog::CI::TestVisibility::Store::Global
-
-        @global_context_uri: String
-
         @environment_tags: Hash[String, String]
+
+        @total_tests_count: Integer
+        @tests_skipped_by_tia_count: Integer
 
         def initialize: () -> void
 
@@ -79,22 +78,8 @@ module Datadog
         def start_datadog_tracer_span: (String span_name, Hash[untyped, untyped] span_options) ?{ (untyped) -> untyped } -> untyped
 
         def build_tracing_span_options: (String? service_name, String type, ?Hash[Symbol, untyped] other_options) -> Hash[Symbol, untyped]
-
-        def start_drb_service: () -> void
-
-        def maybe_remote_global_context: () -> Datadog::CI::TestVisibility::Store::Global
       end
     end
   end
 end
 
-module DRb
-  def self.start_service: (?String uri, ?Object obj) -> untyped
-
-  module DRbUndumped
-  end
-end
-
-class DRbObject
-  def self.new_with_uri: (String uri) -> untyped
-end

--- a/sig/datadog/ci/test_visibility/store/global.rbs
+++ b/sig/datadog/ci/test_visibility/store/global.rbs
@@ -34,6 +34,8 @@ module Datadog
           def deactivate_test_module!: () -> void
 
           def deactivate_test_suite!: (String test_suite_name) -> void
+
+          def stop_all_test_suites: () -> void
         end
       end
     end

--- a/sig/datadog/ci/test_visibility/store/global.rbs
+++ b/sig/datadog/ci/test_visibility/store/global.rbs
@@ -9,13 +9,6 @@ module Datadog
           @test_module: Datadog::CI::TestModule?
           @test_suites: Hash[String, Datadog::CI::TestSuite]
 
-          @total_tests_count: Integer
-          @tests_skipped_by_tia_count: Integer
-
-          attr_reader total_tests_count: Integer
-
-          attr_reader tests_skipped_by_tia_count: Integer
-
           def initialize: () -> void
 
           def fetch_or_activate_test_suite: (String test_suite_name) {() -> Datadog::CI::TestSuite} -> Datadog::CI::TestSuite
@@ -41,10 +34,6 @@ module Datadog
           def deactivate_test_module!: () -> void
 
           def deactivate_test_suite!: (String test_suite_name) -> void
-
-          def incr_total_tests_count: () -> void
-
-          def incr_tests_skipped_by_tia_count: () -> void
         end
       end
     end

--- a/spec/datadog/ci/contrib/ci_queue_minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/ci_queue_minitest/instrumentation_spec.rb
@@ -43,22 +43,20 @@ RSpec.describe "Minitest instrumentation with Shopify's ci-queue runner" do
     # test session and module are failed
     expect([test_session_span, test_module_span]).to all have_fail_status
 
-    # test suite spans are created for each test as for parallel execution
-    expect(test_suite_spans).to have(3).items
-    expect(test_suite_spans).to have_tag_values_no_order(:status, ["pass", "pass", "fail"])
+    # there is a single test suite
+    expect(test_suite_spans).to have(1).item
+    expect(test_suite_spans.first).to have_fail_status
     expect(test_suite_spans).to have_tag_values_no_order(
       :suite,
       [
-        "SomeTest at spec/datadog/ci/contrib/ci_queue_minitest/fake_test.rb (test_fail concurrently)",
-        "SomeTest at spec/datadog/ci/contrib/ci_queue_minitest/fake_test.rb (test_pass concurrently)",
-        "SomeTest at spec/datadog/ci/contrib/ci_queue_minitest/fake_test.rb (test_pass_other concurrently)"
+        "SomeTest at spec/datadog/ci/contrib/ci_queue_minitest/fake_test.rb"
       ]
     )
 
     # there is test span for every test case
     expect(test_spans).to have(3).items
-    # each test span has its own test suite
-    expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 3)
+    # there is a single test suite
+    expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 1)
 
     # every test span is connected to test module and test session
     expect(test_spans).to all have_test_tag(:test_module_id)

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -700,7 +700,7 @@ RSpec.describe "Minitest instrumentation" do
           end
         end
 
-        it "traces all tests correctly, assigning a separate test suite to each of them" do
+        it "traces all tests and test suites correctly" do
           test_threads = test_spans.map { |span| span.get_tag("minitest_thread") }.uniq
 
           # make sure that tests were executed concurrently
@@ -716,7 +716,7 @@ RSpec.describe "Minitest instrumentation" do
               "test_b_2"
             ]
           )
-          expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 4)
+          expect(test_spans).to have_unique_tag_values_count(:test_suite_id, 2)
         end
 
         it "connects tests to a single test session and a single test module" do
@@ -728,15 +728,13 @@ RSpec.describe "Minitest instrumentation" do
         end
 
         it "creates test suite spans" do
-          expect(test_suite_spans).to have(4).items
+          expect(test_suite_spans).to have(2).items
 
           expect(test_suite_spans).to have_tag_values_no_order(
             :suite,
             [
-              "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_1 concurrently)",
-              "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_2 concurrently)",
-              "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_b_1 concurrently)",
-              "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_b_2 concurrently)"
+              "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb",
+              "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
             ]
           )
         end
@@ -756,9 +754,9 @@ RSpec.describe "Minitest instrumentation" do
           let(:itr_skippable_tests) do
             Set.new(
               [
-                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_1 concurrently).test_a_1.",
-                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_a_2 concurrently).test_a_2.",
-                "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb (test_b_2 concurrently).test_b_2."
+                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_a_1.",
+                "TestA at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_a_2.",
+                "TestB at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb.test_b_2."
               ]
             )
           end
@@ -1229,7 +1227,7 @@ RSpec.describe "Minitest instrumentation" do
 
       expect(test_spans_by_test_name["test_passed"]).to have(1).item
 
-      expect(test_suite_spans).to have(12).items
+      expect(test_suite_spans).to have(1).item
 
       expect(test_session_span).to have_fail_status
     end

--- a/spec/support/coverage_helpers.rb
+++ b/spec/support/coverage_helpers.rb
@@ -56,7 +56,7 @@ module CoverageHelpers
   end
 
   def expect_coverage_events_belong_to_suites(test_suite_spans)
-    expect(coverage_events.map(&:test_suite_id).sort).to eq(test_suite_spans.map(&:id).map(&:to_s).sort)
+    expect(coverage_events.map(&:test_suite_id).sort.uniq).to eq(test_suite_spans.map(&:id).map(&:to_s).sort.uniq)
   end
 
   def expect_coverage_events_belong_to_tests(test_spans)


### PR DESCRIPTION
**What does this PR do?**
Adds parallel test suites to minitest tracing. 

**Motivation**
Fixing a long standing issue that we didn't have proper support for parallel executors in minitest

**How to test the change?**
Tested using quotes-rails project:
<img width="871" alt="image" src="https://github.com/user-attachments/assets/9cdf53ba-d351-429b-9c0b-aac43fcf94b9" />
