### PR TITLE
Use Gem::Version for the Ruby 3.2.0-3.2.2 allocation tracing check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+* Use `Gem::Version` for the Ruby 3.2.0-3.2.2 allocation tracing check so it does not misfire on Ruby 3.2.10+ ([#510][])
+
 ## [1.30.0] - 2026-05-12
 
 ### Changed
@@ -899,3 +903,4 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#500]: https://github.com/DataDog/datadog-ci-rb/issues/500
 [#501]: https://github.com/DataDog/datadog-ci-rb/issues/501
 [#506]: https://github.com/DataDog/datadog-ci-rb/issues/506
+[#510]: https://github.com/DataDog/datadog-ci-rb/issues/510

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -180,7 +180,8 @@ module Datadog
             settings.ci.itr_test_impact_analysis_use_allocation_tracing = false
           end
 
-          if RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3" &&
+          if RUBY_VERSION.start_with?("3.2.") &&
+              Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.3") &&
               settings.ci.itr_test_impact_analysis_use_allocation_tracing
             Datadog.logger.warn(
               "Test Impact Analysis: Allocation tracing is not supported in Ruby versions 3.2.0, 3.2.1 and 3.2.2 and will be forcibly " \

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -378,6 +378,29 @@ RSpec.describe Datadog::CI::Configuration::Components do
                       expect(settings.ci.itr_test_impact_analysis_use_allocation_tracing).to eq(false)
                     end
                   end
+
+                  context "when running on a Ruby version affected by the allocation tracing VM bug" do
+                    before { stub_const("RUBY_VERSION", "3.2.2") }
+
+                    it "logs a warning and disables allocation tracing for ITR" do
+                      expect(Datadog.logger).to have_received(:warn).with(/Allocation tracing is not supported/)
+
+                      expect(settings.ci.itr_test_impact_analysis_use_allocation_tracing).to eq(false)
+                    end
+                  end
+
+                  context "when running on a Ruby 3.2 patch version that is not affected by the VM bug" do
+                    # Regression test: a previous lexicographic compare
+                    # (`RUBY_VERSION < "3.2.3"`) incorrectly fired here because
+                    # "3.2.11" < "3.2.3" is true as a string compare.
+                    before { stub_const("RUBY_VERSION", "3.2.11") }
+
+                    it "does not log a warning and leaves allocation tracing enabled" do
+                      expect(Datadog.logger).not_to have_received(:warn).with(/Allocation tracing is not supported/)
+
+                      expect(settings.ci.itr_test_impact_analysis_use_allocation_tracing).to eq(true)
+                    end
+                  end
                 end
 
                 context "when test discovery is enabled with other features" do


### PR DESCRIPTION
**What does this PR do?**

In `Datadog::CI::Configuration::Components#build_test_impact_analysis`, the check that gates the allocation-tracing VM-bug workaround uses a lexicographic string compare:

```ruby
if RUBY_VERSION.start_with?("3.2.") && RUBY_VERSION < "3.2.3" && ...
```

`"3.2.11" < "3.2.3"` is `true` (byte 4: `'1'` (0x31) < `'3'` (0x33)), so the check incorrectly fires on Ruby 3.2.10+ — emitting a misleading warning ("Allocation tracing is not supported in Ruby versions 3.2.0, 3.2.1 and 3.2.2") and force-disabling `itr_test_impact_analysis_use_allocation_tracing` on Ruby versions that are not affected by https://bugs.ruby-lang.org/issues/19482.

This PR switches the second condition to:

```ruby
Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.2.3")
```

so the check matches the warning text and only fires on the three actually-affected patch versions. No other changes — the warning message, the `settings.ci.itr_test_impact_analysis_use_allocation_tracing = false` mutation, and the surrounding method body are untouched.

**Motivation**

Ran into this after bumping our `services/` to Ruby 3.2.11. CI logs still showed the warning every test run, and allocation tracing was getting silently disabled, degrading Test Impact Analysis quality on a Ruby version that has none of the documented VM bugs. Verified the bug is still present on `main` HEAD, so opening a PR rather than waiting for a release.

```
$ ruby -e 'puts "3.2.11" < "3.2.3"'                                      # => true
$ ruby -e 'puts Gem::Version.new("3.2.11") < Gem::Version.new("3.2.3")'  # => false
```

**Additional Notes**

The `RUBY_VERSION.start_with?("3.2.")` guard is preserved, so the cost of the `Gem::Version` allocation is only paid once at boot for users in the 3.2.x line.

**How to test the change?**

Added two specs in `spec/datadog/ci/configuration/components_spec.rb`, both under the existing "when ITR is enabled" context:

- `when running on a Ruby version affected by the allocation tracing VM bug` (stubs `RUBY_VERSION = "3.2.2"`) — asserts the warning is logged and allocation tracing is disabled. This pins the still-correct behavior on affected versions.
- `when running on a Ruby 3.2 patch version that is not affected by the VM bug` (stubs `RUBY_VERSION = "3.2.11"`) — asserts the warning is **not** logged and allocation tracing remains enabled. This is the regression test for the misfire this PR fixes.

The existing single-threaded-coverage spec at the same nesting level is unchanged.