### PR TITLE
[NO-TICKET] Internal: workflow to automatically update dependencies

### DIFF
--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -47,7 +47,9 @@ jobs:
           persist-credentials: false
       - name: Bundle
         run: bundle install
-      - name: Update latest
+      - name: Install current versions
+        run: bundle exec appraisal install
+      - name: Update to the latest versions
         run: bundle exec appraisal update
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -47,8 +47,8 @@ jobs:
           persist-credentials: false
       - name: Bundle
         run: bundle install
-      - name: Install current versions
-        run: bundle exec appraisal install
+      - name: Generate gemfiles
+        run: bundle exec appraisal generate
       - name: Update to the latest versions
         run: bundle exec appraisal update
       - name: Upload artifact

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -4,9 +4,8 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
+  push:
+    branches: ['**']
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -4,6 +4,9 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -36,8 +36,6 @@ jobs:
             version: '3.0'
           - name: ruby
             version: '2.7'
-          - name: jruby
-            version: '9.4'
     container:
       image: 'ghcr.io/datadog/images-rb/engines/${{ matrix.engine.name }}:${{ matrix.engine.version }}'
     steps:

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -1,0 +1,87 @@
+name: 'Update Latest Dependency'
+
+on: # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 0 * * *' # Every day at midnight
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+# Default permissions for all jobs
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        engine:
+          # ADD NEW RUBIES HERE
+          - name: ruby
+            version: '3.4'
+          - name: ruby
+            version: '3.3'
+          - name: ruby
+            version: '3.2'
+          - name: ruby
+            version: '3.1'
+          - name: ruby
+            version: '3.0'
+          - name: ruby
+            version: '2.7'
+          - name: jruby
+            version: '9.4'
+    container:
+      image: 'ghcr.io/datadog/images-rb/engines/${{ matrix.engine.name }}:${{ matrix.engine.version }}'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Bundle
+        run: bundle install
+      - name: Update latest
+        run: bundle exec appraisal update
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: 'gha${{ github.run_id }}-datadog-ci-gem-${{ matrix.engine.name }}-${{ matrix.engine.version }}'
+          path: gemfiles/${{ matrix.engine.name }}_${{ matrix.engine.version }}_*
+          retention-days: 1
+
+  aggregate:
+    needs: build
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true # required for `git` operations (commit & push) at later steps
+
+      - name: Download artifacts for all runtimes
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          path: gemfiles
+          pattern: gha${{ github.run_id }}-datadog-ci-gem-*
+          merge-multiple: true
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GHA_PAT }}
+          branch: auto-generate/update-latest-dependencies
+          title: '[🤖] Update Latest Dependency'
+          base: main
+          labels: internal
+          commit-message: '[🤖] Update Latest Dependency: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          delete-branch: true
+          body: |
+            _This is an auto-generated PR from [here](https://github.com/DataDog/datadog-ci-rb/blob/main/.github/workflows/update-latest-dependencies.yml), which creates a pull request that will be continually updated with new changes until it is merged or closed)_
+
+            The PR updates latest versions of defined dependencies. Please review the changes and merge when ready.

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -4,8 +4,6 @@ on: # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
   workflow_dispatch:
-  push:
-    branches: ['**']
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -9,7 +9,7 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-# Default permissions for all jobss
+# Default permissions for all jobs
 permissions: {}
 
 jobs:

--- a/.github/workflows/update-latest-dependencies.yml
+++ b/.github/workflows/update-latest-dependencies.yml
@@ -12,7 +12,7 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-# Default permissions for all jobs
+# Default permissions for all jobss
 permissions: {}
 
 jobs:


### PR DESCRIPTION
**What does this PR do?**
Automates development dependency updates for Ruby versions 2.7 - 3.4

**Motivation**
As we use gem `datadog` dependency from master now we need to update it more often

**Additional Notes**
Note that jruby is excluded from automated updates for now: there is another issue with psych installation on jruby

**How to test the change?**
First automated PR is created:
https://github.com/DataDog/datadog-ci-rb/pull/315