### PR TITLE
[SDTEST-2033] FIX: send git.tag when requesting library settings if git.branch is not available

### DIFF
--- a/lib/datadog/ci/remote/library_settings_client.rb
+++ b/lib/datadog/ci/remote/library_settings_client.rb
@@ -81,7 +81,7 @@ module Datadog
                 "service" => test_session.service,
                 "env" => @dd_env,
                 "repository_url" => test_session.git_repository_url,
-                "branch" => test_session.git_branch,
+                "branch" => test_session.git_branch || test_session.git_tag,
                 "sha" => test_session.git_commit_sha,
                 "test_level" => Ext::Test::ITR_TEST_SKIPPING_MODE,
                 "configurations" => {

--- a/lib/datadog/ci/span.rb
+++ b/lib/datadog/ci/span.rb
@@ -171,6 +171,12 @@ module Datadog
         tracer_span.get_tag(Ext::Git::TAG_BRANCH)
       end
 
+      # Returns the git tag extracted from the environment.
+      # @return [String, nil] the tag or nil if not set.
+      def git_tag
+        tracer_span.get_tag(Ext::Git::TAG_TAG)
+      end
+
       # Returns the base commit SHA for the pull request, if available.
       # @return [String, nil] the base commit SHA or nil if not set.
       def base_commit_sha

--- a/sig/datadog/ci/span.rbs
+++ b/sig/datadog/ci/span.rbs
@@ -59,6 +59,8 @@ module Datadog
 
       def git_branch: () -> String?
 
+      def git_tag: () -> String?
+
       def os_architecture: () -> String?
 
       def os_platform: () -> String?

--- a/spec/datadog/ci/remote/library_settings_client_spec.rb
+++ b/spec/datadog/ci/remote/library_settings_client_spec.rb
@@ -110,6 +110,32 @@ RSpec.describe Datadog::CI::Remote::LibrarySettingsClient do
         end
       end
 
+      context "when git.branch is not present but git.tag is" do
+        let(:tracer_span) do
+          Datadog::Tracing::SpanOperation.new("session", service: service).tap do |span|
+            span.set_tags({
+              "git.repository_url" => "repository_url",
+              "git.tag" => "tag",
+              "git.commit.sha" => "commit_sha",
+              "os.platform" => "platform",
+              "os.architecture" => "arch",
+              "os.version" => "version",
+              "runtime.name" => "runtime_name",
+              "runtime.version" => "runtime_version"
+            })
+          end
+        end
+
+        it "requests the settings with the tag" do
+          subject
+
+          expect(api).to have_received(:api_request) do |args|
+            attributes = JSON.parse(args[:payload])["data"]["attributes"]
+            expect(attributes["branch"]).to eq("tag")
+          end
+        end
+      end
+
       context "parsing response" do
         context "when response is OK" do
           it "parses the response" do

--- a/spec/datadog/ci/span_spec.rb
+++ b/spec/datadog/ci/span_spec.rb
@@ -302,6 +302,20 @@ RSpec.describe Datadog::CI::Span do
     end
   end
 
+  describe "#git_tag" do
+    it "returns the git tag" do
+      expect(tracer_span).to receive(:get_tag).with("git.tag").and_return("v1.0.0")
+
+      expect(span.git_tag).to eq("v1.0.0")
+    end
+
+    it "returns nil if the tag is not set" do
+      expect(tracer_span).to receive(:get_tag).with("git.tag").and_return(nil)
+
+      expect(span.git_tag).to be_nil
+    end
+  end
+
   describe "#base_commit_sha" do
     it "returns the base commit SHA for the pull request" do
       expect(tracer_span).to receive(:get_tag).with("git.pull_request.base_branch_sha").and_return("base_sha")


### PR DESCRIPTION
**What does this PR do?**
Fixes a 400 error when requesting library settings if CI pipeline is triggered for a tag 

**Motivation**
Error reported in python library

