### PR TITLE
[SDTEST-2432] fetch exact head commit instead of unshallowing parent for impacted tests detection

### DIFF
--- a/lib/datadog/ci/ext/environment.rb
+++ b/lib/datadog/ci/ext/environment.rb
@@ -71,7 +71,7 @@ module Datadog
           # we need to unshallow at least the parent of the current merge commit to be able to extract information
           # from the real original commit.
           if tags[Git::TAG_COMMIT_HEAD_SHA]
-            CI::Git::LocalRepository.git_unshallow(parent_only: true) if CI::Git::LocalRepository.git_shallow_clone?
+            CI::Git::LocalRepository.fetch_head_commit_sha(tags[Git::TAG_COMMIT_HEAD_SHA]) if CI::Git::LocalRepository.git_shallow_clone?
 
             env[ENV_SPECIAL_KEY_FOR_GIT_COMMIT_HEAD_SHA] = tags[Git::TAG_COMMIT_HEAD_SHA]
           end

--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -144,6 +144,7 @@ module Datadog
           PACK_OBJECTS = "pack_objects"
           DIFF = "diff"
           BASE_COMMIT_SHA = "base_commit_sha"
+          FETCH_HEAD_COMMIT_SHA = "fetch_head_commit_sha"
         end
 
         module Provider

--- a/lib/datadog/ci/git/base_branch_sha_detector.rb
+++ b/lib/datadog/ci/git/base_branch_sha_detector.rb
@@ -10,7 +10,7 @@ module Datadog
         def self.base_branch_sha(base_branch)
           Datadog.logger.debug { "Base branch: '#{base_branch}'" }
 
-          remote_name = get_remote_name
+          remote_name = LocalRepository.get_remote_name
           Datadog.logger.debug { "Remote name: '#{remote_name}'" }
 
           source_branch = get_source_branch
@@ -25,20 +25,6 @@ module Datadog
           end
 
           strategy.call
-        end
-
-        def self.get_remote_name
-          # Try to find remote from upstream tracking
-          upstream = LocalRepository.get_upstream_branch
-
-          if upstream
-            upstream.split("/").first
-          else
-            # Fallback to first remote if no upstream is set
-            first_remote_value = CLI.exec_git_command(["remote"])&.split("\n")&.first
-            Datadog.logger.debug { "First remote value: '#{first_remote_value}'" }
-            first_remote_value || "origin"
-          end
         end
 
         def self.get_source_branch

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -213,6 +213,8 @@ module Datadog
           DIFF: "diff"
 
           BASE_COMMIT_SHA: "base_commit_sha"
+
+          FETCH_HEAD_COMMIT_SHA: "fetch_head_commit_sha"
         end
 
         module Provider

--- a/sig/datadog/ci/git/base_branch_sha_detector.rbs
+++ b/sig/datadog/ci/git/base_branch_sha_detector.rbs
@@ -4,8 +4,6 @@ module Datadog
       module BaseBranchShaDetector
         def self.base_branch_sha: (String? base_branch) -> String?
 
-        def self.get_remote_name: () -> String
-
         def self.get_source_branch: () -> String?
       end
     end

--- a/sig/datadog/ci/git/local_repository.rbs
+++ b/sig/datadog/ci/git/local_repository.rbs
@@ -36,13 +36,17 @@ module Datadog
 
         def self.git_shallow_clone?: () -> bool
 
-        def self.git_unshallow: (?parent_only: bool) -> String?
+        def self.git_unshallow: () -> String?
 
         def self.get_changes_since: (String? base_commit) -> Datadog::CI::Git::Diff
 
         def self.base_commit_sha: (?base_branch: String?) -> String?
 
         def self.get_upstream_branch: () -> String?
+
+        def self.fetch_head_commit_sha: (String git_commit_sha) -> String?
+
+        def self.get_remote_name: () -> String
 
         def self.filter_invalid_commits: (Enumerable[String] commits) -> Array[String]
 

--- a/spec/datadog/ci/ext/environment_spec.rb
+++ b/spec/datadog/ci/ext/environment_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment do
               let(:shallow_clone) { true }
 
               it "returns head commit info" do
-                expect(Datadog::CI::Git::LocalRepository).to receive(:git_unshallow).with(parent_only: true).and_return(true)
+                expect(Datadog::CI::Git::LocalRepository).to receive(:fetch_head_commit_sha).with("my-commit-head-sha").and_return(true)
 
                 is_expected.to include(
                   "git.commit.head.message" => head_commit_message

--- a/spec/datadog/ci/git/local_repository_integration_spec.rb
+++ b/spec/datadog/ci/git/local_repository_integration_spec.rb
@@ -484,17 +484,6 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
         end
       end
 
-      context "unshallow with parent_only" do
-        subject do
-          with_clone_git_dir { described_class.git_unshallow(parent_only: true) }
-        end
-
-        it "unshallows the repository" do
-          expect(subject).to be_truthy
-          expect(commits.size).to eq(2)
-        end
-      end
-
       context "when unshallow command fails" do
         before do
           head_commit = "sha"
@@ -520,6 +509,25 @@ RSpec.describe ::Datadog::CI::Git::LocalRepository do
 
         # it signals error to the telemetry
         it_behaves_like "emits telemetry metric", :inc, "git.command_errors", 1
+      end
+    end
+
+    describe ".fetch_head_commit_sha" do
+      let(:commit_sha) do
+        with_source_git_dir do
+          `git rev-parse HEAD~1`.strip
+        end
+      end
+      subject { with_clone_git_dir { described_class.fetch_head_commit_sha(commit_sha) } }
+
+      it "fetches the commit" do
+        subject
+
+        git_commit_message = with_clone_git_dir do
+          described_class.git_commit_message(commit_sha)
+        end
+
+        expect(git_commit_message).to eq("Update README 2")
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
Changes the way we fetch head commit when doing impacted tests detection: before we were always fetching parent commit, now we fetch exact commit sha

**Motivation**
Increase precision of impacted tests feature

**How to test the change?**
Unit tests