### PR TITLE
internal: Fix peek duration specs against unmocked clock

### DIFF
--- a/spec/datadog/ci/test_spec.rb
+++ b/spec/datadog/ci/test_spec.rb
@@ -957,7 +957,7 @@ RSpec.describe Datadog::CI::Test do
         next if test.tracer_span.finished?
         test.finish
       end
-      allow(Time).to receive(:now).and_call_original
+      allow(Datadog::Core::Utils::Time).to receive(:now).and_call_original
     end
 
     def start_peek_duration_test
@@ -968,7 +968,7 @@ RSpec.describe Datadog::CI::Test do
     end
 
     def stub_time_now(*values)
-      allow(Time).to receive(:now).and_return(*values)
+      allow(Datadog::Core::Utils::Time).to receive(:now).and_return(*values)
     end
 
     context "while the test is running" do


### PR DESCRIPTION
## Failure

The `Unit Tests` workflow fails on current `main` commit `be4794851ce9302d72fe01f515aed585fa2e909c` in every supported Ruby job (2.7 through 4.0). The three `Datadog::CI::Test#peek_duration` examples expect mocked elapsed times but observe real sub-millisecond durations instead.

## Root cause

`Datadog::CI::Test#peek_duration` reads `Datadog::Core::Utils::Time.now`. Current `dd-trace-rb` master binds that method to the original wall clock so later `Time.now` monkey-patches do not affect Datadog timing. The specs stub `Time.now`, so their fake clock no longer reaches the implementation.

## Fix

Stub `Datadog::Core::Utils::Time.now`, the clock abstraction used by `peek_duration`, and restore that same method during cleanup. Production behavior is unchanged, and no RBS update is needed for this test-only correction.

## Validation

- `bundle exec rspec spec/datadog/ci/test_spec.rb` — 75 examples, 0 failures
- `bundle exec standardrb` — 501 files inspected, no offenses
- `bundle exec rake steep:check` — no type errors