### PR TITLE
Truncate CI Visibility meta tag values

### DIFF
--- a/lib/datadog/ci/test_tracing/serializers/base.rb
+++ b/lib/datadog/ci/test_tracing/serializers/base.rb
@@ -3,6 +3,7 @@
 require "set"
 
 require_relative "../../ext/test"
+require_relative "meta_truncation"
 
 module Datadog
   module CI
@@ -29,7 +30,9 @@ module Datadog
             @span = span
             @options = options
 
-            @meta = @span.meta.reject { |key, _| Ext::Test::TRANSIENT_TAGS.include?(key) }
+            @meta = MetaTruncation.truncate_string_values(
+              @span.meta.reject { |key, _| Ext::Test::TRANSIENT_TAGS.include?(key) }
+            )
 
             @errors = {}
             @validated = false

--- a/lib/datadog/ci/test_tracing/serializers/meta_truncation.rb
+++ b/lib/datadog/ci/test_tracing/serializers/meta_truncation.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    module TestTracing
+      module Serializers
+        module MetaTruncation
+          MAX_META_STRING_LENGTH = 5000
+
+          def self.truncate_value(value)
+            return value unless value.is_a?(String) && value.length > MAX_META_STRING_LENGTH
+
+            value[0, MAX_META_STRING_LENGTH]
+          end
+
+          def self.truncate_string_values(tags)
+            tags.transform_values { |value| truncate_value(value) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/datadog/ci/test_tracing/transport.rb
+++ b/lib/datadog/ci/test_tracing/transport.rb
@@ -5,6 +5,7 @@ require "datadog/core/telemetry/logging"
 require "datadog/core/utils/only_once"
 
 require_relative "serializers/factories/test_level"
+require_relative "serializers/meta_truncation"
 
 require_relative "../ext/app_types"
 require_relative "../ext/telemetry"
@@ -105,17 +106,17 @@ module Datadog
 
           if dd_env
             packer.write("env")
-            packer.write(dd_env)
+            packer.write(Serializers::MetaTruncation.truncate_value(dd_env))
           end
 
           packer.write("runtime-id")
-          packer.write(Datadog::Core::Environment::Identity.id)
+          packer.write(Serializers::MetaTruncation.truncate_value(Datadog::Core::Environment::Identity.id))
 
           packer.write("language")
-          packer.write(Datadog::Core::Environment::Identity.lang)
+          packer.write(Serializers::MetaTruncation.truncate_value(Datadog::Core::Environment::Identity.lang))
 
           packer.write("library_version")
-          packer.write(Datadog::CI::VERSION::STRING)
+          packer.write(Serializers::MetaTruncation.truncate_value(Datadog::CI::VERSION::STRING))
 
           library_capabilities_tags = Ext::Test::LibraryCapabilities::CAPABILITY_VERSIONS
 
@@ -124,14 +125,16 @@ module Datadog
             packer.write_map_header(2 + library_capabilities_tags.count)
 
             packer.write(Ext::Test::TAG_TEST_SESSION_NAME)
-            packer.write(test_tracing&.logical_test_session_name)
+            packer.write(Serializers::MetaTruncation.truncate_value(test_tracing&.logical_test_session_name))
 
             packer.write(Ext::Test::TAG_USER_PROVIDED_TEST_SERVICE)
-            packer.write(Utils::Configuration.service_name_provided_by_user?.to_s)
+            packer.write(
+              Serializers::MetaTruncation.truncate_value(Utils::Configuration.service_name_provided_by_user?.to_s)
+            )
 
             library_capabilities_tags.each do |tag, value|
               packer.write(tag)
-              packer.write(value)
+              packer.write(Serializers::MetaTruncation.truncate_value(value))
             end
           end
 

--- a/sig/datadog/ci/test_tracing/serializers/meta_truncation.rbs
+++ b/sig/datadog/ci/test_tracing/serializers/meta_truncation.rbs
@@ -1,0 +1,14 @@
+module Datadog
+  module CI
+    module TestTracing
+      module Serializers
+        module MetaTruncation
+          MAX_META_STRING_LENGTH: 5000
+
+          def self.truncate_value: (untyped value) -> untyped
+          def self.truncate_string_values: (Hash[untyped, untyped] tags) -> Hash[untyped, untyped]
+        end
+      end
+    end
+  end
+end

--- a/spec/datadog/ci/test_tracing/serializers/span_spec.rb
+++ b/spec/datadog/ci/test_tracing/serializers/span_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe Datadog::CI::TestTracing::Serializers::Span do
         )
         expect(metrics).to eq({"_dd.top_level" => 1.0, "custom_metric" => 42})
       end
+
+      it "truncates string meta tag values to the backend limit" do
+        first_custom_span.set_tag("long_custom_tag", "a" * 5001)
+
+        expect(meta["long_custom_tag"]).to eq("a" * 5000)
+        expect(metrics).to include("custom_metric" => 42)
+      end
     end
   end
 

--- a/spec/datadog/ci/test_tracing/serializers/test_v2_spec.rb
+++ b/spec/datadog/ci/test_tracing/serializers/test_v2_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe Datadog::CI::TestTracing::Serializers::TestV2 do
 
         expect(metrics).to eq({"_dd.top_level" => 1, "memory_allocations" => 16, "_dd.host.vcpu_count" => Etc.nprocessors})
       end
+
+      it "truncates string meta tag values to the backend limit" do
+        first_test_span.set_tag("long_test_tag", "b" * 5001)
+
+        expect(meta["long_test_tag"]).to eq("b" * 5000)
+        expect(content["test_session_id"]).to eq(test_session_span.id)
+        expect(metrics).to include("memory_allocations" => 16)
+      end
     end
 
     context "trace several tests executions with test visibility" do

--- a/spec/datadog/ci/test_tracing/transport_spec.rb
+++ b/spec/datadog/ci/test_tracing/transport_spec.rb
@@ -124,6 +124,29 @@ RSpec.describe Datadog::CI::TestTracing::Transport do
       end
     end
 
+    context "with metadata values longer than the backend limit" do
+      let(:dd_env) { "e" * 5001 }
+      let(:logical_test_session_name) { "s" * 5001 }
+
+      before do
+        produce_test_trace
+      end
+
+      it "truncates payload metadata string values" do
+        subject.send_events([trace])
+
+        expect(api).to have_received(:citestcycle_request) do |args|
+          payload = MessagePack.unpack(args[:payload])
+
+          expect(payload["metadata"]["*"]["env"]).to eq("e" * 5000)
+
+          Datadog::CI::Ext::AppTypes::CI_SPAN_TYPES.each do |type|
+            expect(payload["metadata"][type]["test_session.name"]).to eq("s" * 5000)
+          end
+        end
+      end
+    end
+
     context "with itr correlation id" do
       let(:serializers_factory) { Datadog::CI::TestTracing::Serializers::Factories::TestSuiteLevel }
 


### PR DESCRIPTION
**What does this PR do?**

Truncates CI Visibility metadata/tag string values to 5000 characters before encoding or dispatching payloads. This covers serialized span metadata and transport-level event metadata so oversized tag values stay within the backend limit.

**Motivation**

The backend accepts a maximum tag value size of 5000 characters. Truncating client-side prevents CI Visibility payloads from carrying metadata values that the backend will reject or drop.

**Additional Notes**

The truncation applies to string metadata values only. Non-string metadata values are left unchanged.

**How to test the change?**

- `git diff --check`
- `ruby -c lib/datadog/ci/test_tracing/serializers/meta_truncation.rb`
- `ruby -c lib/datadog/ci/test_tracing/serializers/base.rb`
- `ruby -c lib/datadog/ci/test_tracing/transport.rb`

RSpec was not run locally because the local checkout does not currently have the required `rspec` executable/gems available.