### PR TITLE
Bump to version 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+## [1.15.0] - 2025-03-25
+
+
+### Added
+
+* parallel tests gem support ([#299][])
+* implemented attempt to fix flow V2 ([#298][])
+
+### Fixed
+
+* Fix: prevent test impact analysis from skipping flaky tests that are attempted to be fixed ([#301][])
+* Fix git commit message extraction to extract multiline commit messages correctly ([#300][])
+
 ## [1.14.0] - 2025-03-11
 
 ### Added
@@ -404,7 +417,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.14.0...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.15.0...main
+[1.15.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.13.0...v1.14.0
 [1.13.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.11.0...v1.12.0
@@ -580,3 +594,7 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#292]: https://github.com/DataDog/datadog-ci-rb/issues/292
 [#294]: https://github.com/DataDog/datadog-ci-rb/issues/294
 [#295]: https://github.com/DataDog/datadog-ci-rb/issues/295
+[#298]: https://github.com/DataDog/datadog-ci-rb/issues/298
+[#299]: https://github.com/DataDog/datadog-ci-rb/issues/299
+[#300]: https://github.com/DataDog/datadog-ci-rb/issues/300
+[#301]: https://github.com/DataDog/datadog-ci-rb/issues/301

--- a/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_activesupport_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    datadog-ci (1.14.0)
+    datadog-ci (1.15.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,7 +4,7 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 14
+      MINOR = 15
       PATCH = 0
       PRE = nil
       BUILD = nil


### PR DESCRIPTION

### Added

* parallel tests gem support (#299)
* implemented attempt to fix flow V2 (#298)

### Fixed

* Fix: prevent test impact analysis from skipping flaky tests that are attempted to be fixed (#301)
* Fix git commit message extraction to extract multiline commit messages correctly (#300)
