### PR TITLE
Add pagination metrics for known tests fetch

### DIFF
--- a/lib/datadog/ci/ext/telemetry.rb
+++ b/lib/datadog/ci/ext/telemetry.rb
@@ -65,6 +65,9 @@ module Datadog
         METRIC_KNOWN_TESTS_REQUEST_ERRORS = "known_tests.request_errors"
         METRIC_KNOWN_TESTS_RESPONSE_BYTES = "known_tests.response_bytes"
         METRIC_KNOWN_TESTS_RESPONSE_TESTS = "known_tests.response_tests"
+        METRIC_KNOWN_TESTS_PAGES_FETCHED = "known_tests.pages_fetched"
+        METRIC_KNOWN_TESTS_TOTAL_FETCH_MS = "known_tests.total_fetch_ms"
+        METRIC_KNOWN_TESTS_TOTAL_REQUEST_MS = "known_tests.total_request_ms"
 
         METRIC_TEST_MANAGEMENT_TESTS_REQUEST = "test_management_tests.request"
         METRIC_TEST_MANAGEMENT_TESTS_REQUEST_MS = "test_management_tests.request_ms"

--- a/lib/datadog/ci/test_tracing/known_tests.rb
+++ b/lib/datadog/ci/test_tracing/known_tests.rb
@@ -122,7 +122,8 @@ module Datadog
             end
 
             # @type var response: Datadog::CI::TestTracing::KnownTests::Response
-            total_request_ms += response.http_response.duration_ms
+            http_response = response.http_response
+            total_request_ms += http_response.duration_ms if http_response
 
             page_tests = response.tests
             result.merge(page_tests)
@@ -137,7 +138,7 @@ module Datadog
             page_number += 1
           end
 
-          fetch_duration_ms = (Core::Utils::Time.get_time - fetch_start_time).to_f * 1000.0
+          fetch_duration_ms = (Core::Utils::Time.get_time - fetch_start_time) * 1000.0
 
           Datadog.logger.debug { "Finished fetching known tests: #{result.size} tests total from #{page_number} page(s)" }
 

--- a/lib/datadog/ci/test_tracing/known_tests.rb
+++ b/lib/datadog/ci/test_tracing/known_tests.rb
@@ -102,7 +102,7 @@ module Datadog
           page_state = nil
           page_number = 1
 
-          fetch_start_time = Core::Utils::Time.get_time
+          fetch_start_time = Core::Utils::Time.get_time(:float_millisecond)
 
           loop do
             Datadog.logger.debug { "Fetching known tests page ##{page_number}#{" with cursor" if page_state}" }
@@ -138,7 +138,8 @@ module Datadog
             page_number += 1
           end
 
-          fetch_duration_ms = (Core::Utils::Time.get_time - fetch_start_time) * 1000.0
+          fetch_duration_ms = Core::Utils::Time.get_time(:float_millisecond) - fetch_start_time
+          # @type var fetch_duration_ms: Float
 
           Datadog.logger.debug { "Finished fetching known tests: #{result.size} tests total from #{page_number} page(s)" }
 

--- a/lib/datadog/ci/test_tracing/known_tests.rb
+++ b/lib/datadog/ci/test_tracing/known_tests.rb
@@ -2,6 +2,8 @@
 
 require "json"
 
+require "datadog/core/utils/time"
+
 require_relative "../ext/telemetry"
 require_relative "../ext/transport"
 require_relative "../transport/telemetry"
@@ -14,6 +16,8 @@ module Datadog
       # fetches and stores a list of known tests from the backend
       class KnownTests
         class Response
+          attr_reader :http_response
+
           def self.from_http_response(http_response)
             new(http_response, nil)
           end
@@ -94,8 +98,11 @@ module Datadog
           return Set.new unless api
 
           result = Set.new
+          total_request_ms = 0.0
           page_state = nil
           page_number = 1
+
+          fetch_start_time = Core::Utils::Time.get_time
 
           loop do
             Datadog.logger.debug { "Fetching known tests page ##{page_number}#{" with cursor" if page_state}" }
@@ -114,6 +121,9 @@ module Datadog
               return Set.new
             end
 
+            # @type var response: Datadog::CI::TestTracing::KnownTests::Response
+            total_request_ms += response.http_response.duration_ms
+
             page_tests = response.tests
             result.merge(page_tests)
             Datadog.logger.debug { "Received #{page_tests.size} known tests from page ##{page_number} (total so far: #{result.size})" }
@@ -127,7 +137,15 @@ module Datadog
             page_number += 1
           end
 
+          fetch_duration_ms = (Core::Utils::Time.get_time - fetch_start_time).to_f * 1000.0
+
           Datadog.logger.debug { "Finished fetching known tests: #{result.size} tests total from #{page_number} page(s)" }
+
+          # Emit pagination aggregate metrics
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_KNOWN_TESTS_PAGES_FETCHED, page_number.to_f)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_KNOWN_TESTS_TOTAL_FETCH_MS, fetch_duration_ms)
+          Utils::Telemetry.distribution(Ext::Telemetry::METRIC_KNOWN_TESTS_TOTAL_REQUEST_MS, total_request_ms)
+
           result
         end
 

--- a/sig/datadog/ci/ext/telemetry.rbs
+++ b/sig/datadog/ci/ext/telemetry.rbs
@@ -82,6 +82,12 @@ module Datadog
 
         METRIC_KNOWN_TESTS_RESPONSE_TESTS: "known_tests.response_tests"
 
+        METRIC_KNOWN_TESTS_PAGES_FETCHED: "known_tests.pages_fetched"
+
+        METRIC_KNOWN_TESTS_TOTAL_FETCH_MS: "known_tests.total_fetch_ms"
+
+        METRIC_KNOWN_TESTS_TOTAL_REQUEST_MS: "known_tests.total_request_ms"
+
         METRIC_TEST_MANAGEMENT_TESTS_REQUEST: "test_management_tests.request"
         METRIC_TEST_MANAGEMENT_TESTS_REQUEST_MS: "test_management_tests.request_ms"
         METRIC_TEST_MANAGEMENT_TESTS_REQUEST_ERRORS: "test_management_tests.request_errors"

--- a/sig/datadog/ci/test_tracing/known_tests.rbs
+++ b/sig/datadog/ci/test_tracing/known_tests.rbs
@@ -10,6 +10,8 @@ module Datadog
           @http_response: Datadog::CI::Transport::Adapters::Net::Response?
           @json: Hash[String, untyped]?
 
+          attr_reader http_response: Datadog::CI::Transport::Adapters::Net::Response?
+
           def self.from_http_response: (Datadog::CI::Transport::Adapters::Net::Response http_response) -> Response
 
           def self.from_json: (Hash[String, untyped] json) -> Response

--- a/spec/datadog/ci/test_tracing/known_tests_spec.rb
+++ b/spec/datadog/ci/test_tracing/known_tests_spec.rb
@@ -319,12 +319,18 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_fetch_ms"
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_request_ms"
 
-          it "emits pages_fetched metric with correct count" do
+          it "emits aggregate pagination metrics with correct values" do
+            allow(Datadog::Core::Utils::Time).to receive(:get_time).and_call_original
+            allow(Datadog::Core::Utils::Time)
+              .to receive(:get_time)
+              .with(:float_millisecond)
+              .and_return(100.0, 125.0)
+
             response
 
-            metric = telemetry_metric(:distribution, "known_tests.pages_fetched")
-            expect(metric).not_to be_nil
-            expect(metric.value).to eq(2.0)
+            expect(telemetry_metric(:distribution, "known_tests.pages_fetched").value).to eq(2.0)
+            expect(telemetry_metric(:distribution, "known_tests.total_fetch_ms").value).to eq(25.0)
+            expect(telemetry_metric(:distribution, "known_tests.total_request_ms").value).to eq(2.0)
           end
         end
 

--- a/spec/datadog/ci/test_tracing/known_tests_spec.rb
+++ b/spec/datadog/ci/test_tracing/known_tests_spec.rb
@@ -14,6 +14,23 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
   describe "#fetch" do
     subject { client.fetch(test_session) }
 
+    # Default http_response stub for tests that call fetch but don't care about response content
+    let(:default_http_response) do
+      double(
+        "http_response",
+        ok?: true,
+        payload: {data: {attributes: {tests: {}}}}.to_json,
+        request_compressed: false,
+        duration_ms: 0.0,
+        gzipped_content?: false,
+        response_size: 0
+      )
+    end
+
+    before do
+      allow(api).to receive(:api_request).and_return(default_http_response)
+    end
+
     let(:service) { "service" }
     let(:tracer_span) do
       Datadog::Tracing::SpanOperation.new("session", service: service).tap do |span|
@@ -112,6 +129,9 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
           it_behaves_like "emits telemetry metric", :inc, "known_tests.request", 1
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.request_ms"
           it_behaves_like "emits telemetry metric", :distribution, "known_tests.response_bytes"
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.pages_fetched"
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_fetch_ms"
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_request_ms"
         end
 
         context "when response is not OK" do
@@ -294,6 +314,18 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
             second_payload = JSON.parse(requests[1][:payload])
             expect(second_payload["data"]["attributes"]["page_info"]["page_state"]).to eq("next_page_cursor")
           end
+
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.pages_fetched"
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_fetch_ms"
+          it_behaves_like "emits telemetry metric", :distribution, "known_tests.total_request_ms"
+
+          it "emits pages_fetched metric with correct count" do
+            response
+
+            metric = telemetry_metric(:distribution, "known_tests.pages_fetched")
+            expect(metric).not_to be_nil
+            expect(metric.value).to eq(2.0)
+          end
         end
 
         context "when a subsequent page request fails" do
@@ -356,6 +388,14 @@ RSpec.describe Datadog::CI::TestTracing::KnownTests do
 
             expect(test_session.get_tag(Datadog::CI::Ext::Test::LibraryConfigurationError::TAG_KNOWN_TESTS))
               .to eq("true")
+          end
+
+          it "does not emit aggregate pagination metrics on failure" do
+            response
+
+            expect(received_telemetry_metric?(:distribution, "known_tests.pages_fetched")).to be false
+            expect(received_telemetry_metric?(:distribution, "known_tests.total_fetch_ms")).to be false
+            expect(received_telemetry_metric?(:distribution, "known_tests.total_request_ms")).to be false
           end
         end
       end


### PR DESCRIPTION
## What does this PR do?

Adds three new distribution metrics to track known tests (Early Flake Detection) pagination behavior:

- `known_tests.pages_fetched` - Number of pages fetched during pagination
- `known_tests.total_fetch_ms` - Wall-clock time from first to last page request
- `known_tests.total_request_ms` - Sum of individual per-page request durations

## Motivation

Currently, only per-request timing is tracked via `known_tests.request_ms`. These new metrics provide observability into:
- How often pagination occurs (single vs multi-page responses)
- Backend pagination performance (total wall-clock time)
- Network overhead vs local processing time (total_fetch_ms vs total_request_ms)

## Implementation Details

- Metrics are emitted **only on successful completion** after all pages are fetched
- If fetch fails midway (network error, invalid response), metrics are not emitted
- Per-request metrics remain unchanged (backward compatible)

## Testing

- Added unit tests for single-page, multi-page, and failure scenarios
- All existing tests pass (33 tests total)

## Checklist

- [x] Tests added and passing
- [x] Code formatted (standardrb)
- [x] Backward compatible (no breaking changes)
- [x] Follows existing telemetry patterns