### PR TITLE
[SDTEST-1753] Fix: prevent test impact analysis from skipping flaky tests that are attempted to be fixed

### DIFF
--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -97,6 +97,13 @@ module Datadog
               )
             end
 
+            def datadog_fqn_test_id
+              @datadog_fqn_test_id ||= Utils::TestRun.datadog_test_id(
+                datadog_test_name,
+                datadog_test_suite_name
+              )
+            end
+
             def datadog_unskippable?
               !!metadata[CI::Ext::Test::ITR_UNSKIPPABLE_OPTION]
             end

--- a/lib/datadog/ci/contrib/rspec/example_group.rb
+++ b/lib/datadog/ci/contrib/rspec/example_group.rb
@@ -34,8 +34,6 @@ module Datadog
                 CI::Ext::Test::TAG_SOURCE_START => metadata[:line_number].to_s
               }
 
-              # parallel_tests gem splits tests by files, so test suite is always executed within a single worker
-              # we can use it for some optimization: start test suite in local process when running under parallel_tests
               test_suite =
                 test_visibility_component&.start_test_suite(
                   suite_name,
@@ -63,7 +61,8 @@ module Datadog
 
             def all_examples_skipped_by_datadog?
               descendant_filtered_examples.all? do |example|
-                !example.datadog_unskippable? && test_optimisation_component&.skippable?(example)
+                !example.datadog_unskippable? && test_optimisation_component&.skippable?(example.datadog_test_id) &&
+                  !test_management_component&.attempt_to_fix?(example.datadog_fqn_test_id)
               end
             end
 
@@ -77,6 +76,10 @@ module Datadog
 
             def test_optimisation_component
               Datadog.send(:components).test_optimisation
+            end
+
+            def test_management_component
+              Datadog.send(:components).test_management
             end
           end
         end

--- a/lib/datadog/ci/test_management/component.rb
+++ b/lib/datadog/ci/test_management/component.rb
@@ -65,6 +65,15 @@ module Datadog
           test_span.set_tag(Ext::Test::TAG_IS_ATTEMPT_TO_FIX, "true") if test_properties["attempt_to_fix"]
         end
 
+        def attempt_to_fix?(datadog_fqn_test_id)
+          return false unless @enabled
+
+          test_properties = @tests_properties[datadog_fqn_test_id]
+          return false if test_properties.nil?
+
+          test_properties.fetch("attempt_to_fix", false)
+        end
+
         # Implementation of Stateful interface
         def serialize_state
           {

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -147,16 +147,16 @@ module Datadog
           event
         end
 
-        def skippable?(test)
+        def skippable?(datadog_test_id)
           return false if !enabled? || !skipping_tests?
 
-          @skippable_tests.include?(test.datadog_test_id)
+          @skippable_tests.include?(datadog_test_id)
         end
 
         def mark_if_skippable(test)
           return if !enabled? || !skipping_tests?
 
-          if skippable?(test) && !test.attempt_to_fix?
+          if skippable?(test.datadog_test_id) && !test.attempt_to_fix?
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
 
             Datadog.logger.debug { "Marked test as skippable: #{test.datadog_test_id}" }

--- a/lib/datadog/ci/test_optimisation/component.rb
+++ b/lib/datadog/ci/test_optimisation/component.rb
@@ -156,7 +156,7 @@ module Datadog
         def mark_if_skippable(test)
           return if !enabled? || !skipping_tests?
 
-          if skippable?(test)
+          if skippable?(test) && !test.attempt_to_fix?
             test.set_tag(Ext::Test::TAG_ITR_SKIPPED_BY_ITR, "true")
 
             Datadog.logger.debug { "Marked test as skippable: #{test.datadog_test_id}" }

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -13,10 +13,12 @@ module Datadog
             @datadog_test_name: String
             @datadog_test_suite_name: String
             @datadog_test_parameters: String
+            @datadog_fqn_test_id: String
 
             def run: (untyped example_group_instance, untyped reporter) -> untyped
 
             def datadog_test_id: () -> String
+            def datadog_fqn_test_id: () -> String
             def datadog_unskippable?: () -> bool
 
             private

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -19,6 +19,8 @@ module Datadog
             def test_visibility_component: () -> Datadog::CI::TestVisibility::Component?
 
             def test_optimisation_component: () -> Datadog::CI::TestOptimisation::Component?
+
+            def test_management_component: () -> Datadog::CI::TestManagement::Component?
           end
         end
       end

--- a/sig/datadog/ci/test_management/component.rbs
+++ b/sig/datadog/ci/test_management/component.rbs
@@ -22,6 +22,8 @@ module Datadog
 
         def tag_test_from_properties: (Datadog::CI::Test test) -> void
 
+        def attempt_to_fix?: (String datadog_fqn_test_id) -> bool
+
         # Implementation of Stateful interface
         def serialize_state: () -> Hash[Symbol, untyped]
 

--- a/sig/datadog/ci/test_optimisation/component.rbs
+++ b/sig/datadog/ci/test_optimisation/component.rbs
@@ -45,7 +45,7 @@ module Datadog
 
         def stop_coverage: (Datadog::CI::Test test) -> Datadog::CI::TestOptimisation::Coverage::Event?
 
-        def skippable?: (Datadog::CI::Test test) -> bool
+        def skippable?: (String datadog_test_id) -> bool
 
         def mark_if_skippable: (Datadog::CI::Test test) -> void
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -751,6 +751,8 @@ RSpec.describe "RSpec instrumentation" do
 
       let(:itr_enabled) { true }
       let(:tests_skipping_enabled) { true }
+
+      let(:test_management_enabled) { true }
     end
 
     context "skipped a single test" do
@@ -830,6 +832,24 @@ RSpec.describe "RSpec instrumentation" do
 
         expect(before_all_spy).to have_received(:call)
         expect(before_context_spy).to have_received(:call)
+      end
+
+      context "but some test is an attempt to fix" do
+        let(:test_properties) do
+          {
+            "SomeTest at ./spec/datadog/ci/contrib/rspec/instrumentation_spec.rb.nested foo." => {
+              "quarantined" => false,
+              "disabled" => false,
+              "attempt_to_fix" => true
+            }
+          }
+        end
+
+        it "does not skip context hooks" do
+          rspec_session_run(with_failed_test: true)
+
+          expect(before_context_spy).to have_received(:call)
+        end
       end
 
       context "but some tests are unskippable" do


### PR DESCRIPTION
**What does this PR do?**
Prevents test impact analysis from skipping any tests with "attempt to fix" property (that means that developer tries to fix this flaky test).

**Motivation**
When developer tries to fix a flaky test we don't want the test to be skipped by test impact analysis. Note that this situation is purely theoretical because if there code changes related to a test, test impact analysis is not going to skip it anyway. Still, we make it even theoretically impossible.

**How to test the change?**
Tests are provided