### PR TITLE
[codex] Improve tooling and typing coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ group :check do
 
   # type checks
   if RUBY_VERSION >= "3.4.0" && RUBY_PLATFORM != "java"
-    gem "rbs", "~> 3.9.0", require: false
-    gem "steep", "~> 1.10.0", require: false
+    gem "rbs", "~> 4.0", require: false
+    gem "steep", "~> 2.0", require: false
   end
 
   # memory checks

--- a/lib/datadog/ci/source_code/static_dependencies_extractor.rb
+++ b/lib/datadog/ci/source_code/static_dependencies_extractor.rb
@@ -51,7 +51,6 @@ module Datadog
           def build_constant_path(symbol_array)
             symbol_array
               .select { |part| part.is_a?(Symbol) }
-              .map(&:to_s)
               .join("::")
           end
 

--- a/sig/datadog/ci/contrib/activesupport/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/activesupport/configuration/settings.rbs
@@ -8,6 +8,8 @@ module Datadog
 
             def enabled: () -> bool
             def enabled=: (bool) -> bool
+
+            def []: (:enabled) -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/activesupport/logs_formatter.rbs
+++ b/sig/datadog/ci/contrib/activesupport/logs_formatter.rbs
@@ -8,7 +8,7 @@ module Datadog
           private
 
           def datadog_logs_component: () -> Datadog::CI::Logs::Component
-          def datadog_configuration: () -> Hash[Symbol, untyped]
+          def datadog_configuration: () -> Datadog::CI::Contrib::ActiveSupport::Configuration::Settings
         end
       end
     end

--- a/sig/datadog/ci/contrib/cucumber/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/cucumber/configuration/settings.rbs
@@ -4,6 +4,15 @@ module Datadog
       module Cucumber
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def service_name: () -> String
+            def service_name=: (String) -> String
+
+            def []: (:enabled) -> bool | (:service_name) -> String
           end
         end
       end

--- a/sig/datadog/ci/contrib/cucumber/filter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/filter.rbs
@@ -3,19 +3,29 @@ module Datadog
     module Contrib
       module Cucumber
         class Filter < ::Cucumber::Core::Filter
-          @test_case_seen: untyped
+          interface _TestCase
+            def ==: (_TestCase other) -> bool
 
-          @test_retries_component: untyped
+            def describe_to: (Object receiver) -> untyped
+          end
 
-          def test_case: (untyped test_case) -> untyped
+          interface _TestCaseFinishedEvent
+            def test_case: () -> _TestCase
+          end
+
+          @test_case_seen: Hash[_TestCase, bool]
+
+          @test_retries_component: Datadog::CI::TestRetries::Component
+
+          def test_case: (_TestCase test_case) -> untyped
 
           private
 
-          def retry_required?: (untyped test_case, untyped event) -> (false | untyped)
+          def retry_required?: (_TestCase test_case, _TestCaseFinishedEvent event) -> bool
 
-          def test_case_seen: () -> untyped
+          def test_case_seen: () -> Hash[_TestCase, bool]
 
-          def test_retries_component: () -> untyped
+          def test_retries_component: () -> Datadog::CI::TestRetries::Component
         end
       end
     end

--- a/sig/datadog/ci/contrib/cucumber/formatter.rbs
+++ b/sig/datadog/ci/contrib/cucumber/formatter.rbs
@@ -51,7 +51,7 @@ module Datadog
 
           def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-          def datadog_configuration: () -> untyped
+          def datadog_configuration: () -> Datadog::CI::Contrib::Cucumber::Configuration::Settings
 
           def test_tracing_component: () -> Datadog::CI::TestTracing::Component
 

--- a/sig/datadog/ci/contrib/cuprite/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/cuprite/configuration/settings.rbs
@@ -4,6 +4,15 @@ module Datadog
       module Cuprite
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def rum_flush_wait_millis: () -> Integer
+            def rum_flush_wait_millis=: (Integer) -> Integer
+
+            def []: (:enabled) -> bool | (:rum_flush_wait_millis) -> Integer
           end
         end
       end

--- a/sig/datadog/ci/contrib/cuprite/driver.rbs
+++ b/sig/datadog/ci/contrib/cuprite/driver.rbs
@@ -18,7 +18,7 @@ module Datadog
 
             def datadog_integration: () -> untyped
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Cuprite::Configuration::Settings
 
             def datadog_end_rum_session: () -> (nil | untyped)
           end

--- a/sig/datadog/ci/contrib/knapsack/runner.rbs
+++ b/sig/datadog/ci/contrib/knapsack/runner.rbs
@@ -14,7 +14,7 @@ module Datadog
 
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::RSpec::Configuration::Settings
 
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component
           end

--- a/sig/datadog/ci/contrib/lograge/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/lograge/configuration/settings.rbs
@@ -8,6 +8,8 @@ module Datadog
 
             def enabled: () -> bool
             def enabled=: (bool) -> bool
+
+            def []: (:enabled) -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/lograge/log_subscriber.rbs
+++ b/sig/datadog/ci/contrib/lograge/log_subscriber.rbs
@@ -10,7 +10,7 @@ module Datadog
 
             def before_format: (untyped data, untyped payload) -> untyped
             def datadog_logs_component: () -> Datadog::CI::Logs::Component
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Lograge::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/minitest/configuration/settings.rbs
@@ -4,6 +4,15 @@ module Datadog
       module Minitest
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def service_name: () -> String
+            def service_name=: (String) -> String
+
+            def []: (:enabled) -> bool | (:service_name) -> String
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/helpers.rbs
+++ b/sig/datadog/ci/contrib/minitest/helpers.rbs
@@ -3,17 +3,27 @@ module Datadog
     module Contrib
       module Minitest
         module Helpers
-          def self.start_test_suite: (untyped klass) -> Datadog::CI::TestSuite?
+          interface _RunnableClass
+            def runnable_methods: () -> Array[String]
 
-          def self.test_suite_name: (untyped klass, String? method_name) -> ::String
+            def name: () -> String?
 
-          def self.parallel?: (untyped klass) -> bool
+            def instance_method: (String method_name) -> UnboundMethod
+
+            def ancestors: () -> Array[Module]
+          end
+
+          def self.start_test_suite: (_RunnableClass klass) -> Datadog::CI::TestSuite?
+
+          def self.test_suite_name: (_RunnableClass klass, String method_name) -> ::String
+
+          def self.parallel?: (_RunnableClass klass) -> bool
 
           def self.ci_queue?: () -> bool
 
-          def self.extract_source_location_from_class: (untyped klass) -> Array[untyped]
+          def self.extract_source_location_from_class: (untyped klass) -> ([String, Integer] | Array[untyped])
 
-          def self.extract_runnable_source_location: (untyped klass, String? method_name) -> Array[untyped]?
+          def self.extract_runnable_source_location: (_RunnableClass klass, String method_name) -> ([String, Integer] | Array[untyped])?
         end
       end
     end

--- a/sig/datadog/ci/contrib/minitest/parallel_executor_minitest_6.rbs
+++ b/sig/datadog/ci/contrib/minitest/parallel_executor_minitest_6.rbs
@@ -12,7 +12,7 @@ module Datadog
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/reporter.rbs
+++ b/sig/datadog/ci/contrib/minitest/reporter.rbs
@@ -10,7 +10,7 @@ module Datadog
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/run_method_capture.rbs
+++ b/sig/datadog/ci/contrib/minitest/run_method_capture.rbs
@@ -3,9 +3,15 @@ module Datadog
     module Contrib
       module Minitest
         module RunMethodCapture
-          def self.capture_concrete_pre_datadog_run!: (untyped storage, untyped owner, untyped datadog_run_owner) -> void
+          interface _Storage
+            def _dd_pre_datadog_minitest_run: () -> UnboundMethod?
 
-          def self.concrete_pre_datadog_run?: (untyped method, untyped datadog_run_owner) -> bool
+            def _dd_pre_datadog_minitest_run=: (UnboundMethod? method) -> UnboundMethod?
+          end
+
+          def self.capture_concrete_pre_datadog_run!: (_Storage storage, untyped owner, Module datadog_run_owner) -> void
+
+          def self.concrete_pre_datadog_run?: (UnboundMethod? method, Module datadog_run_owner) -> bool?
         end
       end
     end

--- a/sig/datadog/ci/contrib/minitest/runnable.rbs
+++ b/sig/datadog/ci/contrib/minitest/runnable.rbs
@@ -6,16 +6,15 @@ module Datadog
           def self.included: (untyped base) -> untyped
 
           module ClassMethods : ::Minitest::Runnable
+            include Datadog::CI::Contrib::Minitest::Helpers::_RunnableClass
 
             def run: (*untyped) -> untyped
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
 
             def test_order: () -> (nil | :parallel | :random | :sorted | :alpha)
-
-            def runnable_methods: () -> Array[String]
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/runnable_minitest_6.rbs
+++ b/sig/datadog/ci/contrib/minitest/runnable_minitest_6.rbs
@@ -6,13 +6,15 @@ module Datadog
           def self.included: (untyped base) -> untyped
 
           module ClassMethods
+            include Datadog::CI::Contrib::Minitest::Helpers::_RunnableClass
+
             def run_suite: (*untyped args) -> untyped
 
             def run: (untyped klass, untyped method_name, untyped reporter) -> untyped
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
 
             def _dd_test_tracing_component: () -> (Datadog::CI::TestTracing::Component | Datadog::CI::TestTracing::NullComponent)
 

--- a/sig/datadog/ci/contrib/minitest/runner.rbs
+++ b/sig/datadog/ci/contrib/minitest/runner.rbs
@@ -18,7 +18,7 @@ module Datadog
 
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
 
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component
 

--- a/sig/datadog/ci/contrib/minitest/test.rbs
+++ b/sig/datadog/ci/contrib/minitest/test.rbs
@@ -10,6 +10,8 @@ module Datadog
           def self._dd_pre_datadog_minitest_run=: (untyped) -> untyped
 
           module ClassMethods
+            include Datadog::CI::Contrib::Minitest::Helpers::_RunnableClass
+
             @datadog_itr_unskippable_suite: bool
             @datadog_itr_unskippable_tests: Array[String]?
 
@@ -42,7 +44,7 @@ module Datadog
 
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Minitest::Configuration::Settings
 
             def _dd_test_tracing_component: () -> Datadog::CI::TestTracing::Component
 

--- a/sig/datadog/ci/contrib/parallel_tests/cli.rbs
+++ b/sig/datadog/ci/contrib/parallel_tests/cli.rbs
@@ -9,7 +9,7 @@ module Datadog
             def run_tests_in_parallel: (Integer num_processes, Hash[Symbol, untyped] options) -> untyped
             def any_test_failed?: (untyped test_results) -> bool
             def datadog_extract_rspec_version: () -> String
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::ParallelTests::Configuration::Settings
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component
           end
         end

--- a/sig/datadog/ci/contrib/parallel_tests/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/parallel_tests/configuration/settings.rbs
@@ -8,6 +8,11 @@ module Datadog
 
             def enabled: () -> bool
             def enabled=: (bool) -> bool
+
+            def service_name: () -> String
+            def service_name=: (String) -> String
+
+            def []: (:enabled) -> bool | (:service_name) -> String
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/rspec/configuration/settings.rbs
@@ -4,8 +4,21 @@ module Datadog
       module RSpec
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def service_name: () -> String
+            def service_name=: (String) -> String
+
+            def datadog_formatter_enabled: () -> bool
+            def datadog_formatter_enabled=: (bool) -> bool
+
             def dry_run_enabled: () -> bool
             def dry_run_enabled=: (bool) -> bool
+
+            def []: (:enabled | :datadog_formatter_enabled | :dry_run_enabled) -> bool | (:service_name) -> String
           end
         end
       end

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -56,7 +56,7 @@ module Datadog
 
             # Component accessors
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::RSpec::Configuration::Settings
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component
             def test_retries_component: () -> Datadog::CI::TestRetries::Component
             def ci_queue?: () -> bool

--- a/sig/datadog/ci/contrib/rspec/example_group.rbs
+++ b/sig/datadog/ci/contrib/rspec/example_group.rbs
@@ -20,7 +20,7 @@ module Datadog
 
             def clear_context_coverage: (String context_id) -> void
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::RSpec::Configuration::Settings
 
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component?
 

--- a/sig/datadog/ci/contrib/rspec/runner.rbs
+++ b/sig/datadog/ci/contrib/rspec/runner.rbs
@@ -12,7 +12,7 @@ module Datadog
 
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::RSpec::Configuration::Settings
 
             def test_tracing_component: () -> Datadog::CI::TestTracing::Component
 

--- a/sig/datadog/ci/contrib/selenium/capybara_driver.rbs
+++ b/sig/datadog/ci/contrib/selenium/capybara_driver.rbs
@@ -10,7 +10,7 @@ module Datadog
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Selenium::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/selenium/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/selenium/configuration/settings.rbs
@@ -4,6 +4,15 @@ module Datadog
       module Selenium
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def rum_flush_wait_millis: () -> Integer
+            def rum_flush_wait_millis=: (Integer) -> Integer
+
+            def []: (:enabled) -> bool | (:rum_flush_wait_millis) -> Integer
           end
         end
       end

--- a/sig/datadog/ci/contrib/selenium/driver.rbs
+++ b/sig/datadog/ci/contrib/selenium/driver.rbs
@@ -10,7 +10,7 @@ module Datadog
 
             private
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Selenium::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/selenium/navigation.rbs
+++ b/sig/datadog/ci/contrib/selenium/navigation.rbs
@@ -10,7 +10,7 @@ module Datadog
 
             def datadog_integration: () -> Datadog::CI::Contrib::Integration
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Selenium::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/semantic_logger/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/semantic_logger/configuration/settings.rbs
@@ -8,6 +8,8 @@ module Datadog
 
             def enabled: () -> bool
             def enabled=: (bool) -> bool
+
+            def []: (:enabled) -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/settings.rbs
+++ b/sig/datadog/ci/contrib/settings.rbs
@@ -2,6 +2,8 @@ module Datadog
   module CI
     module Contrib
       class Settings
+        type option_value = bool | Integer | String | nil
+
         include Core::Configuration::Base
         extend Datadog::Core::Configuration::Options::ClassMethods
         include Datadog::Core::Configuration::Options::InstanceMethods
@@ -10,9 +12,9 @@ module Datadog
 
         def configure: (?::Hash[Symbol, untyped] options) ?{ (Datadog::CI::Contrib::Settings) -> Datadog::CI::Contrib::Settings } -> Datadog::CI::Contrib::Settings?
 
-        def []: (Symbol name) -> Datadog::CI::Contrib::Settings
+        def []: (Symbol name) -> option_value
 
-        def []=: (untyped name, untyped value) -> untyped
+        def []=: (Symbol name, option_value value) -> option_value
 
         # default configuration options
         #

--- a/sig/datadog/ci/contrib/simplecov/configuration/settings.rbs
+++ b/sig/datadog/ci/contrib/simplecov/configuration/settings.rbs
@@ -4,6 +4,12 @@ module Datadog
       module Simplecov
         module Configuration
           class Settings < Datadog::CI::Contrib::Settings
+            def initialize: () ?{ (Settings) -> void } -> void
+
+            def enabled: () -> bool
+            def enabled=: (bool) -> bool
+
+            def []: (:enabled) -> bool
           end
         end
       end

--- a/sig/datadog/ci/contrib/simplecov/report_uploader.rbs
+++ b/sig/datadog/ci/contrib/simplecov/report_uploader.rbs
@@ -16,7 +16,7 @@ module Datadog
 
             def read_coverage_result: () -> String?
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Simplecov::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
+++ b/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
@@ -14,7 +14,7 @@ module Datadog
 
             def __dd_peek_result: () -> ::SimpleCov::Result?
 
-            def datadog_configuration: () -> untyped
+            def datadog_configuration: () -> Datadog::CI::Contrib::Simplecov::Configuration::Settings
           end
         end
       end

--- a/sig/datadog/ci/test_optimization_cache/component.rbs
+++ b/sig/datadog/ci/test_optimization_cache/component.rbs
@@ -2,7 +2,7 @@ module Datadog
   module CI
     module TestOptimizationCache
       class Component
-        READER_BY_MANIFEST_VERSION: Hash[String, untyped]
+        READER_BY_MANIFEST_VERSION: Hash[String, singleton(Readers::V1)]
 
         @locator: Locator
         @reader: Readers::Base
@@ -11,13 +11,13 @@ module Datadog
 
         def cache_available?: () -> bool
 
-        def load_settings: () -> Hash[untyped, untyped]?
+        def load_settings: () -> Hash[String, untyped]?
 
-        def load_known_tests: () -> Hash[untyped, untyped]?
+        def load_known_tests: () -> Hash[String, untyped]?
 
-        def load_test_management: () -> Hash[untyped, untyped]?
+        def load_test_management: () -> Hash[String, untyped]?
 
-        def load_skippable_tests: () -> Hash[untyped, untyped]?
+        def load_skippable_tests: () -> Hash[String, untyped]?
 
         def shutdown!: () -> nil
 

--- a/sig/datadog/ci/test_optimization_cache/readers/base.rbs
+++ b/sig/datadog/ci/test_optimization_cache/readers/base.rbs
@@ -5,17 +5,17 @@ module Datadog
         class Base
           def available?: () -> bool
 
-          def load_settings: () -> Hash[untyped, untyped]?
+          def load_settings: () -> Hash[String, untyped]?
 
-          def load_known_tests: () -> Hash[untyped, untyped]?
+          def load_known_tests: () -> Hash[String, untyped]?
 
-          def load_test_management: () -> Hash[untyped, untyped]?
+          def load_test_management: () -> Hash[String, untyped]?
 
-          def load_skippable_tests: () -> Hash[untyped, untyped]?
+          def load_skippable_tests: () -> Hash[String, untyped]?
 
           private
 
-          def read_json_file: (String file_path) -> Hash[untyped, untyped]?
+          def read_json_file: (String file_path) -> Hash[String, untyped]?
         end
       end
     end

--- a/sig/datadog/ci/test_optimization_cache/readers/legacy.rbs
+++ b/sig/datadog/ci/test_optimization_cache/readers/legacy.rbs
@@ -3,21 +3,21 @@ module Datadog
     module TestOptimizationCache
       module Readers
         class Legacy < Base
-          def load_settings: () -> Hash[untyped, untyped]?
+          def load_settings: () -> Hash[String, untyped]?
 
-          def load_known_tests: () -> Hash[untyped, untyped]?
+          def load_known_tests: () -> Hash[String, untyped]?
 
-          def load_test_management: () -> Hash[untyped, untyped]?
+          def load_test_management: () -> Hash[String, untyped]?
 
-          def load_skippable_tests: () -> Hash[untyped, untyped]?
+          def load_skippable_tests: () -> Hash[String, untyped]?
 
           private
 
-          def load_legacy_json: (String file_name) -> Hash[untyped, untyped]?
+          def load_legacy_json: (String file_name) -> Hash[String, untyped]?
 
-          def backend_response: (Hash[untyped, untyped] payload) -> Hash[String, untyped]
+          def backend_response: (Hash[String, untyped] payload) -> Hash[String, untyped]
 
-          def skippable_tests_response: (Hash[untyped, untyped] payload) -> Hash[String, untyped]
+          def skippable_tests_response: (Hash[String, untyped] payload) -> Hash[String, untyped]
         end
       end
     end

--- a/sig/datadog/ci/test_optimization_cache/readers/v1.rbs
+++ b/sig/datadog/ci/test_optimization_cache/readers/v1.rbs
@@ -9,17 +9,17 @@ module Datadog
 
           def available?: () -> bool
 
-          def load_settings: () -> Hash[untyped, untyped]?
+          def load_settings: () -> Hash[String, untyped]?
 
-          def load_known_tests: () -> Hash[untyped, untyped]?
+          def load_known_tests: () -> Hash[String, untyped]?
 
-          def load_test_management: () -> Hash[untyped, untyped]?
+          def load_test_management: () -> Hash[String, untyped]?
 
-          def load_skippable_tests: () -> Hash[untyped, untyped]?
+          def load_skippable_tests: () -> Hash[String, untyped]?
 
           private
 
-          def load_http_json: (String file_name) -> Hash[untyped, untyped]?
+          def load_http_json: (String file_name) -> Hash[String, untyped]?
 
           def settings_file_path: () -> String
 

--- a/sig/datadog/ci/test_tracing/transport.rbs
+++ b/sig/datadog/ci/test_tracing/transport.rbs
@@ -18,7 +18,7 @@ module Datadog
           ?max_payload_size: Integer
         ) -> void
 
-        def send_traces: (Array[Datadog::Tracing::TraceSegment] traces) -> untyped
+        def send_traces: (Array[Datadog::Tracing::TraceSegment] traces) -> Array[Datadog::CI::Transport::Adapters::Net::Response]
 
         private
 

--- a/sig/datadog/ci/transport/api/builder.rbs
+++ b/sig/datadog/ci/transport/api/builder.rbs
@@ -3,8 +3,20 @@ module Datadog
     module Transport
       module Api
         module Builder
-          def self.build_agentless_api: (untyped settings) -> Datadog::CI::Transport::Api::Agentless?
-          def self.build_evp_proxy_api: (untyped agent_settings) -> Datadog::CI::Transport::Api::EvpProxy?
+          interface _CISettings
+            def agentless_url: () -> String?
+          end
+
+          interface _SettingsExtras
+            def api_key: () -> String
+
+            def site: () -> String?
+
+            def ci: () -> _CISettings
+          end
+
+          def self.build_agentless_api: ((::Datadog::Core::Configuration::Settings & _SettingsExtras) settings) -> Datadog::CI::Transport::Api::Agentless?
+          def self.build_evp_proxy_api: ((::Datadog::Core::Configuration::Settings & _SettingsExtras) settings) -> Datadog::CI::Transport::Api::EvpProxy?
         end
       end
     end

--- a/sig/datadog/ci/transport/api/evp_proxy.rbs
+++ b/sig/datadog/ci/transport/api/evp_proxy.rbs
@@ -16,7 +16,7 @@ module Datadog
 
           def api_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::Adapters::Net::Response
 
-          def citestcov_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> untyped
+          def citestcov_request: (path: String, payload: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::Adapters::Net::Response
 
           def cicovreprt_request: (path: String, event_payload: String, compressed_coverage_report: String, ?headers: Hash[String, String], ?verb: ::String) -> Datadog::CI::Transport::Adapters::Net::Response
 

--- a/sig/datadog/ci/utils/file_storage.rbs
+++ b/sig/datadog/ci/utils/file_storage.rbs
@@ -4,9 +4,9 @@ module Datadog
       module FileStorage
         TEMP_DIR: String
 
-        def self.store: (String key, Hash[untyped, untyped] value) -> bool
+        def self.store: (String key, Hash[Symbol, untyped] value) -> bool
 
-        def self.retrieve: (String key) -> Hash[untyped, untyped]?
+        def self.retrieve: (String key) -> Hash[Symbol, untyped]?
 
         def self.cleanup: () -> bool
 

--- a/sig/datadog/ci/utils/json.rbs
+++ b/sig/datadog/ci/utils/json.rbs
@@ -2,7 +2,7 @@ module Datadog
   module CI
     module Utils
       module Json
-        def self.read_file: (String file_path) -> Hash[untyped, untyped]?
+        def self.read_file: (String file_path) -> Hash[String, untyped]?
       end
     end
   end

--- a/sig/datadog/ci/utils/parsing.rbs
+++ b/sig/datadog/ci/utils/parsing.rbs
@@ -2,7 +2,7 @@ module Datadog
   module CI
     module Utils
       module Parsing
-        def self.convert_to_bool: (untyped value) -> bool
+        def self.convert_to_bool: (Object value) -> bool
       end
     end
   end

--- a/sig/datadog/ci/utils/stateful.rbs
+++ b/sig/datadog/ci/utils/stateful.rbs
@@ -14,13 +14,13 @@ module Datadog
 
         def restore_state_from_datadog_test_runner: () -> bool
 
-        def load_cached_settings: () -> Hash[untyped, untyped]?
+        def load_cached_settings: () -> Hash[String, untyped]?
 
-        def load_cached_known_tests: () -> Hash[untyped, untyped]?
+        def load_cached_known_tests: () -> Hash[String, untyped]?
 
-        def load_cached_test_management: () -> Hash[untyped, untyped]?
+        def load_cached_test_management: () -> Hash[String, untyped]?
 
-        def load_cached_skippable_tests: () -> Hash[untyped, untyped]?
+        def load_cached_skippable_tests: () -> Hash[String, untyped]?
 
         def test_optimization_cache: () -> (Datadog::CI::TestOptimizationCache::Component | Datadog::CI::TestOptimizationCache::NullComponent)
       end


### PR DESCRIPTION
## What changed

This PR updates the root development typing/tooling stack and improves the repo's static typing coverage without changing runtime behavior in the Ruby implementation.

- upgrades the root `Gemfile` development typing dependencies (`rbs`, `steep`)
- trims a redundant conversion in `lib/datadog/ci/source_code/static_dependencies_extractor.rb` to stay aligned with the newer tooling
- tightens RBS signatures across contrib integrations, minitest helpers, cache/state utilities, and transport/build helpers
- gives Steep more precise configuration and helper types so more calls type-check concretely instead of flowing through `untyped`

## Why

We migrated onto newer `rbs` and `steep`, and this follow-up makes that migration more useful in practice:

- better typed-call coverage in framework integrations
- stronger settings/config typing in the RBS layer
- fewer `untyped` escape hatches in small but high-traffic helpers

## Impact

Developer-facing only.

- better Steep signal and coverage
- cleaner RBS contracts around contrib configuration and helper APIs
- no intended runtime behavior change beyond the small `standardrb`-driven cleanup in static dependency extraction

## Validation

Passed:
- `bundle exec rake steep:check`
- `env RUBOCOP_CACHE_ROOT=/private/tmp/rubocop_cache_datadog_ci_rb bundle exec standardrb --no-fix`

Not green yet on this branch:
- `bundle exec rake test:main`

`test:main` currently fails with a broad set of existing branch-level failures after the tooling upgrade, including failures under test tracing serializers/transport and a few integration-style specs. Keeping this PR as draft so that state is explicit while we sort those out.