### PR TITLE
[NO-TICKET] Skip ddcov memcheck for libdatadog v30

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -197,9 +197,21 @@ namespace :spec do
   # ddcov test impact analysis tool with memcheck
   desc ""
   if Gem.loaded_specs.key?("ruby_memcheck")
-    RubyMemcheck::RSpec::RakeTask.new(:ddcov_memcheck) do |t, args|
-      t.pattern = ["spec/ddcov/**/*_spec.rb", "spec/datadog/ci/source_code/**/*_spec.rb"]
-      t.rspec_opts = args.to_a.join(" ")
+    require "libdatadog"
+
+    # Temporary workaround to unblock moving to libdatadog v30. If you see this code here and we've moved past v30
+    # already, we forgot to clean it up -- please do!
+    if Libdatadog::VERSION.start_with?("30.")
+      task :ddcov_memcheck do
+        warn "Skipping ddcov memcheck for libdatadog v30 because of https://github.com/bytecodealliance/rustix/issues/1559" \
+          " (libdatadog v30 causes a crash when running inside valgrind)." \
+          " Libdatadog 31? 32? should include https://github.com/DataDog/libdatadog/pull/1859 and fix this issue."
+      end
+    else
+      RubyMemcheck::RSpec::RakeTask.new(:ddcov_memcheck) do |t, args|
+        t.pattern = ["spec/ddcov/**/*_spec.rb", "spec/datadog/ci/source_code/**/*_spec.rb"]
+        t.rspec_opts = args.to_a.join(" ")
+      end
     end
   else
     task :ddcov_memcheck do


### PR DESCRIPTION
## Summary
- skip `spec:ddcov_memcheck` when `libdatadog` is on `30.x`
- keep the existing memcheck rake task behavior for other `libdatadog` versions
- document the temporary workaround and link the upstream fix context

## Test plan
- [x] GitHub Actions passes on this branch
- [x] Reviewed the `Rakefile` diff to confirm only the memcheck task behavior changed

Made with [Cursor](https://cursor.com)