### PR TITLE
Use c.git.repository_url and c.git.commit_sha if it is defined instead of env vars

### DIFF
--- a/lib/datadog/ci/ext/environment/providers/user_defined_tags.rb
+++ b/lib/datadog/ci/ext/environment/providers/user_defined_tags.rb
@@ -12,11 +12,21 @@ module Datadog
           # User documentation: https://docs.datadoghq.com/continuous_integration/troubleshooting/#data-appears-in-test-runs-but-not-tests
           class UserDefinedTags < Base
             def git_repository_url
-              env[Git::ENV_REPOSITORY_URL]
+              git_config = datadog_git_configuration
+              if git_config&.respond_to?(:repository_url)
+                git_config.repository_url
+              else
+                env[Git::ENV_REPOSITORY_URL]
+              end
             end
 
             def git_commit_sha
-              env[Git::ENV_COMMIT_SHA]
+              git_config = datadog_git_configuration
+              if git_config&.respond_to?(:commit_sha)
+                git_config.commit_sha
+              else
+                env[Git::ENV_COMMIT_SHA]
+              end
             end
 
             def git_branch
@@ -65,6 +75,13 @@ module Datadog
 
             def git_commit_head_sha
               env[Git::ENV_COMMIT_HEAD_SHA]
+            end
+
+            private
+
+            def datadog_git_configuration
+              config = Datadog.configuration
+              config.git if config.respond_to?(:git)
             end
           end
         end

--- a/sig/datadog/ci/ext/environment/providers/user_defined_tags.rbs
+++ b/sig/datadog/ci/ext/environment/providers/user_defined_tags.rbs
@@ -31,6 +31,10 @@ module Datadog
             def git_pull_request_base_branch_sha: () -> String?
 
             def git_commit_head_sha: () -> String?
+
+            private
+
+            def datadog_git_configuration: () -> untyped
           end
         end
       end

--- a/spec/datadog/ci/ext/environment/providers/user_defined_tags_spec.rb
+++ b/spec/datadog/ci/ext/environment/providers/user_defined_tags_spec.rb
@@ -21,7 +21,15 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::UserDefinedTags do
         }
       end
       # Modify HOME so that '~' expansion matches CI home directory.
-      let(:environment_variables) { super().merge("HOME" => env["HOME"]) }
+      # DD_GIT_REPOSITORY_URL and DD_GIT_COMMIT_SHA must also be set in actual ENV because
+      # the provider reads them via Datadog.configuration.git when the config DSL is available.
+      let(:environment_variables) do
+        super().merge(
+          "HOME" => env["HOME"],
+          Datadog::CI::Ext::Git::ENV_REPOSITORY_URL => env[Datadog::CI::Ext::Git::ENV_REPOSITORY_URL],
+          Datadog::CI::Ext::Git::ENV_COMMIT_SHA => env[Datadog::CI::Ext::Git::ENV_COMMIT_SHA]
+        )
+      end
 
       let(:expected_tags) do
         {
@@ -43,6 +51,52 @@ RSpec.describe ::Datadog::CI::Ext::Environment::Providers::UserDefinedTags do
 
       it "matches CI tags" do
         is_expected.to eq(expected_tags)
+      end
+    end
+
+    context "git settings via Datadog configuration DSL" do
+      context "when git settings are available and set programmatically",
+        if: Datadog.configuration.respond_to?(:git) do
+        before do
+          Datadog.configure do |c|
+            c.git.repository_url = "https://programmatic.example.com/repo.git"
+            c.git.commit_sha = "abc123programmatic"
+          end
+        end
+
+        let(:env) { {} }
+
+        it "uses the programmatically configured repository_url" do
+          expect(extracted_tags).to include("git.repository_url" => "https://programmatic.example.com/repo.git")
+        end
+
+        it "uses the programmatically configured commit_sha" do
+          expect(extracted_tags).to include("git.commit.sha" => "abc123programmatic")
+        end
+      end
+
+      context "when Datadog configuration does not support git settings (older dd-trace-rb)" do
+        let(:config_without_git) { double("datadog_config") }
+
+        before do
+          allow(config_without_git).to receive(:respond_to?).with(:git).and_return(false)
+          allow(::Datadog).to receive(:configuration).and_return(config_without_git)
+        end
+
+        let(:env) do
+          {
+            Datadog::CI::Ext::Git::ENV_REPOSITORY_URL => "https://env-fallback.example.com/repo.git",
+            Datadog::CI::Ext::Git::ENV_COMMIT_SHA => "sha-from-env-fallback"
+          }
+        end
+
+        it "falls back to DD_GIT_REPOSITORY_URL environment variable" do
+          expect(extracted_tags).to include("git.repository_url" => "https://env-fallback.example.com/repo.git")
+        end
+
+        it "falls back to DD_GIT_COMMIT_SHA environment variable" do
+          expect(extracted_tags).to include("git.commit.sha" => "sha-from-env-fallback")
+        end
       end
     end
   end


### PR DESCRIPTION
**What does this PR do?**
<!-- A brief description of the change being made with this pull request. -->

This PR replace the direct access to DD_GIT_REPOSITORY_URL and DD_GIT_COMMIT_SHA to access to the config DSL. There is a fallback mechanism if the option is not defined on dd-trace-rb (for older versions).

**Motivation**
<!-- What inspired you to submit this pull request? -->

We're trying to move as much env vars as possible to the config DSL, so that they can be configured programmatically, but also through stable config. These two configs are common to both dd-trace-rb and datadog-ci-rb.

**Additional Notes**
<!-- Anything else we should know when reviewing? -->

Depends on https://github.com/DataDog/dd-trace-rb/pull/5559

**How to test the change?**
<!--
Describe here how the change can be validated.
You are strongly encouraged to provide automated tests for this PR (unit or integration).
If this change cannot be feasibly tested, please explain why,
unless the change does not modify code (e.g. only modifies docs, comments).
-->