### PR TITLE
Bump to version 1.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## [Unreleased]
 
+## [1.32.0] - 2026-06-08
+
+### Changed
+
+* Truncate CI Visibility meta tag values ([#515][])
+
+### Fixed
+
+* Fix Minitest TIA skipped hooks ([#516][])
+* Fix: use Gem::Version for Ruby allocation tracing check ([#522][])
+* Fix symbol collision with a debug gem ([#521][])
+
 ## [1.31.0] - 2026-05-20
 
 ### Added
@@ -641,7 +653,8 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 
 - Ruby versions < 2.7 no longer supported ([#8][])
 
-[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.31.0...main
+[Unreleased]: https://github.com/DataDog/datadog-ci-rb/compare/v1.32.0...main
+[1.32.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.31.0...v1.32.0
 [1.31.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.30.0...v1.31.0
 [1.30.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.29.0...v1.30.0
 [1.29.0]: https://github.com/DataDog/datadog-ci-rb/compare/v1.28.0...v1.29.0
@@ -909,3 +922,7 @@ Currently test suite level visibility is not used by our instrumentation: it wil
 [#506]: https://github.com/DataDog/datadog-ci-rb/issues/506
 [#509]: https://github.com/DataDog/datadog-ci-rb/issues/509
 [#511]: https://github.com/DataDog/datadog-ci-rb/issues/511
+[#515]: https://github.com/DataDog/datadog-ci-rb/issues/515
+[#516]: https://github.com/DataDog/datadog-ci-rb/issues/516
+[#521]: https://github.com/DataDog/datadog-ci-rb/issues/521
+[#522]: https://github.com/DataDog/datadog-ci-rb/issues/522

--- a/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_4.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_2.7_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_5.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_6.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rails_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_2.7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_2.7_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_2.7_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_2.7_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_4.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.0_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_cuprite_0_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.0_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.0_selenium_4_capybara_3.gemfile.lock
@@ -13,7 +13,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.0_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_ci_queue_0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_10.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_4.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.1_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_cuprite_0_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.1_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.1_selenium_4_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.1_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.1_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_ci_queue_0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_10.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_11.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_11.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_4.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.2_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_cuprite_0_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_lograge_0_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5_maxitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_maxitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_minitest_6_maxitest_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_minitest_6_maxitest_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_4_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_parallel_tests_5_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.2_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.2_selenium_4_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.2_semantic_logger_4_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.2_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.2_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_ci_queue_0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_10.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_11.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_11.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_4.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.3_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_cuprite_0_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_lograge_0_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5_maxitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_maxitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_minitest_6_maxitest_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_minitest_6_maxitest_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_4_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_parallel_tests_5_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.3_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.3_selenium_4_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.3_semantic_logger_4_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.3_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.3_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_ci_queue_0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_10.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_11.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_11.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
+++ b/gemfiles/ruby_3.4_cucumber_9.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_cuprite_0_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_lograge_0_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_5_maxitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_maxitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -176,7 +176,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_minitest_6_maxitest_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_minitest_6_maxitest_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -178,7 +178,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_4_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_parallel_tests_5_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_5.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_6.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_3.4_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -373,7 +373,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_3.4_selenium_4_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_3.4_semantic_logger_4_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_3.4_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_3.4_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack

--- a/gemfiles/ruby_4.0_ci_queue_0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_4.0_ci_queue_0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -164,7 +164,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_ci_queue_0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_ci_queue_0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -151,7 +151,7 @@ CHECKSUMS
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_cucumber_10.gemfile.lock
+++ b/gemfiles/ruby_4.0_cucumber_10.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -185,7 +185,7 @@ CHECKSUMS
   cucumber-messages (32.3.1) sha256=ddc88e4c1cf7afb96c06005b92a4a6f221a2fa435a8b4ca04677d215fd82771c
   cucumber-tag-expressions (8.1.0) sha256=9bd8c4b6654f8e5bf2a9c99329b6f32136a75e50cd39d4cfb3927d0fa9f52e21
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_cucumber_11.gemfile.lock
+++ b/gemfiles/ruby_4.0_cucumber_11.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -212,7 +212,7 @@ CHECKSUMS
   cucumber-messages (32.3.1) sha256=ddc88e4c1cf7afb96c06005b92a4a6f221a2fa435a8b4ca04677d215fd82771c
   cucumber-tag-expressions (8.1.0) sha256=9bd8c4b6654f8e5bf2a9c99329b6f32136a75e50cd39d4cfb3927d0fa9f52e21
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_cuprite_0_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_cuprite_0_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -228,7 +228,7 @@ CHECKSUMS
   cucumber-tag-expressions (8.1.0) sha256=9bd8c4b6654f8e5bf2a9c99329b6f32136a75e50cd39d4cfb3927d0fa9f52e21
   cuprite (0.17) sha256=b140d5dc70d08b97ad54bcf45cd95d0bd430e291e9dffe76fff851fddd57c12b
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_knapsack_pro_7_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_knapsack_pro_7_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -144,7 +144,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_knapsack_pro_8_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_knapsack_pro_8_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -144,7 +144,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_lograge_0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_4.0_lograge_0_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -331,7 +331,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_minitest_5.gemfile.lock
+++ b/gemfiles/ruby_4.0_minitest_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -143,7 +143,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_minitest_5_maxitest_6.gemfile.lock
+++ b/gemfiles/ruby_4.0_minitest_5_maxitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -175,7 +175,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
+++ b/gemfiles/ruby_4.0_minitest_5_shoulda_context_2_shoulda_matchers_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -175,7 +175,7 @@ CHECKSUMS
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_minitest_6.gemfile.lock
+++ b/gemfiles/ruby_4.0_minitest_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -145,7 +145,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_minitest_6_maxitest_7.gemfile.lock
+++ b/gemfiles/ruby_4.0_minitest_6_maxitest_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -177,7 +177,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_parallel_tests_4_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_parallel_tests_4_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -145,7 +145,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_parallel_tests_5_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_parallel_tests_5_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -145,7 +145,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rails_5.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails_5.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -286,7 +286,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rails_6.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails_6.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -308,7 +308,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rails_7.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -323,7 +323,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rails_8.gemfile.lock
+++ b/gemfiles/ruby_4.0_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -324,7 +324,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rspec_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_rspec_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -141,7 +141,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_rswag_2_rails_7.gemfile.lock
+++ b/gemfiles/ruby_4.0_rswag_2_rails_7.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -372,7 +372,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_selenium_4_capybara_3.gemfile.lock
+++ b/gemfiles/ruby_4.0_selenium_4_capybara_3.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -219,7 +219,7 @@ CHECKSUMS
   cucumber-messages (32.3.1) sha256=ddc88e4c1cf7afb96c06005b92a4a6f221a2fa435a8b4ca04677d215fd82771c
   cucumber-tag-expressions (8.1.0) sha256=9bd8c4b6654f8e5bf2a9c99329b6f32136a75e50cd39d4cfb3927d0fa9f52e21
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_semantic_logger_4_rails_8.gemfile.lock
+++ b/gemfiles/ruby_4.0_semantic_logger_4_rails_8.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -330,7 +330,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/gemfiles/ruby_4.0_timecop_0.gemfile.lock
+++ b/gemfiles/ruby_4.0_timecop_0.gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: ..
   specs:
-    datadog-ci (1.31.0)
+    datadog-ci (1.32.0)
       datadog (~> 2.4)
       drb
       msgpack
@@ -145,7 +145,7 @@ CHECKSUMS
   climate_control (1.2.0) sha256=36b21896193fa8c8536fa1cd843a07cf8ddbd03aaba43665e26c53ec1bd70aa5
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   datadog (2.36.0.dev)
-  datadog-ci (1.31.0)
+  datadog-ci (1.32.0)
   datadog-ruby_core_source (3.5.2) sha256=c379c012eca11d6c58b112d716a986d051fb566a436d58f46cde7cfec43cb299
   date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6

--- a/lib/datadog/ci/version.rb
+++ b/lib/datadog/ci/version.rb
@@ -4,7 +4,7 @@ module Datadog
   module CI
     module VERSION
       MAJOR = 1
-      MINOR = 31
+      MINOR = 32
       PATCH = 0
       PRE = nil
       BUILD = nil


### PR DESCRIPTION
### Changed

* Truncate CI Visibility meta tag values (#515)

### Fixed

* Fix Minitest TIA skipped hooks (#516)
* Fix: use Gem::Version for Ruby allocation tracing check (#522)
* Fix symbol collision with a debug gem (#521)
