### PR TITLE
Fix Minitest::Spec source location

### DIFF
--- a/lib/datadog/ci/contrib/minitest/helpers.rb
+++ b/lib/datadog/ci/contrib/minitest/helpers.rb
@@ -81,11 +81,14 @@ module Datadog
           end
 
           def self.extract_runnable_source_location(klass, method_name)
-            source_location = extract_source_location_from_class(klass)
-            if source_location.nil? || source_location.empty?
-              return klass.instance_method(method_name).source_location
+            method_source_location = extract_source_location_from_method(klass, method_name)
+            klass_source_location = extract_source_location_from_class(klass)
+
+            if defined?(::Minitest::Spec) && klass&.ancestors&.include?(::Minitest::Spec)
+              method_source_location || klass_source_location
+            else
+              klass_source_location || method_source_location
             end
-            source_location
           end
 
           def self.skip_test_suite(test_suite)
@@ -102,9 +105,21 @@ module Datadog
           end
 
           def self.extract_source_location_from_class(klass)
-            return [] if klass.nil? || klass.name.nil?
+            return nil if klass.nil? || klass.name.nil?
 
-            SourceCode::ConstantResolver.safely_get_const_source_location(klass.name) || []
+            empty_source_location_to_nil(SourceCode::ConstantResolver.safely_get_const_source_location(klass.name))
+          end
+
+          def self.extract_source_location_from_method(klass, method_name)
+            return nil if klass.nil?
+            return nil if method_name.nil? || method_name.empty?
+
+            empty_source_location_to_nil(klass.instance_method(method_name).source_location)
+          end
+
+          def self.empty_source_location_to_nil(source_location)
+            return nil if source_location.nil? || source_location.empty?
+            source_location
           end
         end
       end

--- a/sig/datadog/ci/contrib/minitest/helpers.rbs
+++ b/sig/datadog/ci/contrib/minitest/helpers.rbs
@@ -26,6 +26,8 @@ module Datadog
             def ancestors: () -> Array[Module]
 
             def dd_any_unskippable?: () -> bool
+
+            def nil?: () -> bool
           end
 
           def self.start_test_suite: (_RunnableClass klass) -> Datadog::CI::TestSuite?
@@ -38,9 +40,13 @@ module Datadog
 
           def self.ci_queue?: () -> bool
 
-          def self.extract_source_location_from_class: (untyped klass) -> ([String, Integer] | Array[untyped])
+          def self.extract_source_location_from_class: (untyped? klass) -> ([String, Integer] | Array[untyped])?
 
-          def self.extract_runnable_source_location: (_RunnableClass klass, String method_name) -> ([String, Integer] | Array[untyped])?
+          def self.extract_source_location_from_method: (untyped? klass, String? method_name) -> ([String, Integer] | Array[untyped])?
+
+          def self.empty_source_location_to_nil: (([String, Integer] | Array[untyped])? source_location) -> ([String, Integer] | Array[untyped])?
+
+          def self.extract_runnable_source_location: (untyped? klass, String method_name) -> ([String, Integer] | Array[untyped])?
         end
       end
     end

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -144,6 +144,29 @@ RSpec.describe "Minitest instrumentation" do
       )
     end
 
+    it "traces spec described with a constant from the spec declaration file" do
+      require_relative "helpers/simple_model"
+
+      klass = minitest_describe SimpleModel do
+        it "uses the spec file as source" do
+          assert true
+        end
+      end
+
+      method_name = klass.runnable_methods.first
+      klass.new(method_name).run
+
+      expect(span).to have_test_tag(:name, method_name)
+      expect(span).to have_test_tag(
+        :suite,
+        "SimpleModel at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
+      )
+      expect(span).to have_test_tag(
+        :source_file,
+        "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
+      )
+    end
+
     it "creates spans for several specs" do
       num_specs = 20
 
@@ -496,7 +519,7 @@ RSpec.describe "Minitest instrumentation" do
             :source_file,
             "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
           )
-          expect(first_test_suite_span).to have_test_tag(:source_start, "423")
+          expect(first_test_suite_span).to have_test_tag(:source_start, "446")
           expect(first_test_suite_span).to have_test_tag(
             :codeowners,
             "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
@@ -2013,7 +2036,7 @@ RSpec.describe "Minitest instrumentation" do
       allow(klass).to receive(:instance_method).with(:test_method).and_return(method_double)
 
       # Mock extract_source_location_from_class to return nil (to trigger fallback)
-      allow(Datadog::CI::Contrib::Minitest::Helpers).to receive(:extract_source_location_from_class).with(klass).and_return([])
+      allow(Datadog::CI::Contrib::Minitest::Helpers).to receive(:extract_source_location_from_class).with(klass).and_return(nil)
 
       suite_name = Datadog::CI::Contrib::Minitest::Helpers.test_suite_name(klass, :test_method)
       expect(suite_name).to eq("RelativePathTest at relative/path/to/test.rb")


### PR DESCRIPTION
## Summary

Fix Minitest::Spec suite source resolution when a spec is declared with a constant description, such as `describe SimpleModel`.

For `Minitest::Spec`, the helper now prefers the generated test method source location before falling back to the described class constant source location. This prevents suite names and source attribution from pointing at production files instead of the spec file.

The source-location helpers now normalize empty source locations to `nil`, and the RBS signatures were updated to match the new helper behavior.

Fixes #534.
