### PR TITLE
[NO-TICKET] Make attempt_to_fix take precedence over quarantine and disabled

### DIFF
--- a/lib/datadog/ci/contrib/cucumber/instrumentation.rb
+++ b/lib/datadog/ci/contrib/cucumber/instrumentation.rb
@@ -39,8 +39,9 @@ module Datadog
             def begin_scenario(test_case)
               datadog_test = Datadog::CI.active_test
 
-              # special case for cucumber-ruby: we skip quarantined tests, thus for cucumber quarantined is the same as disabled
-              if datadog_test&.should_skip? || datadog_test&.quarantined?
+              # special case for cucumber-ruby: we skip quarantined tests, thus for cucumber quarantined is the same as disabled.
+              # attempt_to_fix takes precedence over quarantine: such tests must run (and be retried) even when quarantined.
+              if datadog_test&.should_skip? || (datadog_test&.quarantined? && !datadog_test.attempt_to_fix?)
                 raise ::Cucumber::Core::Test::Result::Skipped, datadog_test.datadog_skip_reason
               end
 

--- a/lib/datadog/ci/test.rb
+++ b/lib/datadog/ci/test.rb
@@ -235,8 +235,8 @@ module Datadog
 
       # @internal
       def should_ignore_failures?
-        return true if quarantined? || disabled?
         return false if attempt_to_fix?
+        return true if quarantined? || disabled?
 
         any_retry_passed?
       end
@@ -271,8 +271,9 @@ module Datadog
         # Skip status is always preserved
         return status if status == Ext::Test::Status::SKIP
 
-        # For attempt_to_fix tests (not quarantined/disabled), any failure means the fix didn't work
-        if attempt_to_fix? && !quarantined? && !disabled?
+        # attempt_to_fix takes precedence over quarantine/disabled flags:
+        # any failure across attempts means the fix didn't work.
+        if attempt_to_fix?
           return all_executions_passed? ? Ext::Test::Status::PASS : Ext::Test::Status::FAIL
         end
 

--- a/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/cucumber/instrumentation_spec.rb
@@ -830,6 +830,51 @@ RSpec.describe "Cucumber instrumentation" do
     end
   end
 
+  context "executing failing test scenario that is both quarantined and attempt_to_fix" do
+    let(:feature_file_to_run) { "failing.feature" }
+    let(:expected_test_run_code) { 2 }
+
+    let(:enable_test_management) { true }
+    let(:test_properties_hash) do
+      {
+        "Datadog integration - test failing features at spec/datadog/ci/contrib/cucumber/features/failing.feature.cucumber failing scenario." => {
+          "quarantined" => true,
+          "disabled" => false,
+          "attempt_to_fix" => true
+        }
+      }
+    end
+
+    it "runs the test instead of skipping it and fails the session because the fix did not work" do
+      # 1 original execution (failed, no retries because the fix did not work)
+      expect(test_spans).to have(1).items
+
+      attempt_to_fix_test_span = test_spans.first
+      expect(attempt_to_fix_test_span).to have_fail_status
+      expect(attempt_to_fix_test_span).to have_test_tag(:is_attempt_to_fix)
+      expect(attempt_to_fix_test_span).to have_test_tag(:is_quarantined)
+
+      retries_count = test_spans.count { |span| span.get_tag("test.is_retry") == "true" }
+      expect(retries_count).to eq(0)
+
+      failed_all_retries_count = test_spans.count { |span| span.get_tag("test.has_failed_all_retries") }
+      expect(failed_all_retries_count).to eq(1)
+
+      fix_failed_tests_count = test_spans.count { |span| span.get_tag("test.test_management.attempt_to_fix_passed") == "false" }
+      expect(fix_failed_tests_count).to eq(1)
+
+      # attempt_to_fix takes precedence over quarantine
+      final_status_fail_tests = test_spans.count { |span| span.get_tag("test.final_status") == "fail" }
+      expect(final_status_fail_tests).to eq(1)
+
+      expect(test_suite_spans).to have(1).item
+      expect(test_suite_spans.first).to have_fail_status
+
+      expect(test_session_span).to have_fail_status
+      expect(test_session_span).to have_test_tag(:test_management_enabled, "true")
+    end
+  end
+
   context "executing a feature with Datadog's early flake detection and impacted tests detection enabled" do
     let(:feature_file_to_run) { "passing.feature" }
     let(:enable_retries_new) { true }

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -1624,9 +1624,11 @@ RSpec.describe "Minitest instrumentation" do
       expect(fix_failed_tests_count).to eq(1)
 
       expect(test_suite_spans).to have(1).item
-      expect(test_suite_spans.first).to have_pass_status
+      # suite should fail because attempt_to_fix takes precedence over quarantine
+      expect(test_suite_spans.first).to have_fail_status
 
-      expect(test_session_span).to have_pass_status
+      # session should fail because attempt_to_fix takes precedence over quarantine
+      expect(test_session_span).to have_fail_status
       expect(test_session_span).to have_test_tag(:test_management_enabled, "true")
     end
   end

--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -529,6 +529,9 @@ RSpec.describe Datadog::CI::Test do
     context "when quarantined" do
       before do
         allow(ci_test).to(
+          receive(:attempt_to_fix?).and_return(false)
+        )
+        allow(ci_test).to(
           receive(:quarantined?).and_return(true)
         )
       end
@@ -538,6 +541,9 @@ RSpec.describe Datadog::CI::Test do
 
     context "when disabled" do
       before do
+        allow(ci_test).to(
+          receive(:attempt_to_fix?).and_return(false)
+        )
         allow(ci_test).to(
           receive(:quarantined?).and_return(false)
         )
@@ -590,15 +596,21 @@ RSpec.describe Datadog::CI::Test do
     context "when attempt_to_fix but also quarantined" do
       before do
         allow(ci_test).to(
+          receive(:attempt_to_fix?).and_return(true)
+        )
+        allow(ci_test).to(
           receive(:quarantined?).and_return(true)
         )
       end
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context "when attempt_to_fix but also disabled" do
       before do
+        allow(ci_test).to(
+          receive(:attempt_to_fix?).and_return(true)
+        )
         allow(ci_test).to(
           receive(:quarantined?).and_return(false)
         )
@@ -607,7 +619,7 @@ RSpec.describe Datadog::CI::Test do
         )
       end
 
-      it { is_expected.to be true }
+      it { is_expected.to be false }
     end
 
     context "when neither is true" do
@@ -729,12 +741,13 @@ RSpec.describe Datadog::CI::Test do
         context "but test is also quarantined" do
           before do
             allow(ci_test).to receive(:quarantined?).and_return(true)
+            allow(ci_test).to receive(:all_executions_passed?).and_return(false)
           end
 
-          it "persists final status as pass (quarantined takes precedence)" do
+          it "persists final status as fail (attempt_to_fix takes precedence)" do
             expect(tracer_span).to receive(:set_tag).with(
               Datadog::CI::Ext::Test::TAG_FINAL_STATUS,
-              Datadog::CI::Ext::Test::Status::PASS
+              Datadog::CI::Ext::Test::Status::FAIL
             )
 
             record_final_status
@@ -744,12 +757,13 @@ RSpec.describe Datadog::CI::Test do
         context "but test is also disabled" do
           before do
             allow(ci_test).to receive(:disabled?).and_return(true)
+            allow(ci_test).to receive(:all_executions_passed?).and_return(false)
           end
 
-          it "persists final status as pass (disabled takes precedence)" do
+          it "persists final status as fail (attempt_to_fix takes precedence)" do
             expect(tracer_span).to receive(:set_tag).with(
               Datadog::CI::Ext::Test::TAG_FINAL_STATUS,
-              Datadog::CI::Ext::Test::Status::PASS
+              Datadog::CI::Ext::Test::Status::FAIL
             )
 
             record_final_status


### PR DESCRIPTION
## Summary
- swap precedence in `Datadog::CI::Test#should_ignore_failures?` and `#compute_final_status` so that `attempt_to_fix?` short-circuits before `quarantined?`/`disabled?`
- as a result, an `attempt_to_fix` test that fails any of its retries fails from the framework's point of view (failing the test suite and session), and only passes when every attempt passes — even when the test is also quarantined or disabled
- update Minitest instrumentation spec for the "test is both quarantined and attempt_to_fix" scenario to assert the suite/session now fail; align unit tests in `test_spec.rb` with the new precedence

## Test plan
- [x] `bundle exec rspec spec/datadog/ci/test_spec.rb spec/datadog/ci/contrib/minitest/instrumentation_spec.rb`
- [x] `bundle exec rspec spec/datadog/ci/contrib/rspec/instrumentation_spec.rb`
- [x] `bundle exec rake test:cucumber`
- [x] `bundle exec rspec spec/datadog/ci/test_spec.rb spec/datadog/ci/test_suite_spec.rb spec/datadog/ci/test_retries/ spec/datadog/ci/test_management/`
- [x] `bundle exec rake steep:check`
- [x] `bundle exec standardrb lib/datadog/ci/test.rb spec/datadog/ci/test_spec.rb spec/datadog/ci/contrib/minitest/instrumentation_spec.rb`


Made with [Cursor](https://cursor.com)