### PR TITLE
[SDTEST-2020] fix CODEOWNERS parsing issue where "**" wasn't matching zero folders

### DIFF
--- a/lib/datadog/ci/codeowners/rule.rb
+++ b/lib/datadog/ci/codeowners/rule.rb
@@ -25,6 +25,8 @@ module Datadog
 
         def flags
           return ::File::FNM_PATHNAME if pattern.end_with?("#{::File::SEPARATOR}*")
+          return ::File::FNM_PATHNAME if pattern.include?("*.")
+          return ::File::FNM_PATHNAME if pattern.include?("/**/")
           0
         end
       end

--- a/spec/datadog/ci/codeowners/matcher_spec.rb
+++ b/spec/datadog/ci/codeowners/matcher_spec.rb
@@ -42,12 +42,24 @@ RSpec.describe Datadog::CI::Codeowners::Matcher do
             # Comment line
             /path/to/*.rb @owner3
             /path/to/file.rb @owner1 @owner2 #This is an inline comment.
+            /path/to/a/**/z @owner4
+            /path/to/module/**/** @owner5
           CODEOWNERS
         end
 
         it "returns the list of owners" do
           expect(matcher.list_owners("/path/to/file.rb")).to eq(["@owner1", "@owner2"])
+          expect(matcher.list_owners("/path/to/subfolder/file.rb")).to be_nil
           expect(matcher.list_owners("/path/to/another_file.rb")).to eq(["@owner3"])
+
+          expect(matcher.list_owners("/path/to/a/z/file.rb")).to eq(["@owner4"])
+          expect(matcher.list_owners("/path/to/a/c/z/file.rb")).to eq(["@owner4"])
+          expect(matcher.list_owners("/path/to/a/c/d/z/file.rb")).to eq(["@owner4"])
+          expect(matcher.list_owners("/path/to/a/c/d/z/y/file.rb")).to be_nil
+
+          expect(matcher.list_owners("/path/to/module/file.rb")).to eq(["@owner5"])
+          expect(matcher.list_owners("/path/to/module/submodule/file.rb")).to eq(["@owner5"])
+          expect(matcher.list_owners("/path/to/module/submodule/subsubmodule/file.rb")).to eq(["@owner5"])
         end
       end
 


### PR DESCRIPTION
**What does this PR do?**
As reported by customer we didn't handle the following rules correctly when matching CODEOWNERS rules:
- `/path/to/module/**/**` matched `/path/to/module/submodule/file.rb` but not `/path/to/module/file.rb`
- `/path/to/*.rb` matched not only `/path/to/file.rb` but also `/path/to/subfolder/file.rb`

This PR fixes these issues by using `FNM_PATHNAME` [flag](https://pubs.opengroup.org/onlinepubs/7908799/xsh/fnmatch.html) in more cases: when `*.` or `/**/` expressions are present in the pattern

**Motivation**
Bug reported by a customer

**How to test the change?**
Unit tests are expanded with new examples