### PR TITLE
[SDTEST-2193] Internal: telemetry logging improvements

### DIFF
--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -295,9 +295,9 @@ module Datadog
           test_optimisation.stop_coverage(test)
           test_optimisation.on_test_finished(test, maybe_remote_context)
 
-          Telemetry.event_finished(test)
-
           test_retries.record_test_finished(test)
+
+          Telemetry.event_finished(test)
         end
 
         def on_after_test_span_finished(tracer_span)

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -296,7 +296,6 @@ module Datadog
           test_optimisation.on_test_finished(test, maybe_remote_context)
 
           test_retries.record_test_finished(test)
-
           Telemetry.event_finished(test)
         end
 

--- a/sig/datadog/ci/test_visibility/transport.rbs
+++ b/sig/datadog/ci/test_visibility/transport.rbs
@@ -5,9 +5,6 @@ module Datadog
         attr_reader serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
         attr_reader dd_env: String?
 
-        self.@log_once: Datadog::Core::Utils::OnlyOnce
-        def self.log_once: () -> Datadog::Core::Utils::OnlyOnce
-
         @dd_env: String?
         @serializers_factory: singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestLevel) | singleton(Datadog::CI::TestVisibility::Serializers::Factories::TestSuiteLevel)
 


### PR DESCRIPTION
**What does this PR do?**
Improves Datadog telemetry: ignore skipped Span events because it is very noisy but instead log all dropped events connected to Datadog Test Optimization

**Motivation**
I want to be able to investigate dropped test events better

**How to test the change?**
Unit tests are provided