### PR TITLE
[SDTEST-2431] fix Minitest's test suite name when encountering relative source file paths

### DIFF
--- a/lib/datadog/ci/contrib/minitest/helpers.rb
+++ b/lib/datadog/ci/contrib/minitest/helpers.rb
@@ -38,7 +38,18 @@ module Datadog
               source_location, = klass.instance_method(method_name).source_location
             end
 
-            source_file_path = Pathname.new(source_location.to_s).relative_path_from(Pathname.pwd).to_s
+            # According to https://github.com/DataDog/datadog-ci-rb/issues/386
+            # the source file path coould be relative when using minitest mixins.
+            #
+            # Note that it doesn't break for test suite source location in .start_test_suite method
+            # because it outputs path relative to the repository root.
+            #
+            # For backwards compatibility, we'll continue to use the relative path from the current
+            # working directory for test suite name.
+            source_file_path = Pathname.new(source_location.to_s)
+            if source_file_path.absolute?
+              source_file_path = source_file_path.relative_path_from(Pathname.pwd).to_s
+            end
 
             "#{klass.name} at #{source_file_path}"
           end


### PR DESCRIPTION
**What does this PR do?**
Fixes the crash when encountering relative paths for Minitest's test suites

**Motivation**
Fix https://github.com/DataDog/datadog-ci-rb/issues/386

**Additional Notes**
Thanks @ebarajas for sending the fix

**How to test the change?**
Unit test is provided