### PR TITLE
[SDTEST-1747] fix git commit message extraction to extract multiline commit messages correctly

### DIFF
--- a/lib/datadog/ci/git/local_repository.rb
+++ b/lib/datadog/ci/git/local_repository.rb
@@ -142,7 +142,7 @@ module Datadog
         end
 
         def self.git_commit_message
-          exec_git_command("git show -s --format=%s")
+          exec_git_command("git log -n 1 --format=%B")
         rescue => e
           log_failure(e, "git commit message")
           nil


### PR DESCRIPTION
**What does this PR do?**
Changes git commit message extraction to use command `git log -n 1 --format=%B`.

**Motivation**
Fixes a bug: currently only the first line of the multiline commit message is extracted.

**How to test the change?**
Unit tests are provided