### PR TITLE
Bump to version 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## [Unreleased]
 
+## [1.23.0] - 2025-10-08
+
+
+### Changed
+* In test discovery mode output suiteSourceFile for each test ([#400][])
+* DDTest integration changes ([#407][])
+* Support context propagation from Datadog test runner ([#399][])
+
+### Fixed
+* Fix issue when parallel_tests doesn't track test sessions when using manual instrumentation ([#410][])
+
 ## [1.22.1] - 2025-08-25
 
 ### Fixed
@@ -520,7 +531,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.22.1...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.23.0...main
+[1.23.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.22.1...v1.23.0
 [1.22.1]: https://github.com/DataDog/datadog-ci-rb/compare/v1.22.0...v1.22.1
 [1.22.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.21.1...v1.22.0
 [1.21.1]: https://github.com/DataDog/datadog-ci-rb/compare/v1.21.0...v1.21.1
@@ -739,4 +751,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#393]: https://github.com/DataDog/datadog-ci-rb/issues/393
 [#394]: https://github.com/DataDog/datadog-ci-rb/issues/394
 [#396]: https://github.com/DataDog/datadog-ci-rb/issues/396
+[#399]: https://github.com/DataDog/datadog-ci-rb/issues/399
+[#400]: https://github.com/DataDog/datadog-ci-rb/issues/400
 [#402]: https://github.com/DataDog/datadog-ci-rb/issues/402
+[#407]: https://github.com/DataDog/datadog-ci-rb/issues/407
+[#410]: https://github.com/DataDog/datadog-ci-rb/issues/410

--- a/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_10.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_10.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
+++ b/gemfiles/jruby_9.4_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_minitest_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_rails_5.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_rails_6.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_rails_7.gemfile.lock
+++ b/gemfiles/jruby_9.4_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_rspec_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/jruby_9.4_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/jruby_9.4_timecop_0.gemfile.lock
+++ b/gemfiles/jruby_9.4_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_4.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_5.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_6.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_7.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.22.1)
+    datadog-ci (1.23.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,8 +4,8 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 22
-      PATCH = 1
+      MINOR = 23
+      PATCH = 0
       PRE = nil
       BUILD = nil
       # PRE and BUILD above are modified for dev gems during gem build GHA workflow


### PR DESCRIPTION

### Changed
* In test discovery mode output suiteSourceFile for each test (#400)
* DDTest integration changes (#407)
* Support context propagation from Datadog test runner (#399)

### Fixed
* Fix issue when parallel_tests doesn't track test sessions when using manual instrumentation (#410)
