### PR TITLE
[NO-TICKET] Enable static dependency tracking by default

### DIFF
--- a/lib/datadog/ci/configuration/settings.rb
+++ b/lib/datadog/ci/configuration/settings.rb
@@ -183,7 +183,7 @@ module Datadog
               option :tia_static_dependencies_tracking_enabled do |o|
                 o.type :bool
                 o.env CI::Ext::Settings::ENV_TIA_STATIC_DEPENDENCIES_TRACKING_ENABLED
-                o.default false
+                o.default true
               end
 
               option :code_coverage_report_upload_enabled do |o|

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -136,6 +136,53 @@ RSpec.describe Datadog::CI::Configuration::Components do
             end
           end
 
+          context "when static dependencies tracking is enabled by default" do
+            let(:agentless_enabled) { true }
+            let(:api_key) { "api_key" }
+
+            it "passes the default value to test impact analysis" do
+              allow(Datadog::CI::TestImpactAnalysis::Component).to receive(:new).and_call_original
+
+              fresh_components = if described_class >= Datadog::Core::Configuration::Components
+                Datadog::Core::Configuration::Components.new(settings)
+              else
+                components_class = Datadog::Core::Configuration::Components.dup
+                components_class.prepend(described_class)
+                components_class.new(settings)
+              end
+
+              expect(Datadog::CI::TestImpactAnalysis::Component).to have_received(:new).with(
+                hash_including(static_dependencies_tracking_enabled: true)
+              )
+
+              fresh_components.shutdown!
+            end
+
+            context "when the setting is explicitly disabled" do
+              before do
+                settings.ci.tia_static_dependencies_tracking_enabled = false
+              end
+
+              it "passes the configured value to test impact analysis" do
+                allow(Datadog::CI::TestImpactAnalysis::Component).to receive(:new).and_call_original
+
+                fresh_components = if described_class >= Datadog::Core::Configuration::Components
+                  Datadog::Core::Configuration::Components.new(settings)
+                else
+                  components_class = Datadog::Core::Configuration::Components.dup
+                  components_class.prepend(described_class)
+                  components_class.new(settings)
+                end
+
+                expect(Datadog::CI::TestImpactAnalysis::Component).to have_received(:new).with(
+                  hash_including(static_dependencies_tracking_enabled: false)
+                )
+
+                fresh_components.shutdown!
+              end
+            end
+          end
+
           context "when #force_test_level_visibility" do
             let(:evp_proxy_v2_supported) { true }
 

--- a/spec/datadog/ci/configuration/settings_spec.rb
+++ b/spec/datadog/ci/configuration/settings_spec.rb
@@ -1057,7 +1057,7 @@ RSpec.describe Datadog::CI::Configuration::Settings do
       describe "#tia_static_dependencies_tracking_enabled" do
         subject(:tia_static_dependencies_tracking_enabled) { settings.ci.tia_static_dependencies_tracking_enabled }
 
-        it { is_expected.to be false }
+        it { is_expected.to be true }
 
         context "when #{Datadog::CI::Ext::Settings::ENV_TIA_STATIC_DEPENDENCIES_TRACKING_ENABLED}" do
           around do |example|
@@ -1069,7 +1069,7 @@ RSpec.describe Datadog::CI::Configuration::Settings do
           context "is not defined" do
             let(:enable) { nil }
 
-            it { is_expected.to be false }
+            it { is_expected.to be true }
           end
 
           context "is set to true" do
@@ -1088,10 +1088,10 @@ RSpec.describe Datadog::CI::Configuration::Settings do
 
       describe "#tia_static_dependencies_tracking_enabled=" do
         it "updates the #tia_static_dependencies_tracking_enabled setting" do
-          expect { settings.ci.tia_static_dependencies_tracking_enabled = true }
+          expect { settings.ci.tia_static_dependencies_tracking_enabled = false }
             .to change { settings.ci.tia_static_dependencies_tracking_enabled }
-            .from(false)
-            .to(true)
+            .from(true)
+            .to(false)
         end
       end
 


### PR DESCRIPTION
## Summary
- enable TIA static dependency tracking by default so Ruby constants coverage is collected without extra setup
- update configuration specs to reflect the new default and preserve the explicit opt-out path
- add component wiring coverage to ensure the configured value is passed into test impact analysis

## Test plan
- [x] `bundle exec rspec spec/datadog/ci/configuration/settings_spec.rb spec/datadog/ci/configuration/components_spec.rb`
- [x] `bundle exec standardrb`
- [x] `bundle exec rake steep:check`


Made with [Cursor](https://cursor.com)