### PR TITLE
[SDTEST-2355] Fix handling of base branch commit SHA for Github Actions and GItlab

### DIFF
--- a/lib/datadog/ci/ext/environment/extractor.rb
+++ b/lib/datadog/ci/ext/environment/extractor.rb
@@ -52,6 +52,7 @@ module Datadog
 
               Git::TAG_PULL_REQUEST_BASE_BRANCH => @provider.git_pull_request_base_branch,
               Git::TAG_PULL_REQUEST_BASE_BRANCH_SHA => @provider.git_pull_request_base_branch_sha,
+              Git::TAG_PULL_REQUEST_BASE_BRANCH_HEAD_SHA => @provider.git_pull_request_base_branch_head_sha,
               Environment::TAG_PR_NUMBER => @provider.pr_number,
 
               Git::TAG_COMMIT_HEAD_SHA => @provider.git_commit_head_sha,

--- a/lib/datadog/ci/ext/environment/providers/base.rb
+++ b/lib/datadog/ci/ext/environment/providers/base.rb
@@ -107,6 +107,9 @@ module Datadog
             def git_pull_request_base_branch_sha
             end
 
+            def git_pull_request_base_branch_head_sha
+            end
+
             def git_commit_head_sha
             end
 

--- a/lib/datadog/ci/ext/environment/providers/github_actions.rb
+++ b/lib/datadog/ci/ext/environment/providers/github_actions.rb
@@ -84,7 +84,7 @@ module Datadog
               env["GITHUB_BASE_REF"]
             end
 
-            def git_pull_request_base_branch_sha
+            def git_pull_request_base_branch_head_sha
               return nil if git_pull_request_base_branch.nil?
 
               event_json = github_event_json
@@ -92,8 +92,8 @@ module Datadog
 
               event_json.dig("pull_request", "base", "sha")
             rescue => e
-              Datadog.logger.error("Failed to extract pull request base branch SHA from GitHub Actions: #{e}")
-              Core::Telemetry::Logger.report(e, description: "Failed to extract pull request base branch SHA from GitHub Actions")
+              Datadog.logger.error("Failed to extract pull request base branch head SHA from GitHub Actions: #{e}")
+              Core::Telemetry::Logger.report(e, description: "Failed to extract pull request base branch head SHA from GitHub Actions")
               nil
             end
 

--- a/lib/datadog/ci/ext/environment/providers/gitlab.rb
+++ b/lib/datadog/ci/ext/environment/providers/gitlab.rb
@@ -108,6 +108,14 @@ module Datadog
               env["CI_MERGE_REQUEST_TARGET_BRANCH_NAME"]
             end
 
+            def git_pull_request_base_branch_sha
+              env["CI_MERGE_REQUEST_DIFF_BASE_SHA"]
+            end
+
+            def git_pull_request_base_branch_head_sha
+              env["CI_MERGE_REQUEST_TARGET_BRANCH_SHA"]
+            end
+
             def git_commit_head_sha
               env["CI_MERGE_REQUEST_SOURCE_BRANCH_SHA"]
             end

--- a/lib/datadog/ci/ext/git.rb
+++ b/lib/datadog/ci/ext/git.rb
@@ -23,6 +23,7 @@ module Datadog
         # additional tags that we use for github actions jobs with "pull_request" target
         TAG_PULL_REQUEST_BASE_BRANCH = "git.pull_request.base_branch"
         TAG_PULL_REQUEST_BASE_BRANCH_SHA = "git.pull_request.base_branch_sha"
+        TAG_PULL_REQUEST_BASE_BRANCH_HEAD_SHA = "git.pull_request.base_branch_head_sha"
 
         TAG_COMMIT_HEAD_SHA = "git.commit.head.sha"
         TAG_COMMIT_HEAD_MESSAGE = "git.commit.head.message"

--- a/sig/datadog/ci/ext/environment/providers/base.rbs
+++ b/sig/datadog/ci/ext/environment/providers/base.rbs
@@ -66,6 +66,8 @@ module Datadog
 
             def git_pull_request_base_branch_sha: () -> String?
 
+            def git_pull_request_base_branch_head_sha: () -> String?
+
             def git_commit_head_sha: () -> String?
 
             def git_commit_head_message: () -> String?

--- a/sig/datadog/ci/ext/environment/providers/github_actions.rbs
+++ b/sig/datadog/ci/ext/environment/providers/github_actions.rbs
@@ -36,7 +36,7 @@ module Datadog
 
             def git_pull_request_base_branch: () -> String?
 
-            def git_pull_request_base_branch_sha: () -> String?
+            def git_pull_request_base_branch_head_sha: () -> String?
 
             def git_commit_head_sha: () -> String?
 

--- a/sig/datadog/ci/ext/environment/providers/gitlab.rbs
+++ b/sig/datadog/ci/ext/environment/providers/gitlab.rbs
@@ -48,6 +48,16 @@ module Datadog
 
             def ci_env_vars: () -> String?
 
+            def git_pull_request_base_branch: () -> String?
+
+            def git_pull_request_base_branch_sha: () -> String?
+
+            def git_pull_request_base_branch_head_sha: () -> String?
+
+            def git_commit_head_sha: () -> String?
+
+            def pr_number: () -> String?
+
             private
 
             def extract_name_email: () -> [String?, String?]

--- a/sig/datadog/ci/ext/git.rbs
+++ b/sig/datadog/ci/ext/git.rbs
@@ -46,6 +46,8 @@ module Datadog
 
         TAG_PULL_REQUEST_BASE_BRANCH_SHA: "git.pull_request.base_branch_sha"
 
+        TAG_PULL_REQUEST_BASE_BRANCH_HEAD_SHA: "git.pull_request.base_branch_head_sha"
+
         ENV_REPOSITORY_URL: "DD_GIT_REPOSITORY_URL"
 
         ENV_COMMIT_SHA: "DD_GIT_COMMIT_SHA"

--- a/spec/datadog/ci/ext/environment/providers/github_actions_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/github_actions_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::GithubActions do
           "git.repository_url" => "https://ghenterprise.com/ghactions-repo.git",
           "git.commit.head.sha" => "df289512a51123083a8e6931dd6f57bb3883d4c4",
           "git.pull_request.base_branch" => "github-base-ref",
-          "git.pull_request.base_branch_sha" => "52e0974c74d41160a03d59ddc73bb9f5adab054b",
+          "git.pull_request.base_branch_head_sha" => "52e0974c74d41160a03d59ddc73bb9f5adab054b",
           "pr.number" => "1"
         }
       end

--- a/spec/datadog/ci/ext/environment/providers/gitlab_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/gitlab_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Gitlab do
           "CI_REPOSITORY_URL" => "https://gitlab.com/repo/myrepo.git",
           "CI_MERGE_REQUEST_TARGET_BRANCH_NAME" => "main",
           "CI_MERGE_REQUEST_TARGET_BRANCH_SHA" => "abc123",
+          "CI_MERGE_REQUEST_DIFF_BASE_SHA" => "ghi789",
           "CI_MERGE_REQUEST_SOURCE_BRANCH_SHA" => "def456",
           "GITLAB_CI" => "gitlab"
         }
@@ -51,6 +52,8 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::Gitlab do
           "git.commit.sha" => "b9f0fb3fdbb94c9d24b2c75b49663122a529e123",
           "git.commit.head.sha" => "def456",
           "git.pull_request.base_branch" => "main",
+          "git.pull_request.base_branch_sha" => "ghi789",
+          "git.pull_request.base_branch_head_sha" => "abc123",
           "git.repository_url" => "https://gitlab.com/repo/myrepo.git"
         }
       end


### PR DESCRIPTION
**What does this PR do?**
It turned out that what we used as base sha for Github Actions is in fact a head of base branch - this PR fixes it.
Also it adds base branch sha's for Gitlab.

**How to test the change?**
Unit tests