### PR TITLE
[SDTEST-1961] Send `attempt_to_fix_passed:false` when attempt_to_fix_validation did not succeed

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -94,7 +94,7 @@ module Datadog
             AUTO_TEST_RETRIES_VERSION = "1"
             TEST_MANAGEMENT_QUARANTINE_VERSION = "1"
             TEST_MANAGEMENT_DISABLE_VERSION = "1"
-            TEST_MANAGEMENT_ATTEMPT_TO_FIX_VERSION = "2"
+            TEST_MANAGEMENT_ATTEMPT_TO_FIX_VERSION = "3"
           end
 
           # Map of capabilities to their versions

--- a/lib/datadog/ci/test_retries/component.rb
+++ b/lib/datadog/ci/test_retries/component.rb
@@ -111,9 +111,8 @@ module Datadog
           test_span&.set_tag(Ext::Test::TAG_HAS_FAILED_ALL_RETRIES, "true") if test_span&.all_executions_failed?
 
           # if we are attempting to fix the test and all retries passed, we indicate that the fix might have worked
-          if test_span&.attempt_to_fix? && test_span.all_executions_passed?
-            test_span&.set_tag(Ext::Test::TAG_ATTEMPT_TO_FIX_PASSED, "true")
-          end
+          # otherwise we send "false" to show that it didn't work
+          test_span&.set_tag(Ext::Test::TAG_ATTEMPT_TO_FIX_PASSED, test_span&.all_executions_passed?.to_s) if test_span&.attempt_to_fix?
         end
 
         def should_retry?

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -1577,8 +1577,11 @@ RSpec.describe "Minitest instrumentation" do
       failed_all_retries_count = test_spans.count { |span| span.get_tag("test.has_failed_all_retries") }
       expect(failed_all_retries_count).to eq(1)
 
-      fix_passed_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") }
-      expect(fix_passed_tests_count).to eq(0)
+      fix_passed_successfully_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") == "true" }
+      expect(fix_passed_successfully_tests_count).to eq(0)
+
+      fix_failed_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") == "false" }
+      expect(fix_failed_tests_count).to eq(1)
 
       expect(test_suite_spans).to have(1).item
       expect(test_suite_spans.first).to have_pass_status

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -1558,7 +1558,7 @@ RSpec.describe "RSpec instrumentation" do
       expect(disabled_count).to eq(attempt_to_fix_retries_count + 1)
 
       # we set test.test_management.attempt_to_fix_passed tag on the last retry here
-      fix_passed_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") }
+      fix_passed_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") == "true" }
       expect(fix_passed_tests_count).to eq(1)
 
       expect(test_suite_spans).to have(1).item

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
               "_dd.library_capabilities.auto_test_retries" => "1",
               "_dd.library_capabilities.test_management.quarantine" => "1",
               "_dd.library_capabilities.test_management.disable" => "1",
-              "_dd.library_capabilities.test_management.attempt_to_fix" => "2",
+              "_dd.library_capabilities.test_management.attempt_to_fix" => "3",
               "_dd.test.is_user_provided_service" => "true"
             )
           end


### PR DESCRIPTION
**What does this PR do?**
Sends tag `attempt_to_fix_passed:false` when attempt to fix validation didn't succeed. Bumps libraries capabilities version for attempt_to_fix

**How to test the change?**
Unit tests are provided