### PR TITLE
[NO-TICKET] Internal: update ci-queue dependency for tests

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -83,7 +83,7 @@ def self.with_ci_queue_minitest_gem(minitest_versions: 5, ci_queue_versions: 0)
     Array(ci_queue_versions).each do |ci_queue_v|
       appraise "ci-queue-#{ci_queue_v}-minitest-#{minitest_v}" do
         gem "minitest", "~> #{minitest_v}"
-        gem "ci-queue", "~> #{ci_queue_v}", "< 0.67"
+        gem "ci-queue", "~> #{ci_queue_v}"
         gem "minitest-reporters", "~> 1"
       end
     end

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile
@@ -15,7 +15,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -28,9 +28,9 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -95,7 +95,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,8 +27,8 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
-    ci-queue (0.67.0)
+    bigdecimal (3.2.2-java)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)

--- a/gemfiles/jruby_9.4_cucumber_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_10.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 482c04ebbb01274a52ab61f63143caf26ba1e5fb
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -55,7 +55,7 @@ GEM
       bigdecimal
     cucumber-gherkin (30.0.4)
       cucumber-messages (> 25, < 28)
-    cucumber-html-formatter (21.10.1)
+    cucumber-html-formatter (21.12.0)
       cucumber-messages (> 19, < 28)
     cucumber-messages (27.2.0)
     cucumber-tag-expressions (6.1.2)

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     backports (3.25.1)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     crack (1.0.0)

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -32,7 +32,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -32,7 +32,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -32,7 +32,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
@@ -87,7 +87,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0527)
+    mime-types-data (3.2025.0617)
     minitest (5.25.5)
     msgpack (1.8.0-java)
     multi_test (0.1.2)

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     crack (1.0.0)
@@ -76,7 +76,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0527)
+    mime-types-data (3.2025.0617)
     msgpack (1.8.0-java)
     multi_test (0.1.2)
     os (1.1.4)

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     climate_control (1.2.0)
     crack (1.0.0)
@@ -70,7 +70,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2025.0527)
+    mime-types-data (3.2025.0617)
     msgpack (1.8.0-java)
     multi_test (1.1.0)
     os (1.1.4)

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -54,7 +54,7 @@ GEM
       bigdecimal
     cucumber-gherkin (27.0.0)
       cucumber-messages (>= 19.1.4, < 23)
-    cucumber-html-formatter (21.9.0)
+    cucumber-html-formatter (21.12.0)
       cucumber-messages (> 19, < 28)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.2)

--- a/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     base64 (0.3.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -65,7 +65,7 @@ GEM
       bigdecimal
     cucumber-gherkin (27.0.0)
       cucumber-messages (>= 19.1.4, < 23)
-    cucumber-html-formatter (21.9.0)
+    cucumber-html-formatter (21.12.0)
       cucumber-messages (> 19, < 28)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.2)
@@ -88,7 +88,7 @@ GEM
     libddwaf (1.22.0.0.2-java)
       ffi (~> 1.0)
     logger (1.7.0)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     msgpack (1.8.0-java)
     multi_test (1.1.0)
@@ -97,7 +97,7 @@ GEM
     os (1.1.4)
     public_suffix (6.0.2)
     racc (1.8.1-java)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-test (2.2.0)
       rack (>= 1.3)
     rake (13.3.0)

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)

--- a/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_rails_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_5.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -107,7 +107,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0-java)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/gemfiles/jruby_9.4_rails_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_6.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -124,7 +124,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0-java)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)

--- a/gemfiles/jruby_9.4_rails_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_7.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -102,7 +102,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.1.7-java)
     builder (3.3.0)
-    cgi (0.4.2-java)
+    cgi (0.5.0-java)
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -146,7 +146,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0-java)
-    net-imap (0.5.8)
+    net-imap (0.5.9)
       date
       net-protocol
     net-pop (0.1.2)
@@ -167,7 +167,7 @@ GEM
       jar-dependencies (>= 0.1.7)
     public_suffix (6.0.2)
     racc (1.8.1-java)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -207,7 +207,7 @@ GEM
     rake (13.3.0)
     rake-compiler (1.3.0)
       rake
-    rdoc (6.14.0)
+    rdoc (6.14.1)
       erb
       psych (>= 4.0.0)
     reline (0.6.1)

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     base64 (0.3.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -64,7 +64,7 @@ GEM
       bigdecimal
     cucumber-gherkin (27.0.0)
       cucumber-messages (>= 19.1.4, < 23)
-    cucumber-html-formatter (21.9.0)
+    cucumber-html-formatter (21.12.0)
       cucumber-messages (> 19, < 28)
     cucumber-messages (22.0.0)
     cucumber-tag-expressions (6.1.2)
@@ -78,7 +78,7 @@ GEM
     libddwaf (1.22.0.0.2-java)
       ffi (~> 1.0)
     logger (1.7.0)
-    matrix (0.4.2)
+    matrix (0.4.3)
     mini_mime (1.1.5)
     msgpack (1.8.0-java)
     multi_test (1.1.0)
@@ -87,7 +87,7 @@ GEM
     os (1.1.4)
     public_suffix (6.0.2)
     racc (1.8.1-java)
-    rack (3.1.15)
+    rack (3.1.16)
     rack-test (2.2.0)
       rack (>= 1.3)
     rake (13.3.0)

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DataDog/dd-trace-rb.git
-  revision: 60d42f9dbb0f1c52e01f75f34cfcd0054dae2eb5
+  revision: cd3ce6a3941eafcbc2b9269cf5e05f9b39dd444b
   branch: master
   specs:
     datadog (2.17.0)
@@ -27,7 +27,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    bigdecimal (3.2.1-java)
+    bigdecimal (3.2.2-java)
     climate_control (1.2.0)
     crack (1.0.0)
       bigdecimal

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -31,7 +31,7 @@ GEM
     bigdecimal (3.2.2)
     builder (3.3.0)
     cgi (0.5.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -124,7 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -29,7 +29,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     cgi (0.5.0)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -31,7 +31,7 @@ GEM
     bigdecimal (3.2.2)
     builder (3.3.0)
     cgi (0.5.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -124,7 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!
@@ -142,4 +142,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -29,7 +29,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     cgi (0.5.0)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -183,4 +183,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -183,4 +183,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -161,4 +161,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
@@ -198,4 +198,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_5.gemfile.lock
@@ -252,4 +252,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_6.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_7.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -191,4 +191,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -31,7 +31,7 @@ GEM
     bigdecimal (3.2.2)
     builder (3.3.0)
     cgi (0.5.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -124,7 +124,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!
@@ -142,4 +142,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -29,7 +29,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     cgi (0.5.0)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
@@ -160,4 +160,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -183,4 +183,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -183,4 +183,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -167,4 +167,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -161,4 +161,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
@@ -198,4 +198,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_5.gemfile.lock
@@ -252,4 +252,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_6.gemfile.lock
@@ -271,4 +271,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_7.gemfile.lock
@@ -284,4 +284,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -191,4 +191,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -132,4 +132,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -30,7 +30,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -122,7 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!
@@ -140,4 +140,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -165,4 +165,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
@@ -196,4 +196,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_5.gemfile.lock
@@ -250,4 +250,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_6.gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_7.gemfile.lock
@@ -282,4 +282,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_8.gemfile.lock
@@ -283,4 +283,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -189,4 +189,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.3.26

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -30,7 +30,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -127,7 +127,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!
@@ -145,4 +145,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -134,4 +134,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
@@ -158,4 +158,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -153,4 +153,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -182,4 +182,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -186,4 +186,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -191,4 +191,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -170,4 +170,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -164,4 +164,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -162,4 +162,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
@@ -196,4 +196,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -134,4 +134,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
@@ -291,4 +291,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -133,4 +133,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -161,4 +161,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_5.gemfile.lock
@@ -250,4 +250,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_6.gemfile.lock
@@ -269,4 +269,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_7.gemfile.lock
@@ -282,4 +282,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_8.gemfile.lock
@@ -283,4 +283,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -131,4 +131,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -196,4 +196,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
@@ -290,4 +290,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -135,4 +135,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.4.19

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile
@@ -16,7 +16,7 @@ gem "yard"
 gem "datadog", git: "https://github.com/DataDog/dd-trace-rb.git", branch: "master"
 gem "os"
 gem "minitest", "~> 5"
-gem "ci-queue", "~> 0", "< 0.67"
+gem "ci-queue", "~> 0"
 gem "minitest-reporters", "~> 1"
 
 group :check do

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -30,7 +30,7 @@ GEM
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
     builder (3.3.0)
-    ci-queue (0.66.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -122,7 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  ci-queue (~> 0, < 0.67)
+  ci-queue (~> 0)
   climate_control
   datadog!
   datadog-ci!
@@ -140,4 +140,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -28,7 +28,7 @@ GEM
       rake
       thor (>= 0.14.0)
     bigdecimal (3.2.2)
-    ci-queue (0.68.0)
+    ci-queue (0.69.0)
       logger
     climate_control (1.2.0)
     crack (1.0.0)
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
@@ -184,4 +184,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -181,4 +181,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -185,4 +185,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -190,4 +190,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -165,4 +165,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -159,4 +159,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -157,4 +157,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
@@ -228,4 +228,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -155,4 +155,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
@@ -323,4 +323,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -128,4 +128,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -156,4 +156,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_5.gemfile.lock
@@ -286,4 +286,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_6.gemfile.lock
@@ -305,4 +305,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_7.gemfile.lock
@@ -314,4 +314,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_8.gemfile.lock
@@ -315,4 +315,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -191,4 +191,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
@@ -322,4 +322,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.21
+   2.5.17


### PR DESCRIPTION
**What does this PR do?**
Updates ci-queue dependency again now that the crash reason was fixed: https://github.com/Shopify/ci-queue/pull/340

**How to test the change?**
Change only for unit tests