### PR TITLE
[SDTEST-1985] flaky test management: add sha parameter to the tests_properties request

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -94,7 +94,7 @@ module Datadog
             AUTO_TEST_RETRIES_VERSION = "1"
             TEST_MANAGEMENT_QUARANTINE_VERSION = "1"
             TEST_MANAGEMENT_DISABLE_VERSION = "1"
-            TEST_MANAGEMENT_ATTEMPT_TO_FIX_VERSION = "3"
+            TEST_MANAGEMENT_ATTEMPT_TO_FIX_VERSION = "4"
           end
 
           # Map of capabilities to their versions

--- a/lib/datadog/ci/test_management/tests_properties.rb
+++ b/lib/datadog/ci/test_management/tests_properties.rb
@@ -118,7 +118,8 @@ module Datadog
               "type" => Ext::Transport::DD_API_TEST_MANAGEMENT_TESTS_TYPE,
               "attributes" => {
                 "repository_url" => test_session.git_repository_url,
-                "commit_message" => test_session.git_commit_message
+                "commit_message" => test_session.git_commit_message,
+                "sha" => test_session.git_commit_sha
               }
             }
           }.to_json

--- a/spec/datadog/ci/test_management/tests_properties_spec.rb
+++ b/spec/datadog/ci/test_management/tests_properties_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Datadog::CI::TestManagement::TestsProperties do
       Datadog::Tracing::SpanOperation.new("session", service: service).tap do |span|
         span.set_tags({
           "git.repository_url" => "repository_url",
-          "git.commit.message" => "Test commit message"
+          "git.commit.message" => "Test commit message",
+          "git.commit.sha" => "test_sha"
         })
       end
     end
@@ -38,6 +39,7 @@ RSpec.describe Datadog::CI::TestManagement::TestsProperties do
         attributes = data["attributes"]
         expect(attributes["repository_url"]).to eq("repository_url")
         expect(attributes["commit_message"]).to eq("Test commit message")
+        expect(attributes["sha"]).to eq("test_sha")
       end
     end
 

--- a/spec/datadog/ci/test_visibility/transport_spec.rb
+++ b/spec/datadog/ci/test_visibility/transport_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Datadog::CI::TestVisibility::Transport do
               "_dd.library_capabilities.auto_test_retries" => "1",
               "_dd.library_capabilities.test_management.quarantine" => "1",
               "_dd.library_capabilities.test_management.disable" => "1",
-              "_dd.library_capabilities.test_management.attempt_to_fix" => "3",
+              "_dd.library_capabilities.test_management.attempt_to_fix" => "4",
               "_dd.test.is_user_provided_service" => "true"
             )
           end


### PR DESCRIPTION
**What does this PR do?**
Add sha parameter to the tests_properties request

**Motivation**
Last detail we need for flaky test remediation to work

**How to test the change?**
Unit tests are provided