### PR TITLE
perf: reduce native TIA coverage overhead

### DIFF
--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -238,3 +238,44 @@ The complete RuboCop coverage benchmark improved from 58.61% to 48.17% overhead,
 ### Next step
 
 Stop the optimization loop at the requested threshold. Run final native coverage validation, commit the code and journal, and open the tracer pull request.
+
+## Iteration 6: accepted
+
+- Timestamp: 2026-08-12T09:30:37+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 8c47aa22049ac6c901b466a8c54791004e8a87d9
+- Dirty: yes
+
+### Hypothesis
+
+A discarded instruction sequence can release its source-path storage, allowing Ruby to reuse the raw address for a different file and causing the line-event pointer cache to omit valid per-test coverage.
+
+### Change
+
+Replace raw filename-pointer cache entries with 1,024 GC-marked Ruby path values while retaining direct-mapped pointer comparisons and add a regression test that forces instruction-sequence source reuse.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 45 ++++++++++++++++++++++++-------------
+ spec/ddcov/ddcov_spec.rb            | 39 ++++++++++++++++++++++++++++++++
+ 2 files changed, 69 insertions(+), 15 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 38 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **regressed — accepted for correctness**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-195316.520076000-ruby-rubocop-coverage-p78776-3ba9efbeb9382adc/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-105839.951667000-ruby-rubocop-coverage-p15766-a53e211a985957d6/result.json`
+
+### Findings
+
+The correctness regression reproduced twice before the fix, recording only 873 and 937 of 2,000 included files. It passes after the cache owns the paths. The four-pair candidate benchmark succeeded at 53.46% overhead, versus 48.17% in the earlier one-pair run. Although the mismatched protocols prevent a deterministic comparison, the observed 5.29 percentage-point increase is conservatively recorded and accepted as a performance regression in exchange for complete coverage.
+
+### Next step
+
+Address the next PR review comment independently. Retain this accepted correctness fix and use matching benchmark protocols for any later performance comparison.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -1,0 +1,53 @@
+# Tracer performance optimization journal
+
+- Tracer: datadog-ci-rb
+- Goal: Reduce full-suite RuboCop TIA coverage overhead from 77.87% to below 50% while keeping the functional gate and Ruby regression guards green
+- Created: 2026-08-11T15:39:31+00:00
+
+This journal is append-only. Record every accepted, rejected, and inconclusive iteration.
+
+## Iteration 1: accepted
+
+- Timestamp: 2026-08-11T16:06:21+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 34253b65060ce392f683f6ee5705ef7919bf8980
+- Dirty: yes
+
+### Hypothesis
+
+RuboCop repeatedly alternates among files within an example, while DDCov only suppresses consecutive events from the same source file; caching every source-file pointer seen by the current test will avoid redundant frame and path processing without changing the coverage set.
+
+### Change
+
+Replace DDCov's last-filename pointer with a per-test native set of observed filename pointers and clear it when coverage stops.
+
+```text
+.../ruby-datadog-ci-rubocop-coverage.md            |  7 +++++++
+ ext/datadog_ci_native/datadog_cov.c                | 24 ++++++++++++++--------
+ 2 files changed, 23 insertions(+), 8 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 37 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **improved**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-165044.786436000-ruby-rubocop-coverage-p46106-6bdb2e7f129973c0/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-174937.180428000-ruby-rubocop-coverage-p85160-737569f8b81f24a9/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-174937.180428000-ruby-rubocop-coverage-p85160-737569f8b81f24a9/comparison.json`
+
+### Profiles
+
+- pf2: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-174937.180428000-ruby-rubocop-coverage-p85160-737569f8b81f24a9/profiles/pf2` — on_line_event fell from 5.22% to 4.44% inclusive and the VM trace path fell from 12.23% to 10.87%; allocation finalization is now the largest direct DDCov hotspot at 5.71%.
+
+### Findings
+
+The green candidate reduced overhead from 77.87% to 72.79%, a 5.08 percentage-point improvement. The deterministic multiplier verdict is improved (-2.86%). Avoiding repeated per-file processing helps, but the VM still invokes the line hook for every executed line, and allocation finalization remains expensive.
+
+### Next step
+
+Cache allocation-tracing class-to-source resolution across tests so repeated classes and ancestor chains do not call const_source_location at every DDCov#stop. Run non-coverage regression guards before final acceptance once the under-50% target is reached.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -51,3 +51,48 @@ The green candidate reduced overhead from 77.87% to 72.79%, a 5.08 percentage-po
 ### Next step
 
 Cache allocation-tracing class-to-source resolution across tests so repeated classes and ancestor chains do not call const_source_location at every DDCov#stop. Run non-coverage regression guards before final acceptance once the under-50% target is reached.
+
+## Iteration 2: accepted
+
+- Timestamp: 2026-08-11T16:25:03+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: ea1b5d6f207444298f3093069b5450d5df2a9d5e
+- Dirty: yes
+
+### Hypothesis
+
+Allocation tracing repeatedly resolves the same allocated classes and ancestor constant locations at the end of thousands of tests; caching each class's in-project ancestor files for the collector lifetime will eliminate this repeated DDCov#stop work without mixing per-test coverage.
+
+### Change
+
+Add a GC-safe native class-to-files cache while retaining the existing per-test allocated-class table; cached files are copied into only the current test's impacted-files set.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 57 ++++++++++++++++++++++++++-----------
+ 1 file changed, 41 insertions(+), 16 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 37 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **improved**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-174937.180428000-ruby-rubocop-coverage-p85160-737569f8b81f24a9/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-180824.256267000-ruby-rubocop-coverage-p3881-8d7ee266ef7818d5/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-180824.256267000-ruby-rubocop-coverage-p3881-8d7ee266ef7818d5/comparison.json`
+
+### Profiles
+
+- pf2: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-180824.256267000-ruby-rubocop-coverage-p3881-8d7ee266ef7818d5/profiles/pf2` — DDCov#stop, each_instantiated_klass, and dd_ci_resolve_const_to_file fell out of the focused top frames; vm_trace is now the dominant coverage path at 10.99%, with on_line_event at 4.66%.
+
+### Findings
+
+The candidate reduced overhead from 72.79% to 66.17%, a 6.62 percentage-point improvement. The deterministic multiplier verdict is improved (-3.83%), and the profile confirms the intended allocation-finalization work was removed rather than shifted.
+
+### Next step
+
+Reduce the per-line VM event-hook cost while preserving coverage for method, block, class-body, and dynamically loaded top-level code. Run non-coverage regression guards before final acceptance once overhead is below 50%.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -279,3 +279,44 @@ The correctness regression reproduced twice before the fix, recording only 873 a
 ### Next step
 
 Address the next PR review comment independently. Retain this accepted correctness fix and use matching benchmark protocols for any later performance comparison.
+
+## Iteration 7: accepted
+
+- Timestamp: 2026-08-12T11:02:17+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 40e162e6235a99c784b42f01d904709ebcc599cf
+- Dirty: yes
+
+### Hypothesis
+
+Bounding the persistent class-to-files cache at 100,000 entries and expanding the per-test allocated-class fast cache to 4,096 entries will cap retention without measurably regressing RuboCop TIA coverage performance.
+
+### Change
+
+Start a fresh persistent class-files cache generation when it reaches 100,000 entries, increase the direct-mapped per-test allocated-class cache from 256 to 4,096 entries, and enforce the power-of-two direct-cache sizes at compile time.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 38 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **inconclusive**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-105839.951667000-ruby-rubocop-coverage-p15766-a53e211a985957d6/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-123239.641076000-ruby-rubocop-coverage-p54943-e89cd3172a754b09/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-123239.641076000-ruby-rubocop-coverage-p54943-e89cd3172a754b09/comparison.json`
+
+### Findings
+
+The candidate measured 53.99% overhead versus 53.46% for the matching four-pair reference, a raw increase of 0.53 percentage points. The paired overhead-multiplier change was -0.05%, with a 95% interval from -2.05% to 2.25%; the comparator found no practical regression and returned inconclusive because the interval narrowly overlaps the 2% thresholds.
+
+### Next step
+
+Retain the bounded caches and address or resolve the remaining PR review threads; no additional unchanged benchmark run is warranted for this near-zero observed multiplier change.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -320,3 +320,54 @@ The candidate measured 53.99% overhead versus 53.46% for the matching four-pair 
 ### Next step
 
 Retain the bounded caches and address or resolve the remaining PR review threads; no additional unchanged benchmark run is warranted for this near-zero observed multiplier change.
+
+## Iteration 8: accepted
+
+- Timestamp: 2026-08-12T11:57:40+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 066794fc60a2f98bf4b5ede549ad4a0ff75c6603
+- Dirty: yes
+
+### Hypothesis
+
+The optimized native coverage collector remains correct across direct-cache collisions, GC compaction, many threads, malformed inputs, and directory-prefix edge cases without a practical RuboCop TIA performance regression.
+
+### Change
+
+Add adversarial DDCov coverage for filename and allocated-class cache overflow, GC compaction, threaded dynamic sources, class redefinition, malformed native arguments, and textual path-prefix collisions; validate native inputs and require path-component boundaries in native and Ruby filters.
+
+```text
+ext/datadog_ci_native/datadog_common.c          |  23 ++-
+ ext/datadog_ci_native/datadog_common.h          |   7 +-
+ ext/datadog_ci_native/datadog_cov.c             |  20 ++-
+ lib/datadog/ci/source_code/path_filter.rb       |  16 +-
+ spec/datadog/ci/source_code/path_filter_spec.rb |  11 +-
+ spec/ddcov/ddcov_spec.rb                        | 214 +++++++++++++++++++++++-
+ 6 files changed, 268 insertions(+), 23 deletions(-)
+```
+
+### Functional tests
+
+- DDCov and path-filter specs: **passed** — Ruby 3.3.5; 64 examples, 0 failures; modified Ruby files also pass StandardRB
+- Ruby 2.7 native compilation: **passed** — Native extension compiled successfully with Ruby 2.7.8
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **inconclusive**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-123239.641076000-ruby-rubocop-coverage-p54943-e89cd3172a754b09/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-132730.043102000-ruby-rubocop-coverage-p88309-68fad3f3da00bffb/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260812-132730.043102000-ruby-rubocop-coverage-p88309-68fad3f3da00bffb/comparison.json`
+
+### Findings
+
+The stress suite exposed two real supported-use defects: malformed native path arguments could crash Ruby, and textual prefix matching treated sibling directories as descendants. The four-pair candidate measured 55.16% raw overhead versus 53.99%, but the paired overhead-multiplier estimate improved by 0.80%; its 95% interval (-4.08% to +2.49%) overlaps the 2% practical thresholds, so no practical regression was detected.
+
+### Next step
+
+Retain the correctness hardening and adversarial regressions; no unchanged benchmark rerun is warranted for an inconclusive result whose point estimate improved and whose raw change is below the practical threshold.
+
+### Validation addendum
+
+The complete Ruby 3.3.5 `spec:main` suite passed outside the filesystem sandbox: 2,320 examples, 0 failures, and 1 expected Linux-only pending example. An initial sandboxed attempt failed because DRb Unix sockets and the configured Git signing agent were unavailable; rerunning the unchanged suite with those required capabilities confirmed the failures were environmental.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -192,3 +192,49 @@ The coverage benchmark improved from 66.17% to 58.61% overhead, a 7.56 percentag
 ### Next step
 
 Continue from the 58.61% reference. Investigate the remaining VM event-hook overhead and the large Pf2 unknown/native sample share without weakening exact per-test coverage semantics.
+
+## Iteration 5: accepted
+
+- Timestamp: 2026-08-11T18:20:34+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 6f8688c44527ef9a919cff275e0c7a3488def126
+- Dirty: yes
+
+### Hypothesis
+
+Allocation tracing repeats class-name resolution and hash insertion for every object allocation even after that class has already been recorded for the current test; a native fast-path cache for previously recorded classes will remove this per-object bookkeeping without changing the per-test class set.
+
+### Change
+
+Add consecutive-class and 256-entry direct-mapped caches ahead of allocation class-name resolution and st_table insertion. The authoritative per-test class table remains unchanged; cache collisions fall back to it, and only named classes retained by that table enter the pointer cache.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 37 +++++++++++++++++++++++++++++++++++--
+ 1 file changed, 35 insertions(+), 2 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 36 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+- Ruby non-coverage guards: **passed** — The immediately preceding accepted base passed full ruby-rubocop and ruby-quotes-rails guards. This iteration changes only on_newobj_event, which is registered solely when TIA allocation tracing is enabled, so ordinary tracing cannot execute the new path.
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **improved**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-183814.534638000-ruby-rubocop-coverage-p30210-f0522b4f9b41fcbf/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-195316.520076000-ruby-rubocop-coverage-p78776-3ba9efbeb9382adc/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-195316.520076000-ruby-rubocop-coverage-p78776-3ba9efbeb9382adc/comparison.md`
+
+### Profiles
+
+- pf2: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-195316.520076000-ruby-rubocop-coverage-p78776-3ba9efbeb9382adc/profiles/pf2` — The VM trace path fell from 8.36% to 6.47% inclusive and on_line_event fell from 1.86% to 1.36%. Pf2 does not name on_newobj_event directly, but the reduced native VM-hook share and wall time support the allocation fast-path hypothesis.
+
+### Findings
+
+The complete RuboCop coverage benchmark improved from 58.61% to 48.17% overhead, a 10.44 percentage-point reduction and a deterministic 6.58% multiplier improvement. Baseline and instrumented command durations were 113.91s and 168.77s; a host-level delay between phases occurred outside those measured durations. The functional gate remained green, and the requested under-50% goal is met.
+
+### Next step
+
+Stop the optimization loop at the requested threshold. Run final native coverage validation, commit the code and journal, and open the tracer pull request.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -137,3 +137,58 @@ RuboCop executes Ruby method and block entry events far more often than it alter
 ### Next step
 
 Keep line events and optimize the hot early-return path itself, especially avoiding TypedData extraction and general st_table lookup on every event.
+
+## Iteration 4: accepted
+
+- Timestamp: 2026-08-11T17:49:24+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: 713b5ff5ae7e82c7662d2af6ba58eaf24d8ff2bc
+- Dirty: yes
+
+### Hypothesis
+
+The general st_table membership lookup and typed-data extraction on every Ruby line dominate the remaining on_line_event callback cost; a direct-mapped pointer cache with a consecutive-file fast path will preserve exact coverage while making the common return path constant and allocation-free.
+
+### Change
+
+Replace the per-test st_table of filename pointers with a 256-entry direct-mapped native pointer cache plus a last-filename fast path, and access the callback's already-validated typed data directly. Cache collisions only repeat path processing and cannot omit coverage.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 42 +++++++++++++++++++++++--------------
+ 1 file changed, 26 insertions(+), 16 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 37 examples, 0 failures
+- ruby-rubocop-coverage Crook gate: **passed** — All 37 assertions passed for the complete upstream RuboCop suite
+- ruby-rubocop Crook guard: **passed** — All 36 assertions passed; four-pair benchmark comparison was inconclusive, not regressed
+- ruby-quotes-rails Crook guard: **passed** — All 36 assertions passed; ten-pair benchmark comparison was inconclusive, not regressed
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **improved**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-180824.256267000-ruby-rubocop-coverage-p3881-8d7ee266ef7818d5/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-183814.534638000-ruby-rubocop-coverage-p30210-f0522b4f9b41fcbf/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-183814.534638000-ruby-rubocop-coverage-p30210-f0522b4f9b41fcbf/comparison.json`
+- ruby-rubocop: **inconclusive**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-153739.599524000-ruby-rubocop-p94073-b56b30d9515ed557/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-185308.307027000-ruby-rubocop-p45653-5fb815bc8f93f8b3/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-185308.307027000-ruby-rubocop-p45653-5fb815bc8f93f8b3/comparison.md`
+- ruby-quotes-rails: **inconclusive**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-160600.926505000-ruby-quotes-rails-p8853-55dc2637ed372b38/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-192502.265055000-ruby-quotes-rails-p66327-26a7be4807458535/result.json`
+  - Comparison: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-192502.265055000-ruby-quotes-rails-p66327-26a7be4807458535/comparison.md`
+
+### Profiles
+
+- pf2: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-183814.534638000-ruby-rubocop-coverage-p30210-f0522b4f9b41fcbf/profiles/pf2` — on_line_event fell from 4.66% to 1.86% inclusive; vm_trace fell from 10.99% to 8.36%.
+
+### Findings
+
+The coverage benchmark improved from 66.17% to 58.61% overhead, a 7.56 percentage-point reduction. The direct callback hotspot shrank as predicted. Full-suite RuboCop remained green at 22.90% overhead (inconclusive versus 19.45%), and Quotes Rails remained green at 8.13% (inconclusive versus 10.04%). The isolated long Quotes gap occurred outside measured command duration; its retained measured samples were normal.
+
+### Next step
+
+Continue from the 58.61% reference. Investigate the remaining VM event-hook overhead and the large Pf2 unknown/native sample share without weakening exact per-test coverage semantics.

--- a/docs/performance/ruby-datadog-ci-rubocop-coverage.md
+++ b/docs/performance/ruby-datadog-ci-rubocop-coverage.md
@@ -96,3 +96,44 @@ The candidate reduced overhead from 72.79% to 66.17%, a 6.62 percentage-point im
 ### Next step
 
 Reduce the per-line VM event-hook cost while preserving coverage for method, block, class-body, and dynamically loaded top-level code. Run non-coverage regression guards before final acceptance once overhead is below 50%.
+
+## Iteration 3: rejected
+
+- Timestamp: 2026-08-11T16:35:53+00:00
+- Source: /private/tmp/datadog-ci-rubocop-optimization
+- Branch: anmarchenko/optimize-rubocop-coverage
+- HEAD: a3ca9ef9d97bf69d7831e01f66758631e74b7718
+- Dirty: yes
+
+### Hypothesis
+
+Replacing multi-thread line events with Ruby method, block, class, and script-compilation events will preserve file coverage while avoiding the dominant per-line VM trace-hook cost.
+
+### Change
+
+Use a normal TracePoint for CALL, B_CALL, CLASS, and SCRIPT_COMPILED in multi-thread mode; retain line hooks in single-thread mode and add a top-level-only dynamic-load fixture.
+
+```text
+ext/datadog_ci_native/datadog_cov.c | 49 +++++++++++++++++++++++++++++++++++--
+ spec/ddcov/ddcov_spec.rb            | 12 +++++++++
+ 2 files changed, 59 insertions(+), 2 deletions(-)
+```
+
+### Functional tests
+
+- DDCov native specs: **passed** — Ruby 3.3.5; 38 examples, 0 failures, including dynamic top-level code
+- ruby-rubocop-coverage Crook gate: **failed** — Interrupted after 7 minutes because the functional workload exceeded twice the accepted implementation's duration; Crook cleanup succeeded
+
+### Benchmarks
+
+- ruby-rubocop-coverage: **regressed**
+  - Reference: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-180824.256267000-ruby-rubocop-coverage-p3881-8d7ee266ef7818d5/result.json`
+  - Candidate: `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260811-182812.724018000-ruby-rubocop-coverage-p21019-c8b4f14a475ea8a9/status.json`
+
+### Findings
+
+RuboCop executes Ruby method and block entry events far more often than it alternates among distinct source files after the per-test filename cache. The lower-frequency assumption was false for this workload, so the functional phase alone was enough to reject the candidate without contaminating the accepted reference.
+
+### Next step
+
+Keep line events and optimize the hot early-return path itself, especially avoiding TypedData extraction and general st_table lookup on every event.

--- a/ext/datadog_ci_native/datadog_common.c
+++ b/ext/datadog_ci_native/datadog_common.c
@@ -2,14 +2,25 @@
 #include <ruby.h>
 #include <string.h>
 
-bool dd_ci_is_path_included(const char *path, const char *root_path,
-                            long root_path_len, const char *ignored_path,
-                            long ignored_path_len) {
-  if (strncmp(root_path, path, root_path_len) != 0) {
+static bool has_directory_prefix(const char *path, long path_len,
+                                 const char *prefix, long prefix_len) {
+  if (prefix_len > path_len || memcmp(prefix, path, prefix_len) != 0) {
     return false;
   }
-  if (ignored_path_len > 0 &&
-      strncmp(ignored_path, path, ignored_path_len) == 0) {
+
+  return prefix_len == path_len || prefix[prefix_len - 1] == '/' ||
+         path[prefix_len] == '/';
+}
+
+bool dd_ci_is_path_included(const char *path, long path_len,
+                            const char *root_path, long root_path_len,
+                            const char *ignored_path, long ignored_path_len) {
+  if (!has_directory_prefix(path, path_len, root_path, root_path_len)) {
+    return false;
+  }
+  if (ignored_path_len > 0 && has_directory_prefix(
+                                  path, path_len, ignored_path,
+                                  ignored_path_len)) {
     return false;
   }
   return true;

--- a/ext/datadog_ci_native/datadog_common.h
+++ b/ext/datadog_ci_native/datadog_common.h
@@ -11,14 +11,15 @@
  * Returns true if the path should be included, false otherwise.
  *
  * @param path          The file path to check
+ * @param path_len      Length of path
  * @param root_path     The root path prefix (required)
  * @param root_path_len Length of root_path
  * @param ignored_path  Path prefix to exclude (can be NULL)
  * @param ignored_path_len Length of ignored_path (0 if not set)
  */
-bool dd_ci_is_path_included(const char *path, const char *root_path,
-                            long root_path_len, const char *ignored_path,
-                            long ignored_path_len);
+bool dd_ci_is_path_included(const char *path, long path_len,
+                            const char *root_path, long root_path_len,
+                            const char *ignored_path, long ignored_path_len);
 
 /* ---- Utility functions -------------------------------------------------- */
 

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -13,6 +13,7 @@
 
 #define PROFILE_FRAMES_BUFFER_SIZE 1
 #define SEEN_FILENAME_CACHE_SIZE 256
+#define SEEN_ALLOCATED_CLASS_CACHE_SIZE 256
 
 // threading modes
 enum threading_mode { single, multi };
@@ -77,6 +78,8 @@ struct dd_cov_data {
   VALUE object_allocation_tracepoint;
   st_table *klasses_table; // { (VALUE) -> int } hashmap with class names that
                            // were covered by allocation during the test run
+  VALUE last_allocated_klass;
+  VALUE seen_allocated_klasses[SEEN_ALLOCATED_CLASS_CACHE_SIZE];
   st_table *klass_files_cache; // { (VALUE) -> Array<String> } resolved files
 };
 
@@ -139,6 +142,9 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->threading_mode = multi;
 
   dd_cov_data->object_allocation_tracepoint = Qnil;
+  dd_cov_data->last_allocated_klass = Qnil;
+  memset(dd_cov_data->seen_allocated_klasses, 0,
+         sizeof(dd_cov_data->seen_allocated_klasses));
   // numtable type is needed to store VALUE as a key
   dd_cov_data->klasses_table = st_init_numtable();
   dd_cov_data->klass_files_cache = st_init_numtable();
@@ -285,6 +291,30 @@ static void on_newobj_event(VALUE tracepoint_data, void *data) {
   if (klass == Qnil || klass == 0) {
     return;
   }
+
+  struct dd_cov_data *dd_cov_data = (struct dd_cov_data *)data;
+
+  if (dd_cov_data->last_allocated_klass == klass) {
+    return;
+  }
+
+  uintptr_t klass_ptr = (uintptr_t)klass;
+  size_t cache_index =
+      ((klass_ptr >> 4) ^ (klass_ptr >> 12)) &
+      (SEEN_ALLOCATED_CLASS_CACHE_SIZE - 1);
+  if (dd_cov_data->seen_allocated_klasses[cache_index] == klass) {
+    dd_cov_data->last_allocated_klass = klass;
+    return;
+  }
+
+  // A direct-cache collision must not make us repeat name resolution or table
+  // insertion for a class that this test already observed.
+  if (st_is_member(dd_cov_data->klasses_table, (st_data_t)klass)) {
+    dd_cov_data->last_allocated_klass = klass;
+    dd_cov_data->seen_allocated_klasses[cache_index] = klass;
+    return;
+  }
+
   // Skip anonymous classes starting with "#<Class".
   // it allows us to skip the source location lookup that will always fail
   //
@@ -293,12 +323,12 @@ static void on_newobj_event(VALUE tracepoint_data, void *data) {
     return;
   }
 
-  struct dd_cov_data *dd_cov_data = (struct dd_cov_data *)data;
-
   // We use VALUE directly as a key for the hashmap
   // Ruby itself does it too:
   // https://github.com/ruby/ruby/blob/94b87084a689a3bc732dcaee744508a708223d6c/ext/objspace/object_tracing.c#L113
   st_insert(dd_cov_data->klasses_table, (st_data_t)klass, 1);
+  dd_cov_data->last_allocated_klass = klass;
+  dd_cov_data->seen_allocated_klasses[cache_index] = klass;
 }
 
 // DDCov instance methods available in Ruby
@@ -409,6 +439,9 @@ static VALUE dd_cov_stop(VALUE self) {
   // process classes covered by allocation tracing
   st_foreach(dd_cov_data->klasses_table, each_instantiated_klass,
              (st_data_t)dd_cov_data);
+  dd_cov_data->last_allocated_klass = Qnil;
+  memset(dd_cov_data->seen_allocated_klasses, 0,
+         sizeof(dd_cov_data->seen_allocated_klasses));
   st_clear(dd_cov_data->klasses_table);
 
   VALUE res = dd_cov_data->impacted_files;

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -12,7 +12,7 @@
 // running only the tests that are affected by the changes.
 
 #define PROFILE_FRAMES_BUFFER_SIZE 1
-#define SEEN_FILENAME_CACHE_SIZE 256
+#define SEEN_FILENAME_CACHE_SIZE 1024
 #define SEEN_ALLOCATED_CLASS_CACHE_SIZE 256
 
 // threading modes
@@ -53,10 +53,11 @@ struct dd_cov_data {
   long ignored_path_len;
 
   // Line tracepoint optimisation: make consecutive events from the same file a
-  // single comparison, then use a direct-mapped cache for later revisits. A
-  // collision only repeats path processing; it can never suppress coverage.
-  uintptr_t last_filename_ptr;
-  uintptr_t seen_filename_ptrs[SEEN_FILENAME_CACHE_SIZE];
+  // single comparison, then use a direct-mapped cache for later revisits. Keep
+  // the Ruby strings alive so their pointers cannot be reused for other paths.
+  // A collision only repeats path processing; it can never suppress coverage.
+  VALUE last_filename;
+  VALUE seen_filenames[SEEN_FILENAME_CACHE_SIZE];
 
   // Line tracepoint can work in two modes: single threaded and multi threaded
   //
@@ -88,6 +89,15 @@ static void dd_cov_mark(void *ptr) {
   rb_gc_mark_movable(dd_cov_data->impacted_files);
   rb_gc_mark_movable(dd_cov_data->th_covered);
   rb_gc_mark_movable(dd_cov_data->object_allocation_tracepoint);
+
+  if (dd_cov_data->last_filename != Qnil) {
+    rb_gc_mark(dd_cov_data->last_filename);
+  }
+  for (size_t i = 0; i < SEEN_FILENAME_CACHE_SIZE; i++) {
+    if (dd_cov_data->seen_filenames[i] != Qnil) {
+      rb_gc_mark(dd_cov_data->seen_filenames[i]);
+    }
+  }
 
   // if GC starts withing dd_cov_allocate() call, klasses_table might not be
   // initialized yet
@@ -136,9 +146,10 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->root_len = 0;
   dd_cov_data->ignored_path = NULL;
   dd_cov_data->ignored_path_len = 0;
-  dd_cov_data->last_filename_ptr = 0;
-  memset(dd_cov_data->seen_filename_ptrs, 0,
-         sizeof(dd_cov_data->seen_filename_ptrs));
+  dd_cov_data->last_filename = Qnil;
+  for (size_t i = 0; i < SEEN_FILENAME_CACHE_SIZE; i++) {
+    dd_cov_data->seen_filenames[i] = Qnil;
+  }
   dd_cov_data->threading_mode = multi;
 
   dd_cov_data->object_allocation_tracepoint = Qnil;
@@ -182,18 +193,19 @@ static void on_line_event(rb_event_flag_t event, VALUE data, VALUE self, ID id,
   }
 
   uintptr_t current_filename_ptr = (uintptr_t)c_filename;
-  if (dd_cov_data->last_filename_ptr == current_filename_ptr) {
+  if (dd_cov_data->last_filename != Qnil &&
+      RSTRING_PTR(dd_cov_data->last_filename) == c_filename) {
     return;
   }
-  dd_cov_data->last_filename_ptr = current_filename_ptr;
 
   size_t cache_index =
       ((current_filename_ptr >> 4) ^ (current_filename_ptr >> 12)) &
       (SEEN_FILENAME_CACHE_SIZE - 1);
-  if (dd_cov_data->seen_filename_ptrs[cache_index] == current_filename_ptr) {
+  VALUE cached_filename = dd_cov_data->seen_filenames[cache_index];
+  if (cached_filename != Qnil && RSTRING_PTR(cached_filename) == c_filename) {
+    dd_cov_data->last_filename = cached_filename;
     return;
   }
-  dd_cov_data->seen_filename_ptrs[cache_index] = current_filename_ptr;
 
   VALUE top_frame;
   int captured_frames =
@@ -209,6 +221,8 @@ static void on_line_event(rb_event_flag_t event, VALUE data, VALUE self, ID id,
     return;
   }
 
+  dd_cov_data->last_filename = filename;
+  dd_cov_data->seen_filenames[cache_index] = filename;
   record_impacted_file(dd_cov_data, filename);
 }
 
@@ -447,9 +461,10 @@ static VALUE dd_cov_stop(VALUE self) {
   VALUE res = dd_cov_data->impacted_files;
 
   dd_cov_data->impacted_files = rb_hash_new();
-  dd_cov_data->last_filename_ptr = 0;
-  memset(dd_cov_data->seen_filename_ptrs, 0,
-         sizeof(dd_cov_data->seen_filename_ptrs));
+  dd_cov_data->last_filename = Qnil;
+  for (size_t i = 0; i < SEEN_FILENAME_CACHE_SIZE; i++) {
+    dd_cov_data->seen_filenames[i] = Qnil;
+  }
 
   return res;
 }

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -183,8 +183,9 @@ static VALUE dd_cov_allocate(VALUE klass) {
 // not in the ignored folder) and adds it to the impacted_files hash.
 static bool record_impacted_file(struct dd_cov_data *dd_cov_data,
                                  VALUE filename) {
-  if (!dd_ci_is_path_included(RSTRING_PTR(filename), dd_cov_data->root,
-                              dd_cov_data->root_len, dd_cov_data->ignored_path,
+  if (!dd_ci_is_path_included(RSTRING_PTR(filename), RSTRING_LEN(filename),
+                              dd_cov_data->root, dd_cov_data->root_len,
+                              dd_cov_data->ignored_path,
                               dd_cov_data->ignored_path_len)) {
     return false;
   }
@@ -371,12 +372,22 @@ static VALUE dd_cov_initialize(int argc, VALUE *argv, VALUE self) {
   VALUE opt;
 
   rb_scan_args(argc, argv, "10", &opt);
+  Check_Type(opt, T_HASH);
+
   VALUE rb_root = rb_hash_lookup(opt, ID2SYM(rb_intern("root")));
   if (!RTEST(rb_root)) {
     rb_raise(rb_eArgError, "root is required");
   }
+  Check_Type(rb_root, T_STRING);
+  const char *root = StringValueCStr(rb_root);
+
   VALUE rb_ignored_path =
       rb_hash_lookup(opt, ID2SYM(rb_intern("ignored_path")));
+  const char *ignored_path = NULL;
+  if (RTEST(rb_ignored_path)) {
+    Check_Type(rb_ignored_path, T_STRING);
+    ignored_path = StringValueCStr(rb_ignored_path);
+  }
 
   VALUE rb_threading_mode =
       rb_hash_lookup(opt, ID2SYM(rb_intern("threading_mode")));
@@ -402,13 +413,12 @@ static VALUE dd_cov_initialize(int argc, VALUE *argv, VALUE self) {
 
   dd_cov_data->threading_mode = threading_mode;
   dd_cov_data->root_len = RSTRING_LEN(rb_root);
-  dd_cov_data->root =
-      dd_ci_ruby_strndup(RSTRING_PTR(rb_root), dd_cov_data->root_len);
+  dd_cov_data->root = dd_ci_ruby_strndup(root, dd_cov_data->root_len);
 
   if (RTEST(rb_ignored_path)) {
     dd_cov_data->ignored_path_len = RSTRING_LEN(rb_ignored_path);
     dd_cov_data->ignored_path = dd_ci_ruby_strndup(
-        RSTRING_PTR(rb_ignored_path), dd_cov_data->ignored_path_len);
+        ignored_path, dd_cov_data->ignored_path_len);
   }
 
   if (rb_allocation_tracing_enabled == Qtrue) {

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -3,6 +3,7 @@
 #include <ruby/st.h>
 
 #include <stdbool.h>
+#include <string.h>
 
 #include "datadog_common.h"
 
@@ -11,6 +12,7 @@
 // running only the tests that are affected by the changes.
 
 #define PROFILE_FRAMES_BUFFER_SIZE 1
+#define SEEN_FILENAME_CACHE_SIZE 256
 
 // threading modes
 enum threading_mode { single, multi };
@@ -49,10 +51,11 @@ struct dd_cov_data {
   char *ignored_path;
   long ignored_path_len;
 
-  // Line tracepoint optimisation: cache every filename pointer observed during
-  // the current test. Coverage is a set, so revisiting a file cannot add any
-  // information and should not repeat frame and path processing.
-  st_table *seen_filename_ptrs;
+  // Line tracepoint optimisation: make consecutive events from the same file a
+  // single comparison, then use a direct-mapped cache for later revisits. A
+  // collision only repeats path processing; it can never suppress coverage.
+  uintptr_t last_filename_ptr;
+  uintptr_t seen_filename_ptrs[SEEN_FILENAME_CACHE_SIZE];
 
   // Line tracepoint can work in two modes: single threaded and multi threaded
   //
@@ -97,7 +100,6 @@ static void dd_cov_free(void *ptr) {
   struct dd_cov_data *dd_cov_data = ptr;
   xfree(dd_cov_data->root);
   xfree(dd_cov_data->ignored_path);
-  st_free_table(dd_cov_data->seen_filename_ptrs);
   st_free_table(dd_cov_data->klasses_table);
   st_free_table(dd_cov_data->klass_files_cache);
   xfree(dd_cov_data);
@@ -131,10 +133,12 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->root_len = 0;
   dd_cov_data->ignored_path = NULL;
   dd_cov_data->ignored_path_len = 0;
+  dd_cov_data->last_filename_ptr = 0;
+  memset(dd_cov_data->seen_filename_ptrs, 0,
+         sizeof(dd_cov_data->seen_filename_ptrs));
   dd_cov_data->threading_mode = multi;
 
   dd_cov_data->object_allocation_tracepoint = Qnil;
-  dd_cov_data->seen_filename_ptrs = st_init_numtable();
   // numtable type is needed to store VALUE as a key
   dd_cov_data->klasses_table = st_init_numtable();
   dd_cov_data->klass_files_cache = st_init_numtable();
@@ -162,24 +166,28 @@ static bool record_impacted_file(struct dd_cov_data *dd_cov_data,
 // rb_profile_frames.
 static void on_line_event(rb_event_flag_t event, VALUE data, VALUE self, ID id,
                           VALUE klass) {
-  struct dd_cov_data *dd_cov_data;
-  TypedData_Get_Struct(data, struct dd_cov_data, &dd_cov_data_type,
-                       dd_cov_data);
+  // The hook is registered only with DDCov instances, so the full typed-data
+  // type check on every Ruby line is unnecessary.
+  struct dd_cov_data *dd_cov_data = RTYPEDDATA_DATA(data);
 
   const char *c_filename = rb_sourcefile();
   if (c_filename == NULL) {
     return;
   }
 
-  // Skip every file already observed during this test, not just consecutive
-  // line events from the same file.
   uintptr_t current_filename_ptr = (uintptr_t)c_filename;
-  if (st_is_member(dd_cov_data->seen_filename_ptrs,
-                   (st_data_t)current_filename_ptr)) {
+  if (dd_cov_data->last_filename_ptr == current_filename_ptr) {
     return;
   }
-  st_insert(dd_cov_data->seen_filename_ptrs, (st_data_t)current_filename_ptr,
-            1);
+  dd_cov_data->last_filename_ptr = current_filename_ptr;
+
+  size_t cache_index =
+      ((current_filename_ptr >> 4) ^ (current_filename_ptr >> 12)) &
+      (SEEN_FILENAME_CACHE_SIZE - 1);
+  if (dd_cov_data->seen_filename_ptrs[cache_index] == current_filename_ptr) {
+    return;
+  }
+  dd_cov_data->seen_filename_ptrs[cache_index] = current_filename_ptr;
 
   VALUE top_frame;
   int captured_frames =
@@ -406,7 +414,9 @@ static VALUE dd_cov_stop(VALUE self) {
   VALUE res = dd_cov_data->impacted_files;
 
   dd_cov_data->impacted_files = rb_hash_new();
-  st_clear(dd_cov_data->seen_filename_ptrs);
+  dd_cov_data->last_filename_ptr = 0;
+  memset(dd_cov_data->seen_filename_ptrs, 0,
+         sizeof(dd_cov_data->seen_filename_ptrs));
 
   return res;
 }

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -40,9 +40,10 @@ struct dd_cov_data {
   char *ignored_path;
   long ignored_path_len;
 
-  // Line tracepoint optimisation: cache last seen filename pointer to avoid
-  // unnecessary string comparison if we stay in the same file.
-  uintptr_t last_filename_ptr;
+  // Line tracepoint optimisation: cache every filename pointer observed during
+  // the current test. Coverage is a set, so revisiting a file cannot add any
+  // information and should not repeat frame and path processing.
+  st_table *seen_filename_ptrs;
 
   // Line tracepoint can work in two modes: single threaded and multi threaded
   //
@@ -83,6 +84,7 @@ static void dd_cov_free(void *ptr) {
   struct dd_cov_data *dd_cov_data = ptr;
   xfree(dd_cov_data->root);
   xfree(dd_cov_data->ignored_path);
+  st_free_table(dd_cov_data->seen_filename_ptrs);
   st_free_table(dd_cov_data->klasses_table);
   xfree(dd_cov_data);
 }
@@ -115,10 +117,10 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->root_len = 0;
   dd_cov_data->ignored_path = NULL;
   dd_cov_data->ignored_path_len = 0;
-  dd_cov_data->last_filename_ptr = 0;
   dd_cov_data->threading_mode = multi;
 
   dd_cov_data->object_allocation_tracepoint = Qnil;
+  dd_cov_data->seen_filename_ptrs = st_init_numtable();
   // numtable type is needed to store VALUE as a key
   dd_cov_data->klasses_table = st_init_numtable();
 
@@ -150,13 +152,19 @@ static void on_line_event(rb_event_flag_t event, VALUE data, VALUE self, ID id,
                        dd_cov_data);
 
   const char *c_filename = rb_sourcefile();
-
-  // skip if we cover the same file again
-  uintptr_t current_filename_ptr = (uintptr_t)c_filename;
-  if (dd_cov_data->last_filename_ptr == current_filename_ptr) {
+  if (c_filename == NULL) {
     return;
   }
-  dd_cov_data->last_filename_ptr = current_filename_ptr;
+
+  // Skip every file already observed during this test, not just consecutive
+  // line events from the same file.
+  uintptr_t current_filename_ptr = (uintptr_t)c_filename;
+  if (st_is_member(dd_cov_data->seen_filename_ptrs,
+                   (st_data_t)current_filename_ptr)) {
+    return;
+  }
+  st_insert(dd_cov_data->seen_filename_ptrs, (st_data_t)current_filename_ptr,
+            1);
 
   VALUE top_frame;
   int captured_frames =
@@ -373,7 +381,7 @@ static VALUE dd_cov_stop(VALUE self) {
   VALUE res = dd_cov_data->impacted_files;
 
   dd_cov_data->impacted_files = rb_hash_new();
-  dd_cov_data->last_filename_ptr = 0;
+  st_clear(dd_cov_data->seen_filename_ptrs);
 
   return res;
 }

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -13,7 +13,19 @@
 
 #define PROFILE_FRAMES_BUFFER_SIZE 1
 #define SEEN_FILENAME_CACHE_SIZE 1024
-#define SEEN_ALLOCATED_CLASS_CACHE_SIZE 256
+#define SEEN_ALLOCATED_CLASS_CACHE_SIZE 4096
+#define KLASS_FILES_CACHE_SIZE 100000
+
+#if SEEN_FILENAME_CACHE_SIZE == 0 ||                                       \
+    (SEEN_FILENAME_CACHE_SIZE & (SEEN_FILENAME_CACHE_SIZE - 1)) != 0
+#error "SEEN_FILENAME_CACHE_SIZE must be a power of two"
+#endif
+
+#if SEEN_ALLOCATED_CLASS_CACHE_SIZE == 0 ||                               \
+    (SEEN_ALLOCATED_CLASS_CACHE_SIZE &                                   \
+     (SEEN_ALLOCATED_CLASS_CACHE_SIZE - 1)) != 0
+#error "SEEN_ALLOCATED_CLASS_CACHE_SIZE must be a power of two"
+#endif
 
 // threading modes
 enum threading_mode { single, multi };
@@ -283,6 +295,12 @@ static int each_instantiated_klass(st_data_t key, st_data_t _value,
   }
 
   rb_obj_freeze(files);
+  // Bound cross-test retention without adding eviction work to cache hits.
+  // Reaching the limit starts a fresh cache generation.
+  if (st_table_size(dd_cov_data->klass_files_cache) >=
+      KLASS_FILES_CACHE_SIZE) {
+    st_clear(dd_cov_data->klass_files_cache);
+  }
   st_insert(dd_cov_data->klass_files_cache, key, (st_data_t)files);
 
   return ST_CONTINUE;

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -94,6 +94,7 @@ struct dd_cov_data {
   VALUE last_allocated_klass;
   VALUE seen_allocated_klasses[SEEN_ALLOCATED_CLASS_CACHE_SIZE];
   st_table *klass_files_cache; // { (VALUE) -> Array<String> } resolved files
+  size_t klass_files_cache_size;
 };
 
 static void dd_cov_mark(void *ptr) {
@@ -171,6 +172,7 @@ static VALUE dd_cov_allocate(VALUE klass) {
   // numtable type is needed to store VALUE as a key
   dd_cov_data->klasses_table = st_init_numtable();
   dd_cov_data->klass_files_cache = st_init_numtable();
+  dd_cov_data->klass_files_cache_size = 0;
 
   return dd_cov;
 }
@@ -297,11 +299,12 @@ static int each_instantiated_klass(st_data_t key, st_data_t _value,
   rb_obj_freeze(files);
   // Bound cross-test retention without adding eviction work to cache hits.
   // Reaching the limit starts a fresh cache generation.
-  if (st_table_size(dd_cov_data->klass_files_cache) >=
-      KLASS_FILES_CACHE_SIZE) {
+  if (dd_cov_data->klass_files_cache_size >= KLASS_FILES_CACHE_SIZE) {
     st_clear(dd_cov_data->klass_files_cache);
+    dd_cov_data->klass_files_cache_size = 0;
   }
   st_insert(dd_cov_data->klass_files_cache, key, (st_data_t)files);
+  dd_cov_data->klass_files_cache_size++;
 
   return ST_CONTINUE;
 }

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -25,6 +25,15 @@ static int mark_key_for_gc_i(st_data_t key, st_data_t _value, st_data_t _data) {
   return ST_CONTINUE;
 }
 
+static int mark_klass_files_for_gc_i(st_data_t key, st_data_t value,
+                                     st_data_t _data) {
+  // Both the class key and its cached filenames must remain at stable addresses
+  // because they are stored outside Ruby's object containers.
+  rb_gc_mark((VALUE)key);
+  rb_gc_mark((VALUE)value);
+  return ST_CONTINUE;
+}
+
 // Data structure
 struct dd_cov_data {
   // Ruby hash with filenames impacted by the test.
@@ -65,6 +74,7 @@ struct dd_cov_data {
   VALUE object_allocation_tracepoint;
   st_table *klasses_table; // { (VALUE) -> int } hashmap with class names that
                            // were covered by allocation during the test run
+  st_table *klass_files_cache; // { (VALUE) -> Array<String> } resolved files
 };
 
 static void dd_cov_mark(void *ptr) {
@@ -78,6 +88,9 @@ static void dd_cov_mark(void *ptr) {
   if (dd_cov_data->klasses_table != NULL) {
     st_foreach(dd_cov_data->klasses_table, mark_key_for_gc_i, 0);
   }
+  if (dd_cov_data->klass_files_cache != NULL) {
+    st_foreach(dd_cov_data->klass_files_cache, mark_klass_files_for_gc_i, 0);
+  }
 }
 
 static void dd_cov_free(void *ptr) {
@@ -86,6 +99,7 @@ static void dd_cov_free(void *ptr) {
   xfree(dd_cov_data->ignored_path);
   st_free_table(dd_cov_data->seen_filename_ptrs);
   st_free_table(dd_cov_data->klasses_table);
+  st_free_table(dd_cov_data->klass_files_cache);
   xfree(dd_cov_data);
 }
 
@@ -123,6 +137,7 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->seen_filename_ptrs = st_init_numtable();
   // numtable type is needed to store VALUE as a key
   dd_cov_data->klasses_table = st_init_numtable();
+  dd_cov_data->klass_files_cache = st_init_numtable();
 
   return dd_cov;
 }
@@ -193,27 +208,24 @@ static VALUE safely_get_mod_ancestors(VALUE klass) {
   return dd_ci_rescue_nil(rb_mod_ancestors, klass);
 }
 
-static bool record_impacted_klass(struct dd_cov_data *dd_cov_data,
-                                  VALUE klass) {
-  VALUE klass_name = safely_get_class_name(klass);
-  if (klass_name == Qnil) {
-    return false;
-  }
-
-  VALUE filename = dd_ci_resolve_const_to_file(klass_name);
-  if (filename == Qnil) {
-    return false;
-  }
-
-  return record_impacted_file(dd_cov_data, filename);
-}
-
 // This function is called for each class that was instantiated during the test
 // run.
 static int each_instantiated_klass(st_data_t key, st_data_t _value,
                                    st_data_t data) {
   VALUE klass = (VALUE)key;
   struct dd_cov_data *dd_cov_data = (struct dd_cov_data *)data;
+
+  st_data_t cached_files;
+  if (st_lookup(dd_cov_data->klass_files_cache, key, &cached_files)) {
+    VALUE files = (VALUE)cached_files;
+    long files_len = RARRAY_LEN(files);
+    for (long i = 0; i < files_len; i++) {
+      rb_hash_aset(dd_cov_data->impacted_files, rb_ary_entry(files, i), Qtrue);
+    }
+    return ST_CONTINUE;
+  }
+
+  VALUE files = rb_ary_new();
 
   // rb_mod_ancestors returns an array containing the "klass" itself
   // and all the parent classes and/or included/prepended modules
@@ -229,8 +241,21 @@ static int each_instantiated_klass(st_data_t key, st_data_t _value,
       continue;
     }
 
-    record_impacted_klass(dd_cov_data, mod);
+    VALUE klass_name = safely_get_class_name(mod);
+    if (klass_name == Qnil) {
+      continue;
+    }
+
+    VALUE filename = dd_ci_resolve_const_to_file(klass_name);
+    if (filename == Qnil || !record_impacted_file(dd_cov_data, filename)) {
+      continue;
+    }
+
+    rb_ary_push(files, filename);
   }
+
+  rb_obj_freeze(files);
+  st_insert(dd_cov_data->klass_files_cache, key, (st_data_t)files);
 
   return ST_CONTINUE;
 }

--- a/lib/datadog/ci/source_code/path_filter.rb
+++ b/lib/datadog/ci/source_code/path_filter.rb
@@ -6,8 +6,8 @@ module Datadog
       # PathFilter determines whether a file path should be included in test impact analysis.
       #
       # A path is included if:
-      # - It starts with root_path (prefix match)
-      # - It does NOT start with ignored_path (when ignored_path is set)
+      # - It is equal to root_path or located below it
+      # - It is NOT equal to ignored_path or located below it
       #
       # This module mirrors the C implementation in datadog_common.c (dd_ci_is_path_included).
       module PathFilter
@@ -19,14 +19,22 @@ module Datadog
         # @return [Boolean] true if the path should be included
         def self.included?(path, root_path, ignored_path = nil)
           return false unless path.is_a?(String) && root_path.is_a?(String)
-          return false unless path.start_with?(root_path)
+          return false unless directory_prefix?(path, root_path)
 
           if ignored_path.is_a?(String) && !ignored_path.empty?
-            return false if path.start_with?(ignored_path)
+            return false if directory_prefix?(path, ignored_path)
           end
 
           true
         end
+
+        def self.directory_prefix?(path, prefix)
+          return false unless path.start_with?(prefix)
+
+          path.length == prefix.length || prefix.end_with?(File::SEPARATOR) ||
+            path[prefix.length] == File::SEPARATOR
+        end
+        private_class_method :directory_prefix?
       end
     end
   end

--- a/sig/datadog/ci/source_code/path_filter.rbs
+++ b/sig/datadog/ci/source_code/path_filter.rbs
@@ -5,6 +5,10 @@ module Datadog
     module SourceCode
       module PathFilter
         def self.included?: (String path, String root_path, String? ignored_path) -> bool
+
+        private
+
+        def self.directory_prefix?: (String path, String prefix) -> bool
       end
     end
   end

--- a/spec/datadog/ci/source_code/path_filter_spec.rb
+++ b/spec/datadog/ci/source_code/path_filter_spec.rb
@@ -31,10 +31,7 @@ RSpec.describe Datadog::CI::SourceCode::PathFilter do
     context "when path has similar prefix but is not under root_path" do
       let(:path) { "/app/project_other/foo.rb" }
 
-      it "matches prefix (no trailing slash check)" do
-        # This matches how the C implementation works (strncmp prefix)
-        expect(included?).to be true
-      end
+      it { is_expected.to be false }
     end
 
     context "with ignored_path" do
@@ -56,6 +53,12 @@ RSpec.describe Datadog::CI::SourceCode::PathFilter do
         let(:path) { "/app/project/vendor" }
 
         it { is_expected.to be false }
+      end
+
+      context "when path has a similar prefix but is not under ignored_path" do
+        let(:path) { "/app/project/vendorized/foo.rb" }
+
+        it { is_expected.to be true }
       end
     end
 

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
       end
     end
 
+    context "when initialization arguments are malformed" do
+      it "rejects non-hash options and non-string paths" do
+        expect { described_class.new(nil) }.to raise_error(TypeError)
+        expect do
+          described_class.new(root: Object.new, threading_mode: :multi)
+        end.to raise_error(TypeError)
+        expect do
+          described_class.new(root: "/tmp", ignored_path: Object.new, threading_mode: :multi)
+        end.to raise_error(TypeError)
+      end
+
+      it "rejects paths containing null bytes" do
+        expect do
+          described_class.new(root: "/tmp\0other", threading_mode: :multi)
+        end.to raise_error(ArgumentError)
+        expect do
+          described_class.new(root: "/tmp", ignored_path: "/tmp\0other", threading_mode: :multi)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
     context "when root is the calculator project dir" do
       let(:root) { absolute_path("calculator") }
 
@@ -361,6 +382,28 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
             expect(coverage.size).to eq(1)
             expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
           end
+
+          it "collects distinct dynamic sources executed by many threads" do
+            root = absolute_path("dynamic/threaded")
+            collector = described_class.new(
+              root: root,
+              threading_mode: :multi,
+              use_allocation_tracing: false
+            )
+            sources = Array.new(256) do |index|
+              path = File.join(root, "#{index}.rb")
+              [path, RubyVM::InstructionSequence.compile("Thread.pass\n", path, path)]
+            end
+
+            collector.start
+            sources.each_slice(32).map do |slice|
+              Thread.new { slice.each { |_, iseq| iseq.eval } }
+            end.each(&:join)
+            coverage = collector.stop
+
+            expected_files = sources.map(&:first)
+            expect((coverage.keys & expected_files).size).to eq(expected_files.size)
+          end
         end
 
         context "when threading mode is invalid" do
@@ -375,7 +418,7 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
       end
     end
 
-    context "when instruction sequence source storage is reused" do
+    context "when dynamic source filenames stress the line-event cache" do
       let(:root) { absolute_path("dynamic/included") }
       let(:use_allocation_tracing) { false }
 
@@ -411,6 +454,82 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
 
         recorded_files = coverage.keys & expected_files
         expect(recorded_files.size).to eq(expected_files.size)
+      end
+
+      it "records more distinct sources than the direct cache can hold" do
+        subject.start
+        expected_files = Array.new(1_100) do |index|
+          path = File.join(root, "overflow-#{index}.rb")
+          source = RubyVM::InstructionSequence.compile("nil\n", path, path)
+
+          source.eval
+          path
+        end
+
+        coverage = subject.stop
+
+        expect((coverage.keys & expected_files).size).to eq(expected_files.size)
+      end
+
+      it "keeps cached filenames valid across heap compaction" do
+        skip "Ruby does not support heap compaction" unless GC.respond_to?(:compact)
+
+        first_path = File.join(root, "before-compaction.rb")
+        second_path = File.join(root, "after-compaction.rb")
+        spacer_path = absolute_path("dynamic/excluded/compaction-spacer.rb")
+        first_source = RubyVM::InstructionSequence.compile("nil\n", first_path, first_path)
+        second_source = RubyVM::InstructionSequence.compile("nil\n", second_path, second_path)
+        spacer = RubyVM::InstructionSequence.compile("nil\n", spacer_path, spacer_path)
+
+        subject.start
+        first_source.eval
+        spacer.eval
+        GC.compact
+        first_source.eval
+        second_source.eval
+        coverage = subject.stop
+
+        expect(coverage.keys).to include(first_path, second_path)
+      end
+    end
+
+    context "when paths only share a textual prefix" do
+      let(:root) { absolute_path("dynamic/app") }
+      let(:use_allocation_tracing) { false }
+
+      it "does not include files from a sibling directory" do
+        included_path = File.join(root, "model.rb")
+        sibling_path = absolute_path("dynamic/application/model.rb")
+        included_source = RubyVM::InstructionSequence.compile("nil\n", included_path, included_path)
+        sibling_source = RubyVM::InstructionSequence.compile("nil\n", sibling_path, sibling_path)
+
+        subject.start
+        sibling_source.eval
+        included_source.eval
+        coverage = subject.stop
+
+        expect(coverage.keys).to include(included_path)
+        expect(coverage.keys).not_to include(sibling_path)
+      end
+
+      context "when an ignored path is configured" do
+        let(:root) { absolute_path("dynamic") }
+        let(:ignored_path) { absolute_path("dynamic/vendor") }
+
+        it "does not ignore a sibling directory with the same prefix" do
+          ignored_file = File.join(ignored_path, "dependency.rb")
+          included_file = absolute_path("dynamic/vendorized/application.rb")
+          ignored_source = RubyVM::InstructionSequence.compile("nil\n", ignored_file, ignored_file)
+          included_source = RubyVM::InstructionSequence.compile("nil\n", included_file, included_file)
+
+          subject.start
+          ignored_source.eval
+          included_source.eval
+          coverage = subject.stop
+
+          expect(coverage.keys).to include(included_file)
+          expect(coverage.keys).not_to include(ignored_file)
+        end
       end
     end
 
@@ -593,6 +712,99 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
             expect(coverage.keys).to include(absolute_path("app/model/my_parent_model.rb"))
             expect(coverage.keys).to include(absolute_path("app/model/my_grandparent_model.rb"))
             expect(coverage.keys).to include(absolute_path("app/concerns/queryable.rb"))
+          end
+
+          it "reuses cached class files after heap compaction" do
+            skip "Ruby does not support heap compaction" unless GC.respond_to?(:compact)
+
+            namespace_name = :DDCovCompactionStress
+            namespace = Module.new
+            Object.const_set(namespace_name, namespace)
+            expected_files = Array.new(128) do |index|
+              path = absolute_path("app/generated/compaction-#{index}.rb")
+              RubyVM::InstructionSequence.compile(
+                "class #{namespace_name}::Model#{index}; end",
+                path,
+                path
+              ).eval
+              path
+            end
+            classes = namespace.constants(false).map { |name| namespace.const_get(name) }
+
+            subject.start
+            classes.each(&:new)
+            first_coverage = subject.stop
+            GC.compact
+            subject.start
+            classes.reverse_each(&:new)
+            second_coverage = subject.stop
+
+            expect((first_coverage.keys & expected_files).size).to eq(expected_files.size)
+            expect((second_coverage.keys & expected_files).size).to eq(expected_files.size)
+          ensure
+            Object.send(:remove_const, namespace_name) if Object.const_defined?(namespace_name, false)
+          end
+        end
+
+        context "allocated-class cache stress" do
+          it "records more distinct classes than the direct cache can hold" do
+            namespace_name = :DDCovAllocatedClassCacheStress
+            namespace = Module.new
+            Object.const_set(namespace_name, namespace)
+            expected_files = Array.new(4_200) do |index|
+              path = absolute_path("app/generated/allocated-#{index}.rb")
+              RubyVM::InstructionSequence.compile(
+                "class #{namespace_name}::Model#{index}; end",
+                path,
+                path
+              ).eval
+              path
+            end
+            classes = namespace.constants(false).map { |name| namespace.const_get(name) }
+
+            subject.start
+            classes.each(&:new)
+            coverage = subject.stop
+
+            expect((coverage.keys & expected_files).size).to eq(expected_files.size)
+          ensure
+            Object.send(:remove_const, namespace_name) if Object.const_defined?(namespace_name, false)
+          end
+
+          it "does not confuse a redefined constant with its previous class" do
+            namespace_name = :DDCovRedefinedClassStress
+            namespace = Module.new
+            Object.const_set(namespace_name, namespace)
+            first_path = absolute_path("app/generated/first-model.rb")
+            second_path = absolute_path("app/generated/second-model.rb")
+            RubyVM::InstructionSequence.compile(
+              "class #{namespace_name}::Model; end",
+              first_path,
+              first_path
+            ).eval
+            first_class = namespace.const_get(:Model)
+
+            subject.start
+            first_class.new
+            first_coverage = subject.stop
+
+            namespace.send(:remove_const, :Model)
+            RubyVM::InstructionSequence.compile(
+              "class #{namespace_name}::Model; end",
+              second_path,
+              second_path
+            ).eval
+            second_class = namespace.const_get(:Model)
+
+            subject.start
+            second_class.new
+            second_coverage = subject.stop
+
+            expect(first_coverage.keys).to include(first_path)
+            expect(second_coverage.keys).to include(second_path)
+            expect(second_coverage.keys).not_to include(first_path)
+          ensure
+            Object.send(:remove_const, namespace_name) if Object.const_defined?(namespace_name, false)
           end
         end
 

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -435,7 +435,12 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
 
         subject.start
 
-        2_000.times do |index|
+        # Valgrind makes each forced full-heap collection extremely expensive.
+        # Ordinary CI keeps the full pointer-reuse stress; memcheck only needs
+        # enough iterations to exercise GC ownership and marking.
+        iterations = (ENV["RUBY_MEMCHECK_RUNNING"] == "1") ? 20 : 2_000
+
+        iterations.times do |index|
           basename = format("%04d.rb", index)
           execute_transient_source.call(excluded_dir, basename)
           GC.start(full_mark: true, immediate_sweep: true)

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -375,6 +375,45 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
       end
     end
 
+    context "when instruction sequence source storage is reused" do
+      let(:root) { absolute_path("dynamic/included") }
+      let(:use_allocation_tracing) { false }
+
+      it "does not confuse a new source file with a discarded excluded file" do
+        included_dir = absolute_path("dynamic/included")
+        excluded_dir = absolute_path("dynamic/excluded")
+        spacer_path = absolute_path("dynamic/spacer.rb")
+        spacer = RubyVM::InstructionSequence.compile("nil\n", spacer_path, spacer_path)
+        execute_transient_source = lambda do |directory, basename|
+          path = File.join(directory, basename)
+          RubyVM::InstructionSequence.compile("nil\n", path, path).eval
+        end
+        expected_files = []
+
+        subject.start
+
+        2_000.times do |index|
+          basename = format("%04d.rb", index)
+          execute_transient_source.call(excluded_dir, basename)
+          GC.start(full_mark: true, immediate_sweep: true)
+
+          included_path = File.join(included_dir, basename)
+          included_iseq = RubyVM::InstructionSequence.compile("nil\n", included_path, included_path)
+          expected_files << included_path
+
+          # Keep the consecutive-filename fast path from masking the direct
+          # cache behavior under test.
+          spacer.eval
+          included_iseq.eval
+        end
+
+        coverage = subject.stop
+
+        recorded_files = coverage.keys & expected_files
+        expect(recorded_files.size).to eq(expected_files.size)
+      end
+    end
+
     context "root in app folder" do
       let(:root) { absolute_path("app") }
 


### PR DESCRIPTION
## Summary

- deduplicate source-file work in the native line event hook with a bounded direct cache
- retain 1,024 cached Ruby path objects per test so GC cannot reuse a raw source pointer for a different file
- cache allocation class source resolution across tests
- skip repeated allocation-class bookkeeping before name lookup and hash insertion
- add regression coverage for discarded instruction sequences and an append-only optimization journal

## Performance

Full upstream RuboCop suite with per-test TIA coverage:

- initial (`--warmups 0 --runs 1`): **77.87%** overhead (115.77s baseline / 205.91s instrumented)
- current (`--warmups 1 --runs 4`, medians): **53.46%** overhead (116.85s baseline / 179.31s instrumented)
- overhead reduction: **24.41 percentage points**
- tracer-added time: **90.15s → 62.47s**, saving **27.68s (30.71%)** per full-suite execution
- total instrumented duration: **12.92% lower**

The initial and current results use different sample counts, so these savings are directional rather than a deterministic comparison. The previous implementation reached 48.17% in a one-pair run, but its raw-pointer cache could silently omit files after instruction-sequence collection. The current 53.46% result includes the accepted GC-safe correctness fix.

Every accepted implementation passed Crook's 37-assertion functional gate. Pf2 profiles and every iteration's result paths are retained in the optimization journal.

## Regression guards

- full RuboCop without TIA: 36 assertions passed; comparison inconclusive, not regressed
- Quotes Rails: 36 assertions passed; comparison inconclusive, not regressed

## Validation

- `bundle exec rake compile_ext`
- `bundle exec rspec spec/ddcov/ddcov_spec.rb spec/ddcov/ddcov_with_symlinks_spec.rb` — 38 examples, 0 failures
- focused source-pointer-reuse regression — 2,000/2,000 included files retained
- `bundle exec rake test:main` — 2,308 examples, 0 failures, 1 Linux-only pending
- `ruby-rubocop-coverage` — 37 assertions passed, 53.46% median overhead across four measured pairs

The experiment log and artifact paths are recorded in `docs/performance/ruby-datadog-ci-rubocop-coverage.md`.
