### PR TITLE
fix: Avoid killing commands after output closes

### DIFF
--- a/lib/datadog/ci/utils/command.rb
+++ b/lib/datadog/ci/utils/command.rb
@@ -50,11 +50,12 @@ module Datadog
               end
             end
 
-            if (Core::Utils::Time.get_time - start) > timeout
-              timeout_reached = true
-            end
+            remaining_time = timeout.to_f - (Core::Utils::Time.get_time - start)
+            thread.join(remaining_time) if thread.alive? && remaining_time.positive?
 
             if thread.alive?
+              timeout_reached = true
+
               begin
                 Process.kill("TERM", pid)
               rescue

--- a/spec/datadog/ci/utils/command_spec.rb
+++ b/spec/datadog/ci/utils/command_spec.rb
@@ -131,6 +131,21 @@ RSpec.describe Datadog::CI::Utils::Command do
       end
     end
 
+    context "when command closes its output before exiting" do
+      subject(:result) do
+        described_class.exec_command(
+          [RbConfig.ruby, "-e", "STDOUT.reopen(File::NULL); STDERR.reopen(File::NULL); sleep 0.1"],
+          timeout: 1
+        )
+      end
+
+      it "waits for the command to exit successfully" do
+        output, status = result
+        expect(output).to be_empty
+        expect(status).to be_success
+      end
+    end
+
     context "when attempting shell injection" do
       it "treats shell metacharacters as literal arguments, not shell commands" do
         # Try to inject a command that would create a file if shell injection worked


### PR DESCRIPTION
## Summary

- wait for a command to exit for the remainder of its configured timeout after its output stream reaches EOF
- send `TERM` only when the command is still alive after that deadline
- add a regression test for a command that closes stdout/stderr shortly before a successful exit

## CI failure and root cause

Scheduled Unit Tests run [31344355202](https://github.com/DataDog/datadog-ci-rb/actions/runs/31344355202) failed on main commit `2f8f3c2f69603ee6fe664487bc5e288c9edb348a`.

The Ruby 4.0 main job failed in `Command.exec_command`'s shell-injection test because the successful `echo` child received `SIGTERM`. After the output pipe reached EOF, `exec_command` checked the process waiter immediately and could terminate the child during the short race before the waiter recorded its normal exit.

The same workflow also had an unrelated infrastructure failure: the Ruby 2.7/Cucumber 7 job's JUnit and coverage artifact uploads both failed with `ETIMEDOUT`. No repository change is needed for that upload failure. Both affected jobs passed in the next two scheduled runs on the same SHA.

## Validation

- `bundle exec rspec spec/datadog/ci/utils/command_spec.rb` (22 examples, 0 failures)
- `bundle exec standardrb` (503 files, no offenses)
- `bundle exec rake steep:check` (no type errors)
