### PR TITLE
[SDTEST-2284] Add ci.job.id tag to events

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -13,6 +13,7 @@ module Datadog
     module Ext
       # Defines constants for CI tags
       module Environment
+        TAG_JOB_ID = "ci.job.id"
         TAG_JOB_NAME = "ci.job.name"
         TAG_JOB_URL = "ci.job.url"
         TAG_PIPELINE_ID = "ci.pipeline.id"

--- a/lib/datadog/ci/ext/environment/extractor.rb
+++ b/lib/datadog/ci/ext/environment/extractor.rb
@@ -23,6 +23,7 @@ module Datadog
             return @tags if defined?(@tags)
 
             @tags = {
+              Environment::TAG_JOB_ID => @provider.job_id,
               Environment::TAG_JOB_NAME => @provider.job_name,
               Environment::TAG_JOB_URL => @provider.job_url,
               Environment::TAG_PIPELINE_ID => @provider.pipeline_id,

--- a/lib/datadog/ci/ext/environment/providers/aws_code_pipeline.rb
+++ b/lib/datadog/ci/ext/environment/providers/aws_code_pipeline.rb
@@ -20,6 +20,10 @@ module Datadog
               Provider::AWS
             end
 
+            def job_id
+              env["DD_ACTION_EXECUTION_ID"]
+            end
+
             def pipeline_id
               env["DD_PIPELINE_EXECUTION_ID"]
             end

--- a/lib/datadog/ci/ext/environment/providers/azure.rb
+++ b/lib/datadog/ci/ext/environment/providers/azure.rb
@@ -20,6 +20,10 @@ module Datadog
               Provider::AZURE
             end
 
+            def job_id
+              env["SYSTEM_JOBID"]
+            end
+
             def pipeline_url
               return unless url_defined?
 

--- a/lib/datadog/ci/ext/environment/providers/base.rb
+++ b/lib/datadog/ci/ext/environment/providers/base.rb
@@ -18,6 +18,9 @@ module Datadog
               @env = env
             end
 
+            def job_id
+            end
+
             def job_name
             end
 

--- a/lib/datadog/ci/ext/environment/providers/buildkite.rb
+++ b/lib/datadog/ci/ext/environment/providers/buildkite.rb
@@ -20,6 +20,10 @@ module Datadog
               Provider::BUILDKITE
             end
 
+            def job_id
+              env["BUILDKITE_JOB_ID"]
+            end
+
             def job_url
               "#{env["BUILDKITE_BUILD_URL"]}##{env["BUILDKITE_JOB_ID"]}"
             end

--- a/lib/datadog/ci/ext/environment/providers/circleci.rb
+++ b/lib/datadog/ci/ext/environment/providers/circleci.rb
@@ -20,6 +20,10 @@ module Datadog
               Provider::CIRCLECI
             end
 
+            def job_id
+              env["CIRCLE_BUILD_NUM"]
+            end
+
             def job_url
               env["CIRCLE_BUILD_URL"]
             end

--- a/lib/datadog/ci/ext/environment/providers/github_actions.rb
+++ b/lib/datadog/ci/ext/environment/providers/github_actions.rb
@@ -31,6 +31,10 @@ module Datadog
               "#{github_server_url}/#{env["GITHUB_REPOSITORY"]}/commit/#{env["GITHUB_SHA"]}/checks"
             end
 
+            def job_id
+              env["GITHUB_JOB"]
+            end
+
             def pipeline_id
               env["GITHUB_RUN_ID"]
             end

--- a/lib/datadog/ci/ext/environment/providers/gitlab.rb
+++ b/lib/datadog/ci/ext/environment/providers/gitlab.rb
@@ -18,6 +18,10 @@ module Datadog
               Provider::GITLAB
             end
 
+            def job_id
+              env["CI_JOB_ID"]
+            end
+
             def job_name
               env["CI_JOB_NAME"]
             end

--- a/sig/datadog/ci/ext/environment.rbs
+++ b/sig/datadog/ci/ext/environment.rbs
@@ -3,6 +3,8 @@ module Datadog
     module Ext
       # Defines constants for CI tags
       module Environment
+        TAG_JOB_ID: String
+
         TAG_JOB_NAME: String
 
         TAG_JOB_URL: String

--- a/sig/datadog/ci/ext/environment/providers/aws_code_pipeline.rbs
+++ b/sig/datadog/ci/ext/environment/providers/aws_code_pipeline.rbs
@@ -8,6 +8,8 @@ module Datadog
 
             def provider_name: () -> "awscodepipeline"
 
+            def job_id: () -> String?
+
             def pipeline_id: () -> String?
 
             def ci_env_vars: () -> String?

--- a/sig/datadog/ci/ext/environment/providers/azure.rbs
+++ b/sig/datadog/ci/ext/environment/providers/azure.rbs
@@ -9,6 +9,8 @@ module Datadog
 
             def provider_name: () -> "azurepipelines"
 
+            def job_id: () -> String?
+
             def pipeline_url: () -> String?
 
             def job_url: () -> String?

--- a/sig/datadog/ci/ext/environment/providers/base.rbs
+++ b/sig/datadog/ci/ext/environment/providers/base.rbs
@@ -12,6 +12,8 @@ module Datadog
 
             def initialize: (Hash[String, String?] env) -> void
 
+            def job_id: () -> String?
+
             def job_name: () -> nil
 
             def job_url: () -> nil

--- a/sig/datadog/ci/ext/environment/providers/buildkite.rbs
+++ b/sig/datadog/ci/ext/environment/providers/buildkite.rbs
@@ -6,6 +6,8 @@ module Datadog
           class Buildkite < Base
             def provider_name: () -> "buildkite"
 
+            def job_id: () -> String?
+
             def job_url: () -> ::String
 
             def pipeline_id: () -> String?

--- a/sig/datadog/ci/ext/environment/providers/circleci.rbs
+++ b/sig/datadog/ci/ext/environment/providers/circleci.rbs
@@ -6,6 +6,8 @@ module Datadog
           class Circleci < Base
             def provider_name: () -> "circleci"
 
+            def job_id: () -> String?
+
             def job_url: () -> String?
 
             def job_name: () -> String?

--- a/sig/datadog/ci/ext/environment/providers/gitlab.rbs
+++ b/sig/datadog/ci/ext/environment/providers/gitlab.rbs
@@ -8,6 +8,8 @@ module Datadog
 
             def provider_name: () -> "gitlab"
 
+            def job_id: () -> String?
+
             def job_name: () -> String?
 
             def job_url: () -> String?

--- a/spec/datadog/ci/ext/environment/providers/azure_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/azure_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Azure do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+          "ci.job.id" => "azure-pipelines-job-id",
           "ci.job.url" => "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
           "ci.pipeline.id" => "azure-pipelines-build-id",
           "ci.pipeline.name" => "azure-pipelines-name",

--- a/spec/datadog/ci/ext/environment/providers/buildkite_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/buildkite_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Buildkite do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+          "ci.job.id" => "buildkite-job-id",
           "ci.job.url" => "https://buildkite-build-url.com#buildkite-job-id",
           "ci.pipeline.id" => "buildkite-pipeline-id",
           "ci.pipeline.name" => "buildkite-pipeline-name",

--- a/spec/datadog/ci/ext/environment/providers/circleci_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/circleci_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Circleci do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+          "ci.job.id" => "circleci-pipeline-number",
           "ci.job.name" => "circleci-job-name",
           "ci.job.url" => "https://circleci-build-url.com/",
           "ci.pipeline.id" => "circleci-pipeline-id",

--- a/spec/datadog/ci/ext/environment/providers/github_actions_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/github_actions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::GithubActions do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+          "ci.job.id" => "github-job-name",
           "ci.job.name" => "github-job-name",
           "ci.job.url" => "https://ghenterprise.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
           "ci.pipeline.id" => "ghactions-pipeline-id",
@@ -64,6 +65,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::GithubActions do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+          "ci.job.id" => "github-job-name",
           "ci.job.name" => "github-job-name",
           "ci.job.url" => "https://ghenterprise.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
           "ci.pipeline.id" => "ghactions-pipeline-id",
@@ -108,6 +110,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::GithubActions do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+          "ci.job.id" => "github-job-name",
           "ci.job.name" => "github-job-name",
           "ci.job.url" => "https://ghenterprise.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
           "ci.pipeline.id" => "ghactions-pipeline-id",

--- a/spec/datadog/ci/ext/environment/providers/gitlab_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/gitlab_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Gitlab do
       let(:expected_tags) do
         {
           "_dd.ci.env_vars" => "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+          "ci.job.id" => "gitlab-job-id",
           "ci.job.name" => "gitlab-job-name",
           "ci.job.url" => "https://gitlab.com/job",
           "ci.pipeline.id" => "gitlab-pipeline-id",

--- a/spec/support/fixtures/ci/awscodepipeline.json
+++ b/spec/support/fixtures/ci/awscodepipeline.json
@@ -18,6 +18,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CODEBUILD_BUILD_ARN\":\"arn:aws:codebuild:eu-north-1:12345678:build/codebuild-demo-project:b1e6661e-e4f2-4156-9ab9-82a19\",\"DD_PIPELINE_EXECUTION_ID\":\"bb1f15ed-fde2-494d-8e13-88785bca9cc0\",\"DD_ACTION_EXECUTION_ID\":\"35519dc3-7c45-493c-9ba6-cd78ea11f69d\"}",
+      "ci.job.id": "35519dc3-7c45-493c-9ba6-cd78ea11f69d",
       "ci.pipeline.id": "bb1f15ed-fde2-494d-8e13-88785bca9cc0",
       "ci.provider.name": "awscodepipeline",
       "git.branch": "user-supplied-branch",

--- a/spec/support/fixtures/ci/azurepipelines.json
+++ b/spec/support/fixtures/ci/azurepipelines.json
@@ -18,6 +18,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -53,6 +54,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -87,6 +89,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -123,6 +126,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -159,6 +163,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -195,6 +200,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -231,6 +237,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -267,6 +274,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -301,6 +309,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -335,6 +344,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -369,6 +379,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -403,6 +414,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -437,6 +449,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -473,6 +486,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -510,6 +524,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -549,6 +564,7 @@
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
       "ci.job.name": "azure-pipelines-job-name",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -589,6 +605,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -632,6 +649,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -667,6 +685,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -696,6 +715,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -724,6 +744,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -752,6 +773,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -780,6 +802,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -808,6 +831,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -836,6 +860,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -864,6 +889,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -892,6 +918,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -920,6 +947,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",
@@ -949,6 +977,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"SYSTEM_TEAMPROJECTID\":\"azure-pipelines-project-id\",\"BUILD_BUILDID\":\"azure-pipelines-build-id\",\"SYSTEM_JOBID\":\"azure-pipelines-job-id\"}",
+      "ci.job.id": "azure-pipelines-job-id",
       "ci.job.url": "https://azure-pipelines-server-uri.com/azure-pipelines-project-id/_build/results?buildId=azure-pipelines-build-id&view=logs&j=azure-pipelines-job-id&t=azure-pipelines-task-id",
       "ci.pipeline.id": "azure-pipelines-build-id",
       "ci.pipeline.name": "azure-pipelines-name",

--- a/spec/support/fixtures/ci/buildkite.json
+++ b/spec/support/fixtures/ci/buildkite.json
@@ -20,6 +20,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -56,6 +57,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -92,6 +94,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -128,6 +131,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -166,6 +170,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -204,6 +209,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -242,6 +248,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -278,6 +285,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -314,6 +322,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -350,6 +359,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -386,6 +396,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -422,6 +433,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -458,6 +470,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -494,6 +507,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -530,6 +544,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -566,6 +581,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -602,6 +618,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -646,6 +663,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -693,6 +711,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -732,6 +751,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -766,6 +786,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -799,6 +820,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -832,6 +854,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -865,6 +888,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -898,6 +922,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -931,6 +956,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -964,6 +990,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -997,6 +1024,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -1030,6 +1058,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",
@@ -1065,6 +1094,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.node.labels": "[\"mytag:my-value\",\"myothertag:my-other-value\"]",
       "ci.node.name": "1a222222-e999-3636-8ddd-802222222222",
@@ -1098,6 +1128,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"BUILDKITE_BUILD_ID\":\"buildkite-pipeline-id\",\"BUILDKITE_JOB_ID\":\"buildkite-job-id\"}",
+      "ci.job.id": "buildkite-job-id",
       "ci.job.url": "https://buildkite-build-url.com#buildkite-job-id",
       "ci.pipeline.id": "buildkite-pipeline-id",
       "ci.pipeline.name": "buildkite-pipeline-name",

--- a/spec/support/fixtures/ci/circleci.json
+++ b/spec/support/fixtures/ci/circleci.json
@@ -14,6 +14,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -41,6 +42,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -68,6 +70,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -95,6 +98,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -124,6 +128,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -153,6 +158,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -182,6 +188,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -209,6 +216,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -236,6 +244,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -264,6 +273,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -292,6 +302,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -319,6 +330,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -346,6 +358,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -373,6 +386,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -400,6 +414,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -427,6 +442,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -461,6 +477,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -501,6 +518,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -533,6 +551,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -557,6 +576,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -580,6 +600,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -603,6 +624,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -626,6 +648,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -649,6 +672,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -672,6 +696,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -695,6 +720,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -718,6 +744,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -741,6 +768,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",
@@ -764,6 +792,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CIRCLE_WORKFLOW_ID\":\"circleci-pipeline-id\",\"CIRCLE_BUILD_NUM\":\"circleci-pipeline-number\"}",
+      "ci.job.id": "circleci-pipeline-number",
       "ci.job.name": "circleci-job-name",
       "ci.job.url": "https://circleci-build-url.com/",
       "ci.pipeline.id": "circleci-pipeline-id",

--- a/spec/support/fixtures/ci/github.json
+++ b/spec/support/fixtures/ci/github.json
@@ -15,6 +15,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://ghenterprise.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://ghenterprise.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -44,6 +45,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -73,6 +75,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -102,6 +105,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -131,6 +135,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -162,6 +167,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -193,6 +199,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -224,6 +231,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -253,6 +261,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -282,6 +291,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -311,6 +321,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -340,6 +351,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -369,6 +381,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -399,6 +412,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -429,6 +443,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -459,6 +474,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -497,6 +513,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -542,6 +559,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -575,6 +593,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -600,6 +619,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -625,6 +645,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -650,6 +671,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com:1234/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -675,6 +697,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://1.1.1.1/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -700,6 +723,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://1.1.1.1:1234\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://1.1.1.1:1234/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",
@@ -726,6 +750,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"GITHUB_SERVER_URL\":\"https://github.com\",\"GITHUB_REPOSITORY\":\"ghactions-repo\",\"GITHUB_RUN_ID\":\"ghactions-pipeline-id\",\"GITHUB_RUN_ATTEMPT\":\"ghactions-run-attempt\"}",
+      "ci.job.id": "github-job-name",
       "ci.job.name": "github-job-name",
       "ci.job.url": "https://github.com/ghactions-repo/commit/b9f0fb3fdbb94c9d24b2c75b49663122a529e123/checks",
       "ci.pipeline.id": "ghactions-pipeline-id",

--- a/spec/support/fixtures/ci/gitlab.json
+++ b/spec/support/fixtures/ci/gitlab.json
@@ -21,6 +21,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -61,6 +62,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -101,6 +103,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -143,6 +146,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -185,6 +189,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -227,6 +232,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -267,6 +273,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -307,6 +314,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -348,6 +356,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -390,6 +399,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -432,6 +442,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -474,6 +485,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -515,6 +527,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -555,6 +568,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -595,6 +609,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -635,6 +650,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -675,6 +691,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -715,6 +732,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -755,6 +773,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -795,6 +814,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -835,6 +855,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -875,6 +896,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -925,6 +947,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -978,6 +1001,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",
@@ -1024,6 +1048,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.node.labels": "[\"arch:arm64\",\"linux\"]",
@@ -1068,6 +1093,7 @@
     },
     {
       "_dd.ci.env_vars": "{\"CI_PROJECT_URL\":\"https://gitlab.com/repo\",\"CI_PIPELINE_ID\":\"gitlab-pipeline-id\",\"CI_JOB_ID\":\"gitlab-job-id\"}",
+      "ci.job.id": "gitlab-job-id",
       "ci.job.name": "gitlab-job-name",
       "ci.job.url": "https://gitlab.com/job",
       "ci.pipeline.id": "gitlab-pipeline-id",


### PR DESCRIPTION
**What does this PR do?**
Adds `ci.job.id` tag

**Motivation**
We sent the information about the job.id in `_dd.ci.env.vars` but not in separate tag before - this was confusing

**How to test the change?**
Unit tests are provided