### PR TITLE
Fix symbol collision with a debug gem

### DIFF
--- a/ext/datadog_ci_native/ci.c
+++ b/ext/datadog_ci_native/ci.c
@@ -8,5 +8,5 @@ void Init_datadog_ci_native(void) {
 
   // SourceCode
   Init_datadog_method_inspect();
-  Init_iseq_collector();
+  Init_dd_ci_iseq_collector();
 }

--- a/ext/datadog_ci_native/iseq_collector.c
+++ b/ext/datadog_ci_native/iseq_collector.c
@@ -54,7 +54,7 @@ static VALUE iseq_collector_collect(VALUE self) {
 
 /* ---- Module initialization ---------------------------------------------- */
 
-void Init_iseq_collector(void) {
+void Init_dd_ci_iseq_collector(void) {
   VALUE mDatadog = rb_define_module("Datadog");
   VALUE mCI = rb_define_module_under(mDatadog, "CI");
   VALUE mSourceCode = rb_define_module_under(mCI, "SourceCode");

--- a/ext/datadog_ci_native/iseq_collector.h
+++ b/ext/datadog_ci_native/iseq_collector.h
@@ -1,6 +1,6 @@
 #ifndef ISEQ_COLLECTOR_H
 #define ISEQ_COLLECTOR_H
 
-void Init_iseq_collector(void);
+void Init_dd_ci_iseq_collector(void);
 
 #endif /* ISEQ_COLLECTOR_H */

--- a/spec/datadog/ci/source_code/iseq_collector_spec.rb
+++ b/spec/datadog/ci/source_code/iseq_collector_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "datadog/ci/source_code/static_dependencies"
+require "open3"
+require "rbconfig"
+require "shellwords"
+
+RSpec.describe Datadog::CI::SourceCode::ISeqCollector do
+  let(:lib_path) { File.expand_path("../../../../lib", __dir__) }
+  let(:extension_name) { "datadog_ci_native.#{RUBY_VERSION}_#{RUBY_PLATFORM}" }
+  let(:extension_path) { File.join(lib_path, "#{extension_name}.#{RbConfig::CONFIG["DLEXT"]}") }
+
+  describe "debug gem compatibility", skip: !described_class::STATIC_DEPENDENCIES_EXTRACTION_AVAILABLE do
+    it "does not export the internal iseq collector initializer" do
+      expect(File.exist?(extension_path)).to be(true), "expected native extension at #{extension_path}"
+
+      nm_command = RbConfig::CONFIG["NM"].to_s
+      nm_command = nm_command.empty? ? ["nm"] : Shellwords.split(nm_command)
+      stdout, stderr, status = Open3.capture3(*nm_command, "-g", extension_path)
+
+      expect(status).to be_success, "stdout:\n#{stdout}\nstderr:\n#{stderr}"
+      expect(stdout).not_to match(/(?:^|\s)_?Init_iseq_collector(?:\s|$)/)
+    end
+
+    it "allows debug to install ObjectSpace.each_iseq after datadog/ci is loaded first" do
+      skip "reproduces only on Linux" unless RUBY_PLATFORM.include?("linux")
+
+      script = <<~RUBY
+        require "datadog/ci"
+        require "debug"
+
+        abort "ObjectSpace.each_iseq is missing" unless ObjectSpace.respond_to?(:each_iseq)
+      RUBY
+
+      stdout, stderr, status = Open3.capture3(
+        {"RUBYOPT" => nil},
+        RbConfig.ruby,
+        "-rbundler/setup",
+        "-I#{lib_path}",
+        "-e",
+        script
+      )
+
+      expect(status).to be_success, "stdout:\n#{stdout}\nstderr:\n#{stderr}"
+    end
+  end
+end

--- a/spec/datadog/ci/source_code/iseq_collector_spec.rb
+++ b/spec/datadog/ci/source_code/iseq_collector_spec.rb
@@ -4,25 +4,11 @@ require "spec_helper"
 require "datadog/ci/source_code/static_dependencies"
 require "open3"
 require "rbconfig"
-require "shellwords"
 
 RSpec.describe Datadog::CI::SourceCode::ISeqCollector do
   let(:lib_path) { File.expand_path("../../../../lib", __dir__) }
-  let(:extension_name) { "datadog_ci_native.#{RUBY_VERSION}_#{RUBY_PLATFORM}" }
-  let(:extension_path) { File.join(lib_path, "#{extension_name}.#{RbConfig::CONFIG["DLEXT"]}") }
 
   describe "debug gem compatibility", skip: !described_class::STATIC_DEPENDENCIES_EXTRACTION_AVAILABLE do
-    it "does not export the internal iseq collector initializer" do
-      expect(File.exist?(extension_path)).to be(true), "expected native extension at #{extension_path}"
-
-      nm_command = RbConfig::CONFIG["NM"].to_s
-      nm_command = nm_command.empty? ? ["nm"] : Shellwords.split(nm_command)
-      stdout, stderr, status = Open3.capture3(*nm_command, "-g", extension_path)
-
-      expect(status).to be_success, "stdout:\n#{stdout}\nstderr:\n#{stderr}"
-      expect(stdout).not_to match(/(?:^|\s)_?Init_iseq_collector(?:\s|$)/)
-    end
-
     it "allows debug to install ObjectSpace.each_iseq after datadog/ci is loaded first" do
       skip "reproduces only on Linux" unless RUBY_PLATFORM.include?("linux")
 


### PR DESCRIPTION
## Summary

Fixes #519 by renaming Datadog's internal native iseq collector initializer so it no longer collides with the `debug` gem's own `Init_iseq_collector` symbol on Linux.

## What changed

- Added an isolated Linux-only subprocess repro that matches the customer require order: `require "datadog/ci"` before `require "debug"`.
- Renamed the internal C initializer from `Init_iseq_collector` to `Init_dd_ci_iseq_collector`.
- Kept the Ruby-facing API unchanged: `Datadog::CI::SourceCode::ISeqCollector.collect` and `collect_iseqs` are unchanged.

## Validation

- `bundle exec rake compile_ext`
- `bundle exec rspec spec/datadog/ci/source_code/iseq_collector_spec.rb`
- `bundle exec standardrb spec/datadog/ci/source_code/iseq_collector_spec.rb`
- `bundle exec rake steep:check`
- Linux Docker `ghcr.io/datadog/images-rb/engines/ruby:3.4`: `bundle exec rake compile spec:ddcov_memcheck` passed with `157 examples, 0 failures`.
