### PR TITLE
[SDTEST-1829] add retry reason "external"

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -151,8 +151,8 @@ module Datadog
 
         # possible reasons why a test was retried
         module RetryReason
-          RETRY_NEW = "efd"
-          RETRY_FAILED = "atr"
+          RETRY_DETECT_FLAKY = "early_flake_detection"
+          RETRY_FAILED = "auto_test_retries"
           RETRY_FLAKY_FIXED = "attempt_to_fix"
         end
 

--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -154,6 +154,7 @@ module Datadog
           RETRY_DETECT_FLAKY = "early_flake_detection"
           RETRY_FAILED = "auto_test_retries"
           RETRY_FLAKY_FIXED = "attempt_to_fix"
+          RETRY_EXTERNAL = "external"
         end
 
         # possible reasons why a test was skipped

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -25,6 +25,10 @@ module Datadog
       # Finishes the current test.
       # @return [void]
       def finish
+        if is_retry? && retry_reason.nil?
+          set_tag(Ext::Test::TAG_RETRY_REASON, Ext::Test::RetryReason::RETRY_EXTERNAL)
+        end
+
         test_visibility.deactivate_test
 
         super
@@ -66,6 +70,12 @@ module Datadog
       # @return [Boolean] true if this test is a retry, false otherwise.
       def is_retry?
         get_tag(Ext::Test::TAG_IS_RETRY) == "true"
+      end
+
+      # Returns string with a reason why test was retroed
+      # @return [String] retry reason
+      def retry_reason
+        get_tag(Ext::Test::TAG_RETRY_REASON)
       end
 
       # Returns "true" if this span represents a test that wasn't known to Datadog before.

--- a/lib/datadog/ci/test_retries/driver/retry_new.rb
+++ b/lib/datadog/ci/test_retries/driver/retry_new.rb
@@ -36,7 +36,7 @@ module Datadog
           end
 
           def retry_reason
-            Ext::Test::RetryReason::RETRY_NEW
+            Ext::Test::RetryReason::RETRY_DETECT_FLAKY
           end
         end
       end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -157,9 +157,9 @@ module Datadog
         end
 
         module RetryReason
-          RETRY_NEW: "efd"
+          RETRY_DETECT_FLAKY: "early_flake_detection"
 
-          RETRY_FAILED: "atr"
+          RETRY_FAILED: "auto_test_retries"
 
           RETRY_FLAKY_FIXED: "attempt_to_fix"
         end

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -162,6 +162,8 @@ module Datadog
           RETRY_FAILED: "auto_test_retries"
 
           RETRY_FLAKY_FIXED: "attempt_to_fix"
+
+          RETRY_EXTERNAL: "external"
         end
 
         module SkipReason

--- a/sig/datadog/ci/test.rbs
+++ b/sig/datadog/ci/test.rbs
@@ -10,20 +10,22 @@ module Datadog
       def test_suite_name: () -> String?
       def test_module_id: () -> String?
       def test_session_id: () -> String?
-      def skipped_by_test_impact_analysis?: () -> bool
-      def itr_unskippable!: () -> void
-      def parameters: () -> String?
       def is_retry?: () -> bool
+      def retry_reason: () -> String?
       def is_new?: () -> bool
-      def any_retry_passed?: () -> bool
-      def all_executions_failed?: () -> bool
-      def all_executions_passed?: () -> bool
       def quarantined?: () -> bool
       def disabled?: () -> bool
       def attempt_to_fix?: () -> bool
-      def should_ignore_failures?: () -> bool
+      def itr_unskippable!: () -> void
+      def set_parameters: (Hash[untyped, untyped] arguments, ?Hash[untyped, untyped] metadata) -> void
+      def parameters: () -> String?
+      def any_retry_passed?: () -> bool
+      def all_executions_failed?: () -> bool
+      def all_executions_passed?: () -> bool
       def datadog_skip_reason: () -> String?
       def should_skip?: () -> bool
+      def should_ignore_failures?: () -> bool
+      def skipped_by_test_impact_analysis?: () -> bool
 
       private
 

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -554,7 +554,7 @@ RSpec.describe "Cucumber instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 8)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 8)
 
       # count how many spans were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -580,7 +580,7 @@ RSpec.describe "Cucumber instrumentation" do
 
         # check retry reasons
         retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-        expect(retry_reasons).to eq(["atr"] * 2)
+        expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 2)
 
         # count how many spans were marked as new
         new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -609,7 +609,7 @@ RSpec.describe "Cucumber instrumentation" do
 
         # check retry reasons
         retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-        expect(retry_reasons).to eq(["atr"] * 4)
+        expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 4)
 
         # count how many spans were marked as new
         new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -657,7 +657,7 @@ RSpec.describe "Cucumber instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many spans were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -1021,7 +1021,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 4)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 4)
 
       expect(test_spans_by_test_name["test_passed"]).to have(1).item
 
@@ -1083,7 +1083,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 3)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 3)
 
       expect(test_spans_by_test_name["test_passed"]).to have(1).item
 
@@ -1154,7 +1154,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 5)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 5)
 
       expect(test_suite_spans).to have(1).item
       expect(test_suite_spans.first).to have_fail_status
@@ -1219,7 +1219,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 9)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 9)
 
       # last retry is tagged with has_failed_all_retries for test_failed
       failed_all_retries_count = test_spans.count { |span| span.get_tag("test.has_failed_all_retries") }
@@ -1273,7 +1273,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1325,7 +1325,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1392,7 +1392,7 @@ RSpec.describe "Minitest instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -962,7 +962,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 4)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 4)
 
       expect(test_spans_by_test_name["nested foo"]).to have(1).item
 
@@ -1001,7 +1001,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 3)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 3)
 
       expect(test_spans_by_test_name["nested foo"]).to have(1).item
 
@@ -1042,7 +1042,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["atr"] * 5)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 5)
 
       # it retried failing test 5 times
       expect(test_spans_by_test_name["nested fails"]).to have(6).items
@@ -1100,7 +1100,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1134,7 +1134,7 @@ RSpec.describe "RSpec instrumentation" do
 
         # check retry reasons
         retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-        expect(retry_reasons).to eq(["efd"] * 5)
+        expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 5)
 
         # count how many tests were marked as new
         new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1235,7 +1235,10 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact.sort
-      expect(retry_reasons).to eq((["atr"] * 4) + (["efd"] * 10))
+      expect(retry_reasons).to eq(
+        ([Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED] * 4) +
+          ([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
+      )
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1287,7 +1290,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 20)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 20)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1336,7 +1339,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }
@@ -1386,7 +1389,7 @@ RSpec.describe "RSpec instrumentation" do
 
       # check retry reasons
       retry_reasons = test_spans.map { |span| span.get_tag("test.retry_reason") }.compact
-      expect(retry_reasons).to eq(["efd"] * 10)
+      expect(retry_reasons).to eq([Datadog::CI::Ext::Test::RetryReason::RETRY_DETECT_FLAKY] * 10)
 
       # count how many tests were marked as new
       new_tests_count = test_spans.count { |span| span.get_tag("test.is_new") == "true" }

--- a/spec/datadog/ci/test_visibility/telemetry_spec.rb
+++ b/spec/datadog/ci/test_visibility/telemetry_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Datadog::CI::TestVisibility::Telemetry do
             Datadog::CI::Ext::Test::TAG_IS_RUM_ACTIVE => "true",
             Datadog::CI::Ext::Test::TAG_BROWSER_DRIVER => "selenium",
             Datadog::CI::Ext::Test::TAG_IS_RETRY => "true",
-            Datadog::CI::Ext::Test::TAG_RETRY_REASON => "atr",
+            Datadog::CI::Ext::Test::TAG_RETRY_REASON => Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED,
             Datadog::CI::Ext::Test::TAG_IS_NEW => "true",
             Datadog::CI::Ext::Test::TAG_IS_ATTEMPT_TO_FIX => "true",
             Datadog::CI::Ext::Test::TAG_HAS_FAILED_ALL_RETRIES => "true"
@@ -260,7 +260,7 @@ RSpec.describe Datadog::CI::TestVisibility::Telemetry do
           Datadog::CI::Ext::Telemetry::TAG_IS_RUM => "true",
           Datadog::CI::Ext::Telemetry::TAG_BROWSER_DRIVER => "selenium",
           Datadog::CI::Ext::Telemetry::TAG_IS_RETRY => "true",
-          Datadog::CI::Ext::Telemetry::TAG_RETRY_REASON => "atr",
+          Datadog::CI::Ext::Telemetry::TAG_RETRY_REASON => Datadog::CI::Ext::Test::RetryReason::RETRY_FAILED,
           Datadog::CI::Ext::Telemetry::TAG_IS_NEW => "true",
           Datadog::CI::Ext::Telemetry::TAG_IS_ATTEMPT_TO_FIX => "true",
           Datadog::CI::Ext::Telemetry::TAG_HAS_FAILED_ALL_RETRIES => "true"


### PR DESCRIPTION
**What does this PR do?**
- adds "external" as a retry reason when test is retried outside of datadog-ci library
- renames "atr" and "efd" retry reasons to "auto_test_retries" and "early_flake_detection" respectively

**Motivation**
Streamlining retry reason reporting

**How to test the change?**
Unit tests are provided