### PR TITLE
fix: Support SimpleCov 1.1 result extraction

### DIFF
--- a/gemfiles/ruby_3.2_simplecov_1.gemfile.lock
+++ b/gemfiles/ruby_3.2_simplecov_1.gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (1.0.3)
+    simplecov (1.1.0)
     thor (1.5.0)
     tsort (0.2.0)
     webmock (3.26.2)

--- a/gemfiles/ruby_3.3_simplecov_1.gemfile.lock
+++ b/gemfiles/ruby_3.3_simplecov_1.gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (1.0.3)
+    simplecov (1.1.0)
     thor (1.5.0)
     tsort (0.2.0)
     webmock (3.26.2)

--- a/gemfiles/ruby_3.4_simplecov_1.gemfile.lock
+++ b/gemfiles/ruby_3.4_simplecov_1.gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (1.0.3)
+    simplecov (1.1.0)
     thor (1.5.0)
     tsort (0.2.0)
     webmock (3.26.2)
@@ -212,7 +212,7 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rspec_junit_formatter (0.6.0) sha256=40dde674e6ae4e6cc0ff560da25497677e34fefd2338cc467a8972f602b62b15
-  simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
+  simplecov (1.1.0) sha256=30f12f31a659c377ef402d5463a50eaf9037035fe1fac3d263cb389682cae1b4
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90

--- a/gemfiles/ruby_4.0_simplecov_1.gemfile.lock
+++ b/gemfiles/ruby_4.0_simplecov_1.gemfile.lock
@@ -114,7 +114,7 @@ GEM
     rspec-support (3.13.7)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    simplecov (1.0.3)
+    simplecov (1.1.0)
     thor (1.5.0)
     tsort (0.2.0)
     webmock (3.26.2)
@@ -212,7 +212,7 @@ CHECKSUMS
   rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
   rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
   rspec_junit_formatter (0.6.0) sha256=40dde674e6ae4e6cc0ff560da25497677e34fefd2338cc467a8972f602b62b15
-  simplecov (1.0.3) sha256=38ef0514f16ae7562f0d0f4df02610071115103d301b6de7dacbcc000082e39b
+  simplecov (1.1.0) sha256=30f12f31a659c377ef402d5463a50eaf9037035fe1fac3d263cb389682cae1b4
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90

--- a/lib/datadog/ci/contrib/simplecov/result_extractor.rb
+++ b/lib/datadog/ci/contrib/simplecov/result_extractor.rb
@@ -22,14 +22,26 @@ module Datadog
                 ::SimpleCov::ResultAdapter.call(::Coverage.peek_result)
               )
 
-              # SimpleCov 1.0 changed add_not_loaded_files to return a
-              # [coverage, not_loaded_files] tuple instead of a coverage hash.
-              processed = add_not_loaded_files(result)
-              if processed.is_a?(::Array)
-                coverage, not_loaded_files = processed
-                ::SimpleCov::Result.new(coverage, not_loaded_files: not_loaded_files)
+              if respond_to?(:add_not_loaded_files, true)
+                # SimpleCov 1.0 changed add_not_loaded_files to return a
+                # [coverage, not_loaded_files] tuple instead of a coverage hash.
+                processed = add_not_loaded_files(result)
+                if processed.is_a?(::Array)
+                  coverage, not_loaded_files = processed
+                  ::SimpleCov::Result.new(coverage, not_loaded_files: not_loaded_files)
+                else
+                  ::SimpleCov::Result.new(processed)
+                end
               else
-                ::SimpleCov::Result.new(processed)
+                # SimpleCov 1.1 replaced add_not_loaded_files with these result
+                # processing APIs and records the tracked paths on the result.
+                tracked_files = tracked_file_paths - result.keys
+                coverage, not_loaded_files = inject_unloaded_files(result, tracked_files)
+                ::SimpleCov::Result.new(
+                  coverage,
+                  not_loaded_files: not_loaded_files,
+                  tracked_files: tracked_files
+                )
               end
             end
 

--- a/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
+++ b/sig/datadog/ci/contrib/simplecov/result_extractor.rbs
@@ -31,6 +31,10 @@ module Datadog
             def datadog_configuration: () -> Datadog::CI::Contrib::Simplecov::Configuration::Settings
 
             def add_not_loaded_files: (untyped result) -> untyped
+
+            def tracked_file_paths: () -> untyped
+
+            def inject_unloaded_files: (untyped result, untyped candidate_paths) -> [untyped, untyped]
           end
         end
       end

--- a/spec/datadog/ci/contrib/simplecov/result_extractor_spec.rb
+++ b/spec/datadog/ci/contrib/simplecov/result_extractor_spec.rb
@@ -3,6 +3,46 @@
 require_relative "../../../../../lib/datadog/ci/contrib/simplecov/result_extractor"
 
 RSpec.describe Datadog::CI::Contrib::Simplecov::ResultExtractor do
+  describe "with SimpleCov 1.1 result processing APIs" do
+    let(:base_class) do
+      Class.new do
+        class << self
+          def tracked_file_paths
+            Set.new(["loaded.rb", "not_loaded.rb"])
+          end
+
+          def inject_unloaded_files(result, tracked_files)
+            [result.merge("not_loaded.rb" => {"lines" => [0]}), tracked_files]
+          end
+        end
+      end
+    end
+    let(:simplecov_config) { {enabled: true} }
+    let(:coverage) { {"loaded.rb" => {"lines" => [1]}} }
+    let(:not_loaded_files) { Set.new(["not_loaded.rb"]) }
+    let(:result_class) { class_double(SimpleCov::Result, new: simplecov_result) }
+    let(:simplecov_result) { instance_double(SimpleCov::Result) }
+
+    before do
+      base_class.include(described_class)
+      allow(Datadog.configuration).to receive(:ci).and_return(double(:ci, :[] => simplecov_config))
+      allow(Coverage).to receive(:peek_result).and_return(coverage)
+      allow(SimpleCov::UselessResultsRemover).to receive(:call).and_return(coverage)
+      allow(SimpleCov::ResultAdapter).to receive(:call).and_return(coverage)
+      stub_const("SimpleCov::Result", result_class)
+    end
+
+    it "builds a result with coverage for configured files that were not loaded" do
+      expect(base_class.__dd_peek_result).to be(simplecov_result)
+
+      expect(result_class).to have_received(:new).with(
+        coverage.merge("not_loaded.rb" => {"lines" => [0]}),
+        not_loaded_files: not_loaded_files,
+        tracked_files: not_loaded_files
+      )
+    end
+  end
+
   describe ".included" do
     before do
       SimpleCov.include(described_class)


### PR DESCRIPTION
## Failure

Scheduled Unit Tests runs 31445846366, 31458734426, and 31472963803 failed on main after dependency resolution began installing SimpleCov 1.1.0. Each failing job raised NoMethodError for add_not_loaded_files from the result extractor, cascading into 46 failures in the main suite.

## Root cause

SimpleCov 1.1 removed add_not_loaded_files and replaced it with tracked_file_paths plus inject_unloaded_files. The integration called the removed private API directly.

## Fix

- Feature-detect the legacy API so SimpleCov 0.x and 1.0 keep their existing paths.
- Use the SimpleCov 1.1 processing APIs and preserve tracked and not-loaded file metadata.
- Add a regression example and update the SimpleCov 1 appraisal locks to 1.1.0.
- Extend the RBS surface for the replacement APIs.

## Validation

- Ruby 4.0 / SimpleCov 1.1 focused extractor spec: 5 examples, 0 failures
- Ruby 4.0 / SimpleCov 1.1 integration suite: 22 examples, 0 failures
- Ruby 4.0 / SimpleCov 1.1 main suite: passed
- StandardRB: 503 files, no offenses
- Steep: no type errors