### PR TITLE
Fix regex patterns in publish trust policy

### DIFF
--- a/.github/chainguard/self.publish.sts.yaml
+++ b/.github/chainguard/self.publish.sts.yaml
@@ -5,9 +5,9 @@ subject: repo:DataDog/datadog-ci-rb:environment:release
 claim_pattern:
   event_name: push
   environment: release
-  ref: refs/tags/*
+  ref: refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
   repository: DataDog/datadog-ci-rb
-  job_workflow_ref: DataDog/datadog-ci-rb/\.github/workflows/publish\.yml@refs/tags/*
+  job_workflow_ref: DataDog/datadog-ci-rb/\.github/workflows/publish\.yml@refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- The `claim_pattern` fields in `.github/chainguard/self.publish.sts.yaml` use RE2 regex (implicitly anchored `^...$`), not glob patterns. The trailing `*` after `refs/tags/` quantifies the preceding `/`, so the pattern only matched `refs/tags`, `refs/tags/`, etc. — not `refs/tags/v1.29.0`. The v1.29.0 release exchange returned 403.
- Restrict `ref` and `job_workflow_ref` to semver tags via `v[0-9]+\.[0-9]+\.[0-9]+`, which is both correct and tighter than `.*` per the dd-octo-sts security guidance for privileged permissions (`contents: write`).
