### PR TITLE
[NO-TICKET] Handle nil DDTest skippable tests data

### DIFF
--- a/lib/datadog/ci/test_impact_analysis/component.rb
+++ b/lib/datadog/ci/test_impact_analysis/component.rb
@@ -381,7 +381,7 @@ module Datadog
         #   "data": [{"type": "test", "attributes": {"suite": "suite_name", "name": "test_name", "parameters": "{...}"}}]
         # }
         def transform_test_runner_data(skippable_tests_data)
-          skippable_tests = skippable_tests_data.fetch("skippableTests", {})
+          skippable_tests = skippable_tests_data.fetch("skippableTests", {}) || {}
 
           # Pre-calculate array size for better memory allocation
           total_test_configs = skippable_tests.sum do |_, tests_hash|

--- a/spec/datadog/ci/test_impact_analysis/component_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/component_spec.rb
@@ -315,6 +315,24 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Component do
           expect(component.skipping_tests?).to be true
         end
       end
+
+      context "when skippable_tests.json file contains nil skippableTests" do
+        let(:skippable_tests_data) do
+          {
+            "correlationId" => "nil123",
+            "skippableTests" => nil
+          }
+        end
+
+        it "treats skippable tests as empty" do
+          expect { configure }.not_to raise_error
+
+          expect(component.correlation_id).to eq("nil123")
+          expect(component.skippable_tests).to be_empty
+          expect(component.enabled?).to be true
+          expect(component.skipping_tests?).to be true
+        end
+      end
     end
 
     context "when ITR is disabled locally" do


### PR DESCRIPTION
## Summary
- treat a nil `skippableTests` payload from DDTest as an empty hash during test runner state restoration
- add regression coverage for DDTest cache data that includes a correlation ID but no skippable tests payload

## Test plan
- [x] `bundle exec rspec spec/datadog/ci/test_impact_analysis/component_spec.rb`
- [x] `bundle exec standardrb lib/datadog/ci/test_impact_analysis/component.rb spec/datadog/ci/test_impact_analysis/component_spec.rb`
- [x] `bundle exec rake steep:check`
