### PR TITLE
[BUGFIX] fix: RSpec's DocumentationFormatter might not be present at instrumentation time

### DIFF
--- a/lib/datadog/ci/contrib/rspec/integration.rb
+++ b/lib/datadog/ci/contrib/rspec/integration.rb
@@ -24,10 +24,7 @@ module Datadog
             !defined?(::RSpec).nil? && !defined?(::RSpec::Core).nil? &&
               !defined?(::RSpec::Core::Example).nil? &&
               !defined?(::RSpec::Core::Runner).nil? &&
-              !defined?(::RSpec::Core::ExampleGroup).nil? &&
-              !defined?(::RSpec::Core::Formatters::DocumentationFormatter).nil? &&
-              !defined?(::RSpec::Core::Formatters::BaseFormatter).nil? &&
-              !defined?(::RSpec::Core::Formatters::BaseTextFormatter).nil?
+              !defined?(::RSpec::Core::ExampleGroup).nil?
           end
 
           def compatible?

--- a/lib/datadog/ci/contrib/rspec/patcher.rb
+++ b/lib/datadog/ci/contrib/rspec/patcher.rb
@@ -21,7 +21,13 @@ module Datadog
             ::RSpec::Core::Runner.include(Runner)
             ::RSpec::Core::Example.include(Example)
             ::RSpec::Core::ExampleGroup.include(ExampleGroup)
-            ::RSpec::Core::Formatters::DocumentationFormatter.include(DocumentationFormatter)
+
+            # only add DocumentationFormatter's patch if it's loaded at this point
+            if defined?(::RSpec::Core::Formatters::DocumentationFormatter) &&
+                defined?(::RSpec::Core::Formatters::BaseFormatter) &&
+                defined?(::RSpec::Core::Formatters::BaseTextFormatter)
+              ::RSpec::Core::Formatters::DocumentationFormatter.include(DocumentationFormatter)
+            end
           end
         end
       end


### PR DESCRIPTION
**What does this PR do?**
Attempts to fix https://github.com/DataDog/datadog-ci-rb/issues/380

We have a very curious bug report in an issue above where knapsack_pro tracing stops working after pretty innocuous minor version update of datadog-ci gem.  Examining the debug logs did not bring a lot of clarity: the tests seem to be running normally, APM tracing works, transport layer works - but not a single RSpec example traced. As if RSpec instrumentation wouldn't exist at all.

The only change between `1.19.0` and `1.20.2` that could cause this behaviour is this:

```ruby
              !defined?(::RSpec::Core::Formatters::DocumentationFormatter).nil? &&
              !defined?(::RSpec::Core::Formatters::BaseFormatter).nil? &&
              !defined?(::RSpec::Core::Formatters::BaseTextFormatter).nil?
```

There is a possibility that it is wrong to expect RSpec formatters to be loaded when `spec_helper` is required - so I'll carefully revert this change for now and we'll see if it helps.

The downside of this change is that Datadog's additional output will disappear for auto instrumented test sessions - this one is to have a proper fix at a later point.

**Motivation**
Fixing an issue reported

**How to test the change?**
Unit and integration tests still pass