### PR TITLE
[SDTEST-3761] Propagate ITR test skipping enabled tag

### DIFF
--- a/lib/datadog/ci/ext/test.rb
+++ b/lib/datadog/ci/ext/test.rb
@@ -154,6 +154,7 @@ module Datadog
         INHERITABLE_TAGS = [
           TAG_FRAMEWORK,
           TAG_FRAMEWORK_VERSION,
+          TAG_ITR_TEST_SKIPPING_ENABLED,
           LibraryConfigurationError::TAG_SETTINGS,
           LibraryConfigurationError::TAG_SKIPPABLE_TESTS,
           LibraryConfigurationError::TAG_KNOWN_TESTS,

--- a/lib/datadog/ci/test_session.rb
+++ b/lib/datadog/ci/test_session.rb
@@ -57,20 +57,12 @@ module Datadog
       # Return the test session tags that could be inherited by sub-spans
       # @return [Hash] the tags to be inherited by sub-spans.
       def inheritable_tags
-        return @inheritable_tags if defined?(@inheritable_tags)
-
-        # this method is not synchronized because it does not iterate over the tags collection, but rather
-        # uses synchronized method #get_tag to get each tag value
-        res = {}
-        Ext::Test::INHERITABLE_TAGS.each do |tag|
+        Ext::Test::INHERITABLE_TAGS.each_with_object({}) do |tag, res|
           value = get_tag(tag)
           # skip tags that are not set on the session (e.g. library configuration error tags
           # are only set when the corresponding backend request fails)
-          next if value.nil?
-
-          res[tag] = value
+          res[tag] = value unless value.nil?
         end
-        @inheritable_tags = res.freeze
       end
     end
   end

--- a/sig/datadog/ci/test_session.rbs
+++ b/sig/datadog/ci/test_session.rbs
@@ -4,8 +4,6 @@ module Datadog
       attr_accessor estimated_total_tests_count: Integer
       attr_accessor distributed: bool
 
-      @inheritable_tags: Hash[untyped, untyped]
-
       def inheritable_tags: () -> Hash[untyped, untyped]
 
       def test_command: () -> String?

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -1113,6 +1113,15 @@ RSpec.describe "RSpec instrumentation" do
         expect(test_session_span).to have_test_tag(:itr_tests_skipped, "true")
         expect(test_session_span).to have_test_tag(:itr_test_skipping_count, 1)
       end
+
+      it "propagates test skipping enabled tag to child events" do
+        rspec_session_run(with_failed_test: true)
+
+        expect([test_module_span, first_test_suite_span]).to all(
+          have_test_tag(:itr_test_skipping_enabled, "true")
+        )
+        expect(test_spans).to all have_test_tag(:itr_test_skipping_enabled, "true")
+      end
     end
 
     context "skipped all tests" do

--- a/spec/datadog/ci/test_session_spec.rb
+++ b/spec/datadog/ci/test_session_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe Datadog::CI::TestSession do
         )
       end
     end
+
+    context "when an inheritable tag is set after inherited tags were read" do
+      before do
+        ci_test_session.inheritable_tags
+        ci_test_session.set_tag(Datadog::CI::Ext::Test::TAG_ITR_TEST_SKIPPING_ENABLED, true)
+      end
+
+      it "returns the updated inheritable tags" do
+        expect(inheritable_tags).to include(
+          Datadog::CI::Ext::Test::TAG_ITR_TEST_SKIPPING_ENABLED => "true"
+        )
+      end
+    end
   end
 
   describe "#name" do


### PR DESCRIPTION
Summary:
- Propagates test.itr.tests_skipping.enabled from test sessions to child CI events.
- Removes memoization from inheritable_tags so late session tag updates are visible to later child spans.
- Adds unit and RSpec integration coverage for the propagation path.

Validation:
- bundle exec rspec spec/datadog/ci/test_session_spec.rb
- bundle exec rspec spec/datadog/ci/contrib/rspec/instrumentation_spec.rb:1117
- RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache bundle exec standardrb lib/datadog/ci/ext/test.rb lib/datadog/ci/test_session.rb spec/datadog/ci/test_session_spec.rb spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
- bundle exec rake steep:check
- bundle exec rake rbs:clean
- git diff --check