### PR TITLE
Add spec for missing command error

### DIFF
--- a/spec/datadog/ci/utils/command_spec.rb
+++ b/spec/datadog/ci/utils/command_spec.rb
@@ -211,6 +211,12 @@ RSpec.describe Datadog::CI::Utils::Command do
         expect(status).to be_success
       end
     end
+
+    context "when command is missing" do
+      it "raises Errno::ENOENT" do
+        expect { described_class.exec_command(["nonexistent_command"]) }.to raise_error(Errno::ENOENT)
+      end
+    end
   end
 
   describe ".popen_with_stdin" do


### PR DESCRIPTION
## Summary
- cover missing command case in `Command.exec_command`

## Testing
- `bundle exec standardrb spec/datadog/ci/utils/command_spec.rb` *(fails: command not found)*
- `bundle exec rspec spec/datadog/ci/utils/command_spec.rb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684bed118808832597be29c692a995fd