### PR TITLE
[SDTEST-2450] Fix: make test_suite_name parameter optional for Datadog::CI.active_test_suite method

### DIFF
--- a/lib/datadog/ci.rb
+++ b/lib/datadog/ci.rb
@@ -187,9 +187,21 @@ module Datadog
       # test_suite.finish
       # ```
       #
+      # Most of the time, there is only one active test suite - except when using minitest with parallel test runner,
+      # such as rails built-in test runner.
+      #
+      # When using RSpec or minitest without parallel test runner, there is only one active test suite, so you can use the following code to fetch it:
+      #
+      # ```
+      # test_suite = Datadog::CI.active_test_suite
+      # test_suite.finish
+      # ```
+      #
+      # @param test_suite_name [String?] the name of the test suite to fetch. Optional. When not provided, it assumes that there is a single active test suite and returns it. If there are multiple active test suites and test_suite_name is not provided, it returns nil.
+      #
       # @return [Datadog::CI::TestSuite] the active test suite
       # @return [nil] if no test suite with given name is active
-      def active_test_suite(test_suite_name)
+      def active_test_suite(test_suite_name = nil)
         test_visibility.active_test_suite(test_suite_name)
       end
 

--- a/lib/datadog/ci/test_visibility/component.rb
+++ b/lib/datadog/ci/test_visibility/component.rb
@@ -162,6 +162,10 @@ module Datadog
         end
 
         def active_test_suite(test_suite_name)
+          # when test_suite_name is not provided (from public API most likely)
+          # we return the single active test suite because most of the time there is only one test suite running
+          return single_active_test_suite if test_suite_name.nil?
+
           # when fetching test_suite to use as test's context, try local context instance first
           local_test_suite = @context.active_test_suite(test_suite_name)
           return local_test_suite if local_test_suite
@@ -314,6 +318,14 @@ module Datadog
         end
 
         # HELPERS
+        def single_active_test_suite
+          # when fetching test_suite to use as test's context, try local context instance first
+          local_test_suite = @context.single_active_test_suite
+          return local_test_suite if local_test_suite
+
+          maybe_remote_context.single_active_test_suite
+        end
+
         def skip_tracing(block = nil)
           block&.call(nil)
         end

--- a/sig/datadog/ci.rbs
+++ b/sig/datadog/ci.rbs
@@ -23,7 +23,7 @@ module Datadog
 
     def self.active_test: () -> Datadog::CI::Test?
 
-    def self.active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
+    def self.active_test_suite: (?String? test_suite_name) -> Datadog::CI::TestSuite?
 
     def self.active_span: () -> Datadog::CI::Span?
 

--- a/sig/datadog/ci/test_visibility/component.rbs
+++ b/sig/datadog/ci/test_visibility/component.rbs
@@ -53,7 +53,7 @@ module Datadog
 
         def active_test_module: () -> Datadog::CI::TestModule?
 
-        def active_test_suite: (String test_suite_name) -> Datadog::CI::TestSuite?
+        def active_test_suite: (String? test_suite_name) -> Datadog::CI::TestSuite?
 
         def active_test: () -> Datadog::CI::Test?
 
@@ -91,6 +91,8 @@ module Datadog
         def set_codeowners: (Datadog::CI::Span span) -> void
 
         def null_span: () -> Datadog::CI::Span
+
+        def single_active_test_suite: () -> Datadog::CI::TestSuite?
 
         def skip_tracing: (?untyped block) -> untyped
 

--- a/sig/datadog/ci/test_visibility/null_component.rbs
+++ b/sig/datadog/ci/test_visibility/null_component.rbs
@@ -22,7 +22,7 @@ module Datadog
 
         def active_test_module: () -> nil
 
-        def active_test_suite: (String test_suite_name) -> nil
+        def active_test_suite: (String? test_suite_name) -> nil
 
         def active_test: () -> nil
 

--- a/spec/datadog/ci/test_visibility/component_spec.rb
+++ b/spec/datadog/ci/test_visibility/component_spec.rb
@@ -752,6 +752,70 @@ RSpec.describe Datadog::CI::TestVisibility::Component do
         end
       end
 
+      describe "#active_test_suite" do
+        context "when test_suite_name is provided" do
+          subject { test_visibility.active_test_suite("my suite") }
+
+          context "when there is no active test suite" do
+            it { is_expected.to be_nil }
+          end
+
+          context "when test suite is started" do
+            let(:test_suite) { test_visibility.start_test_suite("my suite") }
+            before do
+              test_suite
+            end
+
+            it "returns the active test suite" do
+              expect(subject).to be(test_suite)
+            end
+          end
+
+          context "when test suite with a different name is started" do
+            let(:test_suite) { test_visibility.start_test_suite("my other suite") }
+            before do
+              test_suite
+            end
+
+            it "returns the active test suite" do
+              expect(subject).to be_nil
+            end
+          end
+        end
+
+        context "when test_suite_name is nil" do
+          subject { test_visibility.active_test_suite(nil) }
+
+          context "when there is no active test suite" do
+            it { is_expected.to be_nil }
+          end
+
+          context "when there is one active test suite" do
+            let(:test_suite) { test_visibility.start_test_suite("my suite") }
+            before do
+              test_suite
+            end
+
+            it "returns the single active test suite" do
+              expect(subject).to be(test_suite)
+            end
+          end
+
+          context "when there are multiple active test suites" do
+            let(:test_suite1) { test_visibility.start_test_suite("my suite 1") }
+            let(:test_suite2) { test_visibility.start_test_suite("my suite 2") }
+            before do
+              test_suite1
+              test_suite2
+            end
+
+            it "returns nil when there are multiple test suites" do
+              expect(subject).to be_nil
+            end
+          end
+        end
+      end
+
       describe "#active_test" do
         subject { test_visibility.active_test }
 

--- a/spec/datadog/ci_spec.rb
+++ b/spec/datadog/ci_spec.rb
@@ -230,16 +230,33 @@ RSpec.describe Datadog::CI do
     end
 
     describe "::active_test_suite" do
-      let(:test_suite_name) { "my-suite" }
-      subject(:active_test_suite) { described_class.active_test_suite(test_suite_name) }
-
       let(:ci_test_suite) { instance_double(Datadog::CI::TestSuite) }
 
-      before do
-        allow(test_visibility).to receive(:active_test_suite).with(test_suite_name).and_return(ci_test_suite)
+      context "when test_suite_name is provided" do
+        let(:test_suite_name) { "my-suite" }
+        subject(:active_test_suite) { described_class.active_test_suite(test_suite_name) }
+
+        before do
+          allow(test_visibility).to receive(:active_test_suite).with(test_suite_name).and_return(ci_test_suite)
+        end
+
+        it { is_expected.to be(ci_test_suite) }
       end
 
-      it { is_expected.to be(ci_test_suite) }
+      context "when test_suite_name is not provided" do
+        subject(:active_test_suite) { described_class.active_test_suite }
+
+        before do
+          allow(test_visibility).to receive(:active_test_suite).with(nil).and_return(ci_test_suite)
+        end
+
+        it { is_expected.to be(ci_test_suite) }
+
+        it "calls test_visibility with nil" do
+          active_test_suite
+          expect(test_visibility).to have_received(:active_test_suite).with(nil)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
**What does this PR do?**
For most setups there is always a single test suit running at a time. Also, when test_suite is traced by Datadog library it is extremely hard (or impossible) for manual API's user to construct the same test suite name as the one Datadog uses. 

This PR fixes this problem by making `test_suite_name` parameter optional: when it is not provided, the single running test suite is returned (or nil when there are none or multiple test suites)

**Motivation**
It was brought to my attention that the `active_test_suite` method is barely usable currently

**How to test the change?**
Unit tests are provided