### PR TITLE
[SDTEST-3523] Add _dd.ci.library_configuration_error.* tags on backend errors

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -93,6 +93,17 @@ module Datadog
         TAG_HAS_FAILED_ALL_RETRIES = "test.has_failed_all_retries" # true if test was retried and none of the retries passed
         TAG_ATTEMPT_TO_FIX_PASSED = "test.test_management.attempt_to_fix_passed" # true if test was marked as "attempted to fix" and all of the retries passed
 
+        # Hidden tags used to indicate that a communication error occurred with the backend
+        # during one of the library configuration requests. They are propagated to every CI event
+        # (test session, test module, test suite, test) so that the backend can detect when
+        # data may be incomplete because the library could not load configuration.
+        module LibraryConfigurationError
+          TAG_SETTINGS = "_dd.ci.library_configuration_error.settings"
+          TAG_SKIPPABLE_TESTS = "_dd.ci.library_configuration_error.skippable_tests"
+          TAG_KNOWN_TESTS = "_dd.ci.library_configuration_error.known_tests"
+          TAG_TEST_MANAGEMENT_TESTS = "_dd.ci.library_configuration_error.test_management_tests"
+        end
+
         # a set of tag indicating which capabilities (features) are supported by the library
         module LibraryCapabilities
           TAG_TEST_IMPACT_ANALYSIS = "_dd.library_capabilities.test_impact_analysis"
@@ -140,7 +151,14 @@ module Datadog
         METRIC_CPU_COUNT = "_dd.host.vcpu_count"
 
         # tags that are common for the whole session and can be inherited from the test session
-        INHERITABLE_TAGS = [TAG_FRAMEWORK, TAG_FRAMEWORK_VERSION].freeze
+        INHERITABLE_TAGS = [
+          TAG_FRAMEWORK,
+          TAG_FRAMEWORK_VERSION,
+          LibraryConfigurationError::TAG_SETTINGS,
+          LibraryConfigurationError::TAG_SKIPPABLE_TESTS,
+          LibraryConfigurationError::TAG_KNOWN_TESTS,
+          LibraryConfigurationError::TAG_TEST_MANAGEMENT_TESTS
+        ].freeze
 
         # could be either "test" or "suite" depending on whether we skip individual tests or whole suites
         ITR_TEST_SKIPPING_MODE = "test" # we always skip tests (not suites) in Ruby

--- a/lib/datadog/ci/remote/library_settings_client.rb
+++ b/lib/datadog/ci/remote/library_settings_client.rb
@@ -49,6 +49,10 @@ module Datadog
               error_type: http_response.telemetry_error_type,
               status_code: http_response.code
             )
+
+            # mark the test session so that all events emitted in this session are tagged
+            # with the hidden _dd.ci.library_configuration_error.settings tag
+            test_session.set_tag(Ext::Test::LibraryConfigurationError::TAG_SETTINGS, "true")
           end
 
           library_settings = LibrarySettings.from_http_response(http_response)

--- a/lib/datadog/ci/test_impact_analysis/skippable.rb
+++ b/lib/datadog/ci/test_impact_analysis/skippable.rb
@@ -111,6 +111,10 @@ module Datadog
               error_type: http_response.telemetry_error_type,
               status_code: http_response.code
             )
+
+            # mark the test session so that all events emitted in this session are tagged
+            # with the hidden _dd.ci.library_configuration_error.skippable_tests tag
+            test_session.set_tag(Ext::Test::LibraryConfigurationError::TAG_SKIPPABLE_TESTS, "true")
           end
 
           Response.from_http_response(http_response)

--- a/lib/datadog/ci/test_management/tests_properties.rb
+++ b/lib/datadog/ci/test_management/tests_properties.rb
@@ -3,6 +3,7 @@
 require "json"
 
 require_relative "../ext/telemetry"
+require_relative "../ext/test"
 require_relative "../ext/transport"
 require_relative "../transport/telemetry"
 require_relative "../utils/parsing"
@@ -112,6 +113,10 @@ module Datadog
               error_type: http_response.telemetry_error_type,
               status_code: http_response.code
             )
+
+            # mark the test session so that all events emitted in this session are tagged
+            # with the hidden _dd.ci.library_configuration_error.test_management_tests tag
+            test_session.set_tag(Ext::Test::LibraryConfigurationError::TAG_TEST_MANAGEMENT_TESTS, "true")
           end
 
           Response.from_http_response(http_response).tests

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -63,7 +63,12 @@ module Datadog
         # uses synchronized method #get_tag to get each tag value
         res = {}
         Ext::Test::INHERITABLE_TAGS.each do |tag|
-          res[tag] = get_tag(tag)
+          value = get_tag(tag)
+          # skip tags that are not set on the session (e.g. library configuration error tags
+          # are only set when the corresponding backend request fails)
+          next if value.nil?
+
+          res[tag] = value
         end
         @inheritable_tags = res.freeze
       end

--- a/lib/datadog/ci/test_tracing/known_tests.rb
+++ b/lib/datadog/ci/test_tracing/known_tests.rb
@@ -103,6 +103,10 @@ module Datadog
             response = fetch_page(api, test_session, page_state: page_state)
 
             unless response.ok?
+              # mark the test session so that all events emitted in this session are tagged
+              # with the hidden _dd.ci.library_configuration_error.known_tests tag
+              test_session.set_tag(Ext::Test::LibraryConfigurationError::TAG_KNOWN_TESTS, "true")
+
               Datadog.logger.debug(
                 "Failed to fetch known tests page ##{page_number}, bailing out of known tests fetch. " \
                 "Early flake detection will not work."

--- a/sig/datadog/ci/ext/test.rbs
+++ b/sig/datadog/ci/ext/test.rbs
@@ -122,6 +122,13 @@ module Datadog
 
         TAG_ATTEMPT_TO_FIX_PASSED: "test.test_management.attempt_to_fix_passed"
 
+        module LibraryConfigurationError
+          TAG_SETTINGS: "_dd.ci.library_configuration_error.settings"
+          TAG_SKIPPABLE_TESTS: "_dd.ci.library_configuration_error.skippable_tests"
+          TAG_KNOWN_TESTS: "_dd.ci.library_configuration_error.known_tests"
+          TAG_TEST_MANAGEMENT_TESTS: "_dd.ci.library_configuration_error.test_management_tests"
+        end
+
         module LibraryCapabilities
           TAG_TEST_IMPACT_ANALYSIS: "_dd.library_capabilities.test_impact_analysis"
           TAG_EARLY_FLAKE_DETECTION: "_dd.library_capabilities.early_flake_detection"

--- a/spec/datadog/ci/remote/library_settings_client_spec.rb
+++ b/spec/datadog/ci/remote/library_settings_client_spec.rb
@@ -139,6 +139,13 @@ RSpec.describe Datadog::CI::Remote::LibrarySettingsClient do
 
       context "parsing response" do
         context "when response is OK" do
+          it "does not tag the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_SETTINGS))
+              .to be_nil
+          end
+
           it "parses the response" do
             expect(response.ok?).to be true
             expect(response.payload).to eq(attributes)
@@ -221,6 +228,13 @@ RSpec.describe Datadog::CI::Remote::LibrarySettingsClient do
             expect(response.ok?).to be false
             expect(response.payload).to eq("itr_enabled" => false)
             expect(response.require_git?).to be false
+          end
+
+          it "tags the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_SETTINGS))
+              .to eq("true")
           end
 
           it_behaves_like "emits telemetry metric", :inc, "git_requests.settings_errors", 1

--- a/spec/datadog/ci/test_impact_analysis/skippable_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/skippable_spec.rb
@@ -109,6 +109,13 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Skippable do
             expect(response.error_message).to be_nil
           end
 
+          it "does not tag the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_SKIPPABLE_TESTS))
+              .to be_nil
+          end
+
           it_behaves_like "emits telemetry metric", :inc, "itr_skippable_tests.request", 1
           it_behaves_like "emits telemetry metric", :distribution, "itr_skippable_tests.request_ms"
           it_behaves_like "emits telemetry metric", :distribution, "itr_skippable_tests.response_bytes"
@@ -134,6 +141,13 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Skippable do
             expect(response.correlation_id).to be_nil
             expect(response.tests).to be_empty
             expect(response.error_message).to eq("Status code: 422, response: not authorized")
+          end
+
+          it "tags the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_SKIPPABLE_TESTS))
+              .to eq("true")
           end
 
           it_behaves_like "emits telemetry metric", :inc, "itr_skippable_tests.request_errors", 1

--- a/spec/datadog/ci/test_management/tests_properties_spec.rb
+++ b/spec/datadog/ci/test_management/tests_properties_spec.rb
@@ -171,6 +171,13 @@ RSpec.describe Datadog::CI::TestManagement::TestsProperties do
             })
           end
 
+          it "does not tag the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_TEST_MANAGEMENT_TESTS))
+              .to be_nil
+          end
+
           it_behaves_like "emits telemetry metric", :inc, "test_management_tests.request", 1
           it_behaves_like "emits telemetry metric", :distribution, "test_management_tests.request_ms"
           it_behaves_like "emits telemetry metric", :distribution, "test_management_tests.response_bytes"
@@ -193,6 +200,13 @@ RSpec.describe Datadog::CI::TestManagement::TestsProperties do
 
           it "parses the response" do
             expect(response).to be_empty
+          end
+
+          it "tags the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_TEST_MANAGEMENT_TESTS))
+              .to eq("true")
           end
 
           it_behaves_like "emits telemetry metric", :inc, "test_management_tests.request_errors", 1

--- a/spec/datadog/ci/test_session_spec.rb
+++ b/spec/datadog/ci/test_session_spec.rb
@@ -18,18 +18,34 @@ RSpec.describe Datadog::CI::TestSession do
   describe "#inheritable_tags" do
     subject(:inheritable_tags) { ci_test_session.inheritable_tags }
 
-    before do
-      Datadog::CI::Ext::Test::INHERITABLE_TAGS.each do |tag|
-        tracer_span.set_tag(tag, "value for #{tag}")
+    context "when all inheritable tags are set" do
+      before do
+        Datadog::CI::Ext::Test::INHERITABLE_TAGS.each do |tag|
+          tracer_span.set_tag(tag, "value for #{tag}")
+        end
+      end
+
+      it "returns a hash of inheritable tags" do
+        is_expected.to eq(
+          Datadog::CI::Ext::Test::INHERITABLE_TAGS.each_with_object({}) do |tag, memo|
+            memo[tag] = "value for #{tag}"
+          end
+        )
       end
     end
 
-    it "returns a hash of inheritable tags" do
-      is_expected.to eq(
-        Datadog::CI::Ext::Test::INHERITABLE_TAGS.each_with_object({}) do |tag, memo|
-          memo[tag] = "value for #{tag}"
-        end
-      )
+    context "when only some of the inheritable tags are set" do
+      before do
+        tracer_span.set_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK, "rspec")
+        tracer_span.set_tag(Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION, "3.13.0")
+      end
+
+      it "skips inheritable tags that are not set on the test session" do
+        is_expected.to eq(
+          Datadog::CI::Ext::Test::TAG_FRAMEWORK => "rspec",
+          Datadog::CI::Ext::Test::TAG_FRAMEWORK_VERSION => "3.13.0"
+        )
+      end
     end
   end
 

--- a/spec/datadog/ci/test_tracing/known_tests_spec.rb
+++ b/spec/datadog/ci/test_tracing/known_tests_spec.rb
@@ -102,6 +102,13 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
             expect(response).to eq(Set.new(["AdminControllerTest.test_new.", "AdminControllerTest.test_index.", "AdminControllerTest.test_create."]))
           end
 
+          it "does not tag the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_KNOWN_TESTS))
+              .to be_nil
+          end
+
           it_behaves_like "emits telemetry metric", :inc, "known_tests.request", 1
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.request_ms"
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.response_bytes"
@@ -124,6 +131,13 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
 
           it "parses the response" do
             expect(response).to be_empty
+          end
+
+          it "tags the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_KNOWN_TESTS))
+              .to eq("true")
           end
 
           it_behaves_like "emits telemetry metric", :inc, "known_tests.request_errors", 1
@@ -335,6 +349,13 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
 
           it "returns empty set of known tests" do
             expect(response).to be_empty
+          end
+
+          it "tags the test session with the library configuration error tag" do
+            response
+
+            expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_KNOWN_TESTS))
+              .to eq("true")
           end
         end
       end


### PR DESCRIPTION
## Summary

- When a library configuration request to the backend fails (network error or non-2xx response), tag every CI event (test session, module, suite, test) with a hidden `_dd.ci.library_configuration_error.<request_name>` marker set to `"true"`. This lets the backend detect when a session's data may be incomplete because the library could not load remote configuration.
- We use this information to show a warning in Datadog UI to help the user see the reason of possible misbehaving feature
- Tags are set on the test session span when the corresponding fetch fails and propagate to children via the existing `INHERITABLE_TAGS` mechanism. `TestSession#inheritable_tags` now filters out `nil` values so unset error tags are not propagated.

## Test plan

- [x] `bundle exec rspec spec/datadog/ci/test_session_spec.rb`
- [x] `bundle exec rspec spec/datadog/ci/remote/library_settings_client_spec.rb`
- [x] `bundle exec rspec spec/datadog/ci/test_impact_analysis/skippable_spec.rb`
- [x] `bundle exec rspec spec/datadog/ci/test_tracing/known_tests_spec.rb`
- [x] `bundle exec rspec spec/datadog/ci/test_management/tests_properties_spec.rb`
- [x] `bundle exec rake steep:check`
- [x] `bundle exec standardrb`

## How it looks in UI

<img width="2346" height="612" alt="image" src="https://github.com/user-attachments/assets/32fa99a6-4f25-44eb-b25c-89e58402d620" />
