### PR TITLE
[CODEX-1] Fix stdin close in Command.popen_with_stdin

### DIFF
--- a/lib/datadog/ci/utils/command.rb
+++ b/lib/datadog/ci/utils/command.rb
@@ -92,6 +92,7 @@ module Datadog
         end
 
         def self.popen_with_stdin(command, stdin_data: nil, retries_left: OPEN_STDIN_RETRY_COUNT)
+          stdin = nil
           result = Open3.popen2e(*command)
           stdin = result.first
 
@@ -108,7 +109,7 @@ module Datadog
 
           result
         ensure
-          stdin.close
+          stdin&.close
         end
       end
     end

--- a/spec/datadog/ci/utils/command_spec.rb
+++ b/spec/datadog/ci/utils/command_spec.rb
@@ -286,6 +286,16 @@ RSpec.describe Datadog::CI::Utils::Command do
         }.to raise_error(Errno::EPIPE)
       end
     end
+
+    context "when Open3.popen2e raises an error" do
+      it "propagates the error without NameError" do
+        allow(Open3).to receive(:popen2e).and_raise(Errno::ENOENT.new("not found"))
+
+        expect do
+          described_class.popen_with_stdin(["missing_command"], stdin_data: nil)
+        end.to raise_error(Errno::ENOENT)
+      end
+    end
   end
 
   describe "integration with real git commands" do


### PR DESCRIPTION
## Summary
- initialize `stdin` before creating subprocess
- close stdin only when initialized
- add spec for Open3 failure

## Testing
- `bundle exec rake spec:main` *(fails: The git source https://github.com/DataDog/dd-trace-rb.git is not yet checked out)*

------
https://chatgpt.com/codex/tasks/task_b_684bed237b1483259fc5a069892745a7