### PR TITLE
[SDTEST-2479] in test discovery mode output suiteSourceFile for each test

### DIFF
--- a/lib/datadog/ci/test_discovery/component.rb
+++ b/lib/datadog/ci/test_discovery/component.rb
@@ -86,6 +86,7 @@ module Datadog
             "name" => test.name,
             "suite" => test.test_suite_name,
             "sourceFile" => test.source_file,
+            "suiteSourceFile" => test.test_suite&.source_file,
             "fqn" => test.datadog_test_id
           }
 

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -1815,12 +1815,14 @@ RSpec.describe "RSpec instrumentation" do
             "name" => "nested fails",
             "suite" => "SomeTest at ./spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
             "sourceFile" => "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
+            "suiteSourceFile" => "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
             "fqn" => "SomeTest at ./spec/datadog/ci/contrib/rspec/instrumentation_spec.rb.nested fails.{\"arguments\":{},\"metadata\":{\"scoped_id\":\"1:1:2\"}}"
           },
           {
             "name" => "nested foo",
             "suite" => "SomeTest at ./spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
             "sourceFile" => "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
+            "suiteSourceFile" => "spec/datadog/ci/contrib/rspec/instrumentation_spec.rb",
             "fqn" => "SomeTest at ./spec/datadog/ci/contrib/rspec/instrumentation_spec.rb.nested foo.{\"arguments\":{},\"metadata\":{\"scoped_id\":\"1:1:1\"}}"
           }
         ]

--- a/spec/datadog/ci/test_discovery/component_spec.rb
+++ b/spec/datadog/ci/test_discovery/component_spec.rb
@@ -253,13 +253,19 @@ RSpec.describe Datadog::CI::TestDiscovery::Component do
   end
 
   describe "#on_test_started" do
+    let(:test_suite) {
+      double("test_suite",
+        source_file: "/path/to/suite.rb")
+    }
+
     let(:test) {
       double("test",
         mark_test_discovery_mode!: nil,
         name: "test_example",
         test_suite_name: "ExampleSuite",
         source_file: "/path/to/test.rb",
-        datadog_test_id: "ExampleSuite.test_example.nil")
+        datadog_test_id: "ExampleSuite.test_example.nil",
+        test_suite: test_suite)
     }
 
     context "when test discovery mode is enabled" do
@@ -278,6 +284,7 @@ RSpec.describe Datadog::CI::TestDiscovery::Component do
           "name" => "test_example",
           "suite" => "ExampleSuite",
           "sourceFile" => "/path/to/test.rb",
+          "suiteSourceFile" => "/path/to/suite.rb",
           "fqn" => "ExampleSuite.test_example.nil"
         }
 
@@ -343,7 +350,8 @@ RSpec.describe Datadog::CI::TestDiscovery::Component do
               name: "test_#{i}_#{j}",
               test_suite_name: "Suite#{i}",
               source_file: "/path/test_#{i}_#{j}.rb",
-              datadog_test_id: "test_id_#{i}_#{j}")
+              datadog_test_id: "test_id_#{i}_#{j}",
+              test_suite: nil)
             component.on_test_started(test)
           end
         end


### PR DESCRIPTION
**What does this PR do?**
Outputs test suite's source file additionally to test's source file in test discovery mode

**Motivation**
Shared RSpec examples are defined in helper files, but executed in test suite files - we need to know where test suite is located to know where test is executed

**How to test the change?**
Unit tests are provided