### PR TITLE
Optimize TIA coverage collection overhead

### DIFF
--- a/docs/performance/rails-tia-stress-test-level.md
+++ b/docs/performance/rails-tia-stress-test-level.md
@@ -15,9 +15,10 @@ sampling, timing-dependent behavior, or load-order-dependent behavior were not.
 
 The benchmark runs 1,000 Rails examples. Its correctness gate requires all
 19,080 assertions, 1,000 coverage events, and the exact expected file
-associations before any timing is accepted. The baseline executes normal test
-tracing without TIA code coverage; the instrumented variant adds normal TIA
-test-level coverage.
+associations before any timing is accepted. The baseline is the uninstrumented
+workload; the instrumented variant enables normal test tracing and TIA
+test-level coverage. The separate `ruby-rails-tia-stress-default` benchmark is
+the tracing-only floor.
 
 The repository root is invariant for the lifetime of the process and never
 changes between coverage events. Coverage serialization may therefore capture

--- a/docs/performance/rails-tia-stress-test-level.md
+++ b/docs/performance/rails-tia-stress-test-level.md
@@ -1,0 +1,123 @@
+# Rails TIA stress optimization outcome
+
+- Tracer: datadog-ci-rb
+- Workload: `ruby-rails-tia-stress-test-level`
+- Correctness priority: deterministic, substantially complete TIA coverage is the primary constraint
+- Final target: 32% overhead
+- Outcome: target not reached; final safe candidate measures 51.50% overhead
+- Completed: 2026-08-15
+
+This document records the final disposition of the optimization loop. Bounded,
+explicit blind spots were acceptable during exploration. Broad coverage loss,
+sampling, timing-dependent behavior, or load-order-dependent behavior were not.
+
+## Benchmark contract
+
+The benchmark runs 1,000 Rails examples. Its correctness gate requires all
+19,080 assertions, 1,000 coverage events, and the exact expected file
+associations before any timing is accepted. The baseline executes normal test
+tracing without TIA code coverage; the instrumented variant adds normal TIA
+test-level coverage.
+
+The repository root is invariant for the lifetime of the process and never
+changes between coverage events. Coverage serialization may therefore capture
+and reuse that root instead of repeatedly resolving it.
+
+DDCov supports exactly one active instance and one collector per process.
+Instances may be reused or activated sequentially, including from different
+threads. An overlapping start fails deterministically.
+
+## Retained changes
+
+The final candidate keeps only optimizations that preserve the existing
+coverage event sources and pass the cross-workload guards:
+
+- Register the NEWOBJ callback as a raw VM event hook, avoiding the TracePoint
+  wrapper. The callback introduces no general Ruby API calls; `rb_mod_name` is
+  the explicitly permitted safe lookup.
+- Normalize, deduplicate, and MessagePack coverage filenames in one native
+  operation. The common all-absolute shape writes suffix bytes relative to the
+  immutable repository root without allocating relative Strings. Unsupported
+  shapes fall back before the packer is mutated.
+- Use `Zlib::BEST_SPEED` for CI test-coverage payloads only. Other request types
+  retain their existing compression behavior.
+- Enforce and document the one-active-DDCov-collector contract.
+
+Native and Ruby serialization were verified byte-for-byte for native paths,
+relative and absolute custom paths, duplicates, UTF-8, binary filenames,
+long filenames, and arrays requiring non-fixarray MessagePack headers.
+
+## Rejected event architecture
+
+A target-bound CALL/B_CALL/LINE architecture replaced the global multi-thread
+line hook and produced the best Rails point estimate. It reached 33.64%
+overhead while preserving the Rails stress gate, and a later combined candidate
+reached an inconclusive 29.79% point estimate.
+
+The same architecture was disastrous on the required full
+`ruby-rubocop-coverage` guard. Its functional workload exceeded ten minutes at
+approximately 99% CPU, compared with roughly three minutes on current main.
+Checkpoint isolation identified the target-event commit as the regression
+boundary. The architecture was therefore rejected in full despite its Rails
+result. No target collector, target TracePoint, or CALL/B_CALL replacement is
+present in the final candidate.
+
+This is the reason the 32% Rails target is considered unreachable within the
+accepted correctness and cross-workload constraints.
+
+## Final validation
+
+### Rails TIA stress
+
+- Status: passed
+- Correctness: all 19,080 assertions passed
+- Protocol: 1 warmup pair, 4 measured pairs
+- Baseline median: 34,700.27 ms
+- Instrumented median: 52,570.26 ms
+- Final overhead: **51.50%**
+- Artifact:
+  `/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260815-024102.326825000-ruby-rails-tia-stress-test-level-p57606-1a7d52c1274ee45d/result.json`
+
+All timed children exited successfully. There was no macOS-sleep gap. The
+fourth pair was slower in both variants and had proportionally high user CPU;
+the reported median is determined by the stable middle samples.
+
+### RuboCop coverage guard
+
+- Current main: 52.17% overhead
+- Final candidate: 53.45% overhead
+- Correctness: all 37 assertions passed for both
+- Runtime multiplier change: +0.02%
+- 95% interval: -2.65% to +3.40%
+- Verdict: inconclusive; no practical regression detected
+
+Reference:
+`/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260814-231143.560352000-ruby-rubocop-coverage-p65216-ad32ead4baa68798/result.json`
+
+Candidate:
+`/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260815-003007.666284000-ruby-rubocop-coverage-p21376-181ce166cb319fca/result.json`
+
+### Quotes Rails guard
+
+- Current main: 7.65% overhead
+- Final candidate: 8.35% overhead
+- Correctness: all 36 assertions passed for both
+- Runtime multiplier change: -0.50%
+- 95% interval: -13.62% to +11.32%
+- Verdict: inconclusive; no practical regression detected
+
+Reference:
+`/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260815-010349.126843000-ruby-quotes-rails-p39475-cbe2424c086ea8ae/result.json`
+
+Candidate:
+`/Users/andrey.marchenko/p/shepherd/benchmark-data/runs/20260815-023112.785462000-ruby-quotes-rails-p49574-17567978fd9d0b18/result.json`
+
+The long gap in the current-main Quotes run occurred between timed child
+processes because macOS slept. It is not included in any recorded duration.
+
+## Decision
+
+Stop the loop and ship the safe subset. It reduces deterministic tracer work
+without changing the coverage event model, keeps the exact Rails correctness
+gate green, and has no detected practical regression on RuboCop coverage or
+Quotes Rails. The 32% target is explicitly not claimed.

--- a/ext/datadog_ci_native/datadog_cov.c
+++ b/ext/datadog_ci_native/datadog_cov.c
@@ -1,5 +1,6 @@
 #include <ruby.h>
 #include <ruby/debug.h>
+#include <ruby/encoding.h>
 #include <ruby/st.h>
 
 #include <stdbool.h>
@@ -30,8 +31,23 @@
 // threading modes
 enum threading_mode { single, multi };
 
+// DDCov supports exactly one active collector per process. This process-wide
+// invariant keeps coverage ownership deterministic and avoids callback fan-out.
+static VALUE active_collector = Qnil;
+
+struct packed_files_context {
+  VALUE root;
+  VALUE seen;
+  VALUE packed;
+  long root_len;
+  uint32_t files_count;
+  bool direct_absolute;
+  bool supported;
+};
+
+
 // functions declarations
-static void on_newobj_event(VALUE tracepoint_data, void *data);
+static void on_newobj_event(VALUE self, const rb_trace_arg_t *tracearg);
 
 static int mark_key_for_gc_i(st_data_t key, st_data_t _value, st_data_t _data) {
   VALUE klass = (VALUE)key;
@@ -88,7 +104,8 @@ struct dd_cov_data {
   // contain any methods that could be covered by line tracepoint.
   //
   // Allocation tracing works only in multi threaded mode.
-  VALUE object_allocation_tracepoint;
+  bool allocation_tracing_enabled;
+  bool allocation_hook_active;
   st_table *klasses_table; // { (VALUE) -> int } hashmap with class names that
                            // were covered by allocation during the test run
   VALUE last_allocated_klass;
@@ -101,7 +118,6 @@ static void dd_cov_mark(void *ptr) {
   struct dd_cov_data *dd_cov_data = ptr;
   rb_gc_mark_movable(dd_cov_data->impacted_files);
   rb_gc_mark_movable(dd_cov_data->th_covered);
-  rb_gc_mark_movable(dd_cov_data->object_allocation_tracepoint);
 
   if (dd_cov_data->last_filename != Qnil) {
     rb_gc_mark(dd_cov_data->last_filename);
@@ -135,8 +151,6 @@ static void dd_cov_compact(void *ptr) {
   struct dd_cov_data *dd_cov_data = ptr;
   dd_cov_data->impacted_files = rb_gc_location(dd_cov_data->impacted_files);
   dd_cov_data->th_covered = rb_gc_location(dd_cov_data->th_covered);
-  dd_cov_data->object_allocation_tracepoint =
-      rb_gc_location(dd_cov_data->object_allocation_tracepoint);
   // keys for dd_cov_data->klasses_table are not moved by GC, so we don't need
   // to update them
 }
@@ -165,7 +179,8 @@ static VALUE dd_cov_allocate(VALUE klass) {
   }
   dd_cov_data->threading_mode = multi;
 
-  dd_cov_data->object_allocation_tracepoint = Qnil;
+  dd_cov_data->allocation_tracing_enabled = false;
+  dd_cov_data->allocation_hook_active = false;
   dd_cov_data->last_allocated_klass = Qnil;
   memset(dd_cov_data->seen_allocated_klasses, 0,
          sizeof(dd_cov_data->seen_allocated_klasses));
@@ -175,6 +190,255 @@ static VALUE dd_cov_allocate(VALUE klass) {
   dd_cov_data->klass_files_cache_size = 0;
 
   return dd_cov;
+}
+
+static bool string_bytes_are_ascii(VALUE string) {
+  const unsigned char *ptr = (const unsigned char *)RSTRING_PTR(string);
+  long len = RSTRING_LEN(string);
+  for (long i = 0; i < len; i++) {
+    if ((ptr[i] & 0x80U) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void packed_files_append_u16(VALUE packed, uint16_t value) {
+  unsigned char bytes[2] = {(unsigned char)(value >> 8),
+                            (unsigned char)value};
+  rb_str_cat(packed, (const char *)bytes, 2);
+}
+
+static void packed_files_append_u32(VALUE packed, uint32_t value) {
+  unsigned char bytes[4] = {
+      (unsigned char)(value >> 24), (unsigned char)(value >> 16),
+      (unsigned char)(value >> 8), (unsigned char)value};
+  rb_str_cat(packed, (const char *)bytes, 4);
+}
+
+static void packed_files_append_string_header(VALUE packed, uint32_t len,
+                                              bool binary) {
+  unsigned char byte;
+  if (binary) {
+    if (len < 256) {
+      byte = 0xc4;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      byte = (unsigned char)len;
+      rb_str_cat(packed, (const char *)&byte, 1);
+    } else if (len < 65536) {
+      byte = 0xc5;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      packed_files_append_u16(packed, (uint16_t)len);
+    } else {
+      byte = 0xc6;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      packed_files_append_u32(packed, len);
+    }
+  } else if (len < 32) {
+    byte = (unsigned char)(0xa0U | len);
+    rb_str_cat(packed, (const char *)&byte, 1);
+  } else if (len < 256) {
+    byte = 0xd9;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    byte = (unsigned char)len;
+    rb_str_cat(packed, (const char *)&byte, 1);
+  } else if (len < 65536) {
+    byte = 0xda;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    packed_files_append_u16(packed, (uint16_t)len);
+  } else {
+    byte = 0xdb;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    packed_files_append_u32(packed, len);
+  }
+}
+
+static bool packed_files_append_entry(struct packed_files_context *context,
+                                      VALUE file, bool custom_file) {
+  if (file == Qnil && !custom_file) {
+    return true;
+  }
+  if (!RB_TYPE_P(file, T_STRING) || rb_obj_class(file) != rb_cString) {
+    context->supported = false;
+    return false;
+  }
+
+  VALUE relative_file = file;
+  VALUE dedup_file = file;
+  const char *relative_ptr = RSTRING_PTR(file);
+  long relative_len = RSTRING_LEN(file);
+#ifdef _WIN32
+  context->supported = false;
+  return false;
+#else
+  const char *file_ptr = RSTRING_PTR(file);
+  long file_len = RSTRING_LEN(file);
+  bool absolute = file_len > 0 && file_ptr[0] == '/';
+  if (absolute) {
+    if (file_len <= context->root_len ||
+        memcmp(file_ptr, RSTRING_PTR(context->root),
+               (size_t)context->root_len) != 0 ||
+        file_ptr[context->root_len] != '/') {
+      // Absolute custom files outside the immutable repository root are
+      // ignored. Native coverage is already filtered by the same root.
+      return true;
+    }
+
+    relative_len = file_len - context->root_len - 1;
+    if (relative_len == 0) {
+      return true;
+    }
+    if (context->direct_absolute) {
+      relative_ptr = file_ptr + context->root_len + 1;
+    } else {
+      relative_file = rb_str_substr(file, context->root_len + 1, file_len);
+      dedup_file = relative_file;
+      relative_ptr = RSTRING_PTR(relative_file);
+    }
+  } else if (!custom_file) {
+    // Relative native paths depend on cwd-to-root Pathname semantics. They are
+    // uncommon and retain the authoritative Ruby fallback.
+    context->supported = false;
+    return false;
+  }
+#endif
+
+  if (relative_len == 0) {
+    return true;
+  }
+  if (rb_hash_lookup2(context->seen, dedup_file, Qundef) != Qundef) {
+    return true;
+  }
+  rb_hash_aset(context->seen, dedup_file, Qtrue);
+
+  int encoding_index = rb_enc_get_index(relative_file);
+  bool binary = encoding_index == rb_ascii8bit_encindex();
+  if (!binary && encoding_index != rb_utf8_encindex() &&
+      encoding_index != rb_usascii_encindex() &&
+      !string_bytes_are_ascii(relative_file)) {
+    context->supported = false;
+    return false;
+  }
+
+  if (relative_len > UINT32_MAX) {
+    rb_raise(rb_eArgError,
+             "size of coverage filename is too long to pack: %lu bytes",
+             (unsigned long)relative_len);
+  }
+
+  static const unsigned char filename_entry_prefix[] = {
+      0x81, 0xa8, 'f', 'i', 'l', 'e', 'n', 'a', 'm', 'e'};
+  rb_str_cat(context->packed, (const char *)filename_entry_prefix,
+             sizeof(filename_entry_prefix));
+  packed_files_append_string_header(context->packed, (uint32_t)relative_len,
+                                    binary);
+  rb_str_cat(context->packed, relative_ptr, relative_len);
+  context->files_count++;
+  return true;
+}
+
+static int pack_native_file_i(VALUE file, VALUE _value, VALUE context_value) {
+  struct packed_files_context *context =
+      (struct packed_files_context *)context_value;
+  return packed_files_append_entry(context, file, false) ? ST_CONTINUE
+                                                         : ST_STOP;
+}
+
+static bool packed_file_is_absolute(VALUE file, bool custom_file) {
+#ifdef _WIN32
+  return false;
+#else
+  if (file == Qnil && !custom_file) {
+    return true;
+  }
+  return RB_TYPE_P(file, T_STRING) && rb_obj_class(file) == rb_cString &&
+         RSTRING_LEN(file) > 0 && RSTRING_PTR(file)[0] == '/';
+#endif
+}
+
+static int detect_absolute_native_file_i(VALUE file, VALUE _value,
+                                         VALUE all_absolute_value) {
+  bool *all_absolute = (bool *)all_absolute_value;
+  if (!packed_file_is_absolute(file, false)) {
+    *all_absolute = false;
+    return ST_STOP;
+  }
+  return ST_CONTINUE;
+}
+
+static void
+packed_files_write_array_header(struct packed_files_context *context) {
+  unsigned char header[5];
+  size_t header_len;
+  if (context->files_count < 16) {
+    header[0] = (unsigned char)(0x90U | context->files_count);
+    header_len = 1;
+  } else if (context->files_count < 65536) {
+    header[0] = 0xdc;
+    header[1] = (unsigned char)(context->files_count >> 8);
+    header[2] = (unsigned char)context->files_count;
+    header_len = 3;
+  } else {
+    header[0] = 0xdd;
+    header[1] = (unsigned char)(context->files_count >> 24);
+    header[2] = (unsigned char)(context->files_count >> 16);
+    header[3] = (unsigned char)(context->files_count >> 8);
+    header[4] = (unsigned char)context->files_count;
+    header_len = 5;
+  }
+
+  long body_len = RSTRING_LEN(context->packed) - 5;
+  char *packed_ptr = RSTRING_PTR(context->packed);
+  if (header_len != 5) {
+    memmove(packed_ptr + header_len, packed_ptr + 5, (size_t)body_len);
+    rb_str_resize(context->packed, body_len + (long)header_len);
+    packed_ptr = RSTRING_PTR(context->packed);
+  }
+  memcpy(packed_ptr, header, header_len);
+}
+
+static VALUE dd_cov_pack_coverage_files(VALUE klass, VALUE coverage,
+                                        VALUE custom_files, VALUE root) {
+  Check_Type(coverage, T_HASH);
+  Check_Type(custom_files, T_ARRAY);
+  if (!RB_TYPE_P(root, T_STRING) || rb_obj_class(root) != rb_cString ||
+      RSTRING_LEN(root) == 0 || !string_bytes_are_ascii(root)) {
+    return Qnil;
+  }
+
+  bool all_absolute = true;
+  rb_hash_foreach(coverage, detect_absolute_native_file_i,
+                  (VALUE)&all_absolute);
+  long custom_files_len = RARRAY_LEN(custom_files);
+  for (long i = 0; all_absolute && i < custom_files_len; i++) {
+    all_absolute =
+        packed_file_is_absolute(rb_ary_entry(custom_files, i), true);
+  }
+
+  struct packed_files_context context = {
+      .root = root,
+      .seen = rb_hash_new(),
+      .packed = rb_str_buf_new(4096),
+      .root_len = RSTRING_LEN(root),
+      .files_count = 0,
+      .direct_absolute = all_absolute,
+      .supported = true};
+  rb_str_resize(context.packed, 5);
+
+  rb_hash_foreach(coverage, pack_native_file_i, (VALUE)&context);
+  if (!context.supported) {
+    return Qnil;
+  }
+
+  for (long i = 0; i < custom_files_len; i++) {
+    if (!packed_files_append_entry(&context, rb_ary_entry(custom_files, i),
+                                   true)) {
+      return Qnil;
+    }
+  }
+
+  packed_files_write_array_header(&context);
+  return context.packed;
 }
 
 // Helper functions (available in C only)
@@ -312,9 +576,8 @@ static int each_instantiated_klass(st_data_t key, st_data_t _value,
 
 // Executed on RUBY_INTERNAL_EVENT_NEWOBJ event and captures the source file for
 // the allocated object's class.
-static void on_newobj_event(VALUE tracepoint_data, void *data) {
-  rb_trace_arg_t *tracearg = rb_tracearg_from_tracepoint(tracepoint_data);
-  VALUE new_object = rb_tracearg_object(tracearg);
+static void on_newobj_event(VALUE self, const rb_trace_arg_t *tracearg) {
+  VALUE new_object = rb_tracearg_object((rb_trace_arg_t *)tracearg);
 
   // To keep things fast and practical, we only care about objects that extend
   // either Object or Struct.
@@ -328,7 +591,7 @@ static void on_newobj_event(VALUE tracepoint_data, void *data) {
     return;
   }
 
-  struct dd_cov_data *dd_cov_data = (struct dd_cov_data *)data;
+  struct dd_cov_data *dd_cov_data = RTYPEDDATA_DATA(self);
 
   if (dd_cov_data->last_allocated_klass == klass) {
     return;
@@ -351,10 +614,7 @@ static void on_newobj_event(VALUE tracepoint_data, void *data) {
     return;
   }
 
-  // Skip anonymous classes starting with "#<Class".
-  // it allows us to skip the source location lookup that will always fail
-  //
-  // rb_mod_name returns nil for anonymous classes
+  // rb_mod_name returns nil for anonymous classes and is safe during NEWOBJ.
   if (rb_mod_name(klass) == Qnil) {
     return;
   }
@@ -422,8 +682,7 @@ static VALUE dd_cov_initialize(int argc, VALUE *argv, VALUE self) {
   }
 
   if (rb_allocation_tracing_enabled == Qtrue) {
-    dd_cov_data->object_allocation_tracepoint = rb_tracepoint_new(
-        Qnil, RUBY_INTERNAL_EVENT_NEWOBJ, on_newobj_event, (void *)dd_cov_data);
+    dd_cov_data->allocation_tracing_enabled = true;
   }
 
   return Qnil;
@@ -439,6 +698,15 @@ static VALUE dd_cov_start(VALUE self) {
     rb_raise(rb_eRuntimeError, "root is required");
   }
 
+  if (active_collector == self) {
+    return self;
+  }
+  if (active_collector != Qnil) {
+    rb_raise(rb_eRuntimeError,
+             "only one DDCov collector can be active at a time");
+  }
+  active_collector = self;
+
   // add line tracepoint
   if (dd_cov_data->threading_mode == single) {
     VALUE thval = rb_thread_current();
@@ -448,9 +716,17 @@ static VALUE dd_cov_start(VALUE self) {
     rb_add_event_hook(on_line_event, RUBY_EVENT_LINE, self);
   }
 
-  // add object allocation tracepoint
-  if (dd_cov_data->object_allocation_tracepoint != Qnil) {
-    rb_tracepoint_enable(dd_cov_data->object_allocation_tracepoint);
+  // Register the same raw hook that TracePoint would wrap, but dispatch
+  // directly to the allocation callback. NEWOBJ permits no general Ruby API;
+  // the callback is limited to the existing event-safe accessors plus the
+  // explicitly safe rb_mod_name lookup.
+  if (dd_cov_data->allocation_tracing_enabled &&
+      !dd_cov_data->allocation_hook_active) {
+    rb_add_event_hook2((rb_event_hook_func_t)on_newobj_event,
+                       RUBY_INTERNAL_EVENT_NEWOBJ, self,
+                       RUBY_EVENT_HOOK_FLAG_SAFE |
+                           RUBY_EVENT_HOOK_FLAG_RAW_ARG);
+    dd_cov_data->allocation_hook_active = true;
   }
 
   return self;
@@ -462,6 +738,12 @@ static VALUE dd_cov_stop(VALUE self) {
   struct dd_cov_data *dd_cov_data;
   TypedData_Get_Struct(self, struct dd_cov_data, &dd_cov_data_type,
                        dd_cov_data);
+
+  if (active_collector != self) {
+    VALUE inactive_result = dd_cov_data->impacted_files;
+    dd_cov_data->impacted_files = rb_hash_new();
+    return inactive_result;
+  }
 
   // stop line tracepoint
   if (dd_cov_data->threading_mode == single) {
@@ -476,9 +758,11 @@ static VALUE dd_cov_stop(VALUE self) {
     rb_remove_event_hook(on_line_event);
   }
 
-  // stop object allocation tracepoint
-  if (dd_cov_data->object_allocation_tracepoint != Qnil) {
-    rb_tracepoint_disable(dd_cov_data->object_allocation_tracepoint);
+  // There is exactly one active collector, so this removes the process's only
+  // allocation hook.
+  if (dd_cov_data->allocation_hook_active) {
+    rb_remove_event_hook_with_data((rb_event_hook_func_t)on_newobj_event, self);
+    dd_cov_data->allocation_hook_active = false;
   }
 
   // process classes covered by allocation tracing
@@ -497,6 +781,8 @@ static VALUE dd_cov_stop(VALUE self) {
     dd_cov_data->seen_filenames[i] = Qnil;
   }
 
+  active_collector = Qnil;
+
   return res;
 }
 
@@ -507,9 +793,13 @@ void Init_datadog_cov(void) {
   VALUE mCoverage = rb_define_module_under(mTestImpactAnalysis, "Coverage");
   VALUE cDatadogCov = rb_define_class_under(mCoverage, "DDCov", rb_cObject);
 
+  rb_global_variable(&active_collector);
+
   rb_define_alloc_func(cDatadogCov, dd_cov_allocate);
 
   rb_define_method(cDatadogCov, "initialize", dd_cov_initialize, -1);
   rb_define_method(cDatadogCov, "start", dd_cov_start, 0);
   rb_define_method(cDatadogCov, "stop", dd_cov_stop, 0);
+  rb_define_singleton_method(cDatadogCov, "pack_coverage_files",
+                             dd_cov_pack_coverage_files, 3);
 }

--- a/lib/datadog/ci/test_impact_analysis/coverage/ddcov.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/ddcov.rb
@@ -4,7 +4,12 @@ module Datadog
   module CI
     module TestImpactAnalysis
       module Coverage
-        # Placeholder for code coverage collection
+        # Native test-impact coverage collector.
+        #
+        # Only one DDCov instance may collect coverage in a process at a time.
+        # Collectors may be reused or activated sequentially, but starting a
+        # second collector while another one is active raises RuntimeError.
+        #
         # Implementation in ext/datadog_ci_native/datadog_cov.c
         class DDCov
         end

--- a/lib/datadog/ci/test_impact_analysis/coverage/event.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/event.rb
@@ -58,12 +58,7 @@ module Datadog
             end
 
             packer.write("files")
-            packer.write_array_header(@files.size)
-            @files.each do |filename|
-              packer.write_map_header(1)
-              packer.write("filename")
-              packer.write(filename)
-            end
+            @files.write_to(packer)
           end
 
           def to_s

--- a/lib/datadog/ci/test_impact_analysis/coverage/files.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/files.rb
@@ -16,6 +16,10 @@ module Datadog
           def initialize(coverage, custom_impacted_files = EMPTY_FILES)
             @coverage = coverage
             @custom_impacted_files = custom_impacted_files
+            # The repository root is a process invariant between coverage
+            # events. Capture it once so native normalization can reuse the
+            # same exact boundary for this event without repeated lookups.
+            @root = Git::LocalRepository.root
             @normalized_files = nil
           end
 
@@ -25,6 +29,32 @@ module Datadog
 
           def size
             normalized_files.size
+          end
+
+          # Writes the complete MessagePack files array. The native fast path
+          # combines absolute-path classification, immutable-root slicing,
+          # stable deduplication, and filename-entry packing. Any shape it does
+          # not support falls back before writing bytes.
+          def write_to(packer)
+            if defined?(DDCov) &&
+                packer.respond_to?(:compatibility_mode?) &&
+                !packer.compatibility_mode? &&
+                (packed_files = DDCov.pack_coverage_files(
+                  @coverage,
+                  @custom_impacted_files,
+                  @root
+                ))
+              packer.buffer.write(packed_files)
+              return packer
+            end
+
+            packer.write_array_header(size)
+            each do |filename|
+              packer.write_map_header(1)
+              packer.write("filename")
+              packer.write(filename)
+            end
+            packer
           end
 
           # Returns a readable view while preserving the paths supplied by

--- a/lib/datadog/ci/transport/api/agentless.rb
+++ b/lib/datadog/ci/transport/api/agentless.rb
@@ -54,7 +54,14 @@ module Datadog
           def citestcov_request(path:, payload:, headers: {}, verb: "post")
             super
 
-            perform_request(@citestcov_http, path: path, payload: @citestcov_payload, headers: headers, verb: verb)
+            perform_request(
+              @citestcov_http,
+              path: path,
+              payload: @citestcov_payload,
+              headers: headers,
+              verb: verb,
+              compression_level: Zlib::BEST_SPEED
+            )
           end
 
           def logs_intake_request(path:, payload:, headers: {}, verb: "post")
@@ -71,14 +78,24 @@ module Datadog
 
           private
 
-          def perform_request(http_client, path:, payload:, headers:, verb:, accept_compressed_response: false)
-            response = http_client.request(
+          def perform_request(
+            http_client,
+            path:,
+            payload:,
+            headers:,
+            verb:,
+            accept_compressed_response: false,
+            compression_level: nil
+          )
+            request_options = {
               path: path,
               payload: payload,
               headers: headers_with_default(headers),
               verb: verb,
               accept_compressed_response: accept_compressed_response
-            )
+            }
+            request_options[:compression_level] = compression_level if compression_level
+            response = http_client.request(**request_options)
 
             log_api_key_error(response)
 

--- a/lib/datadog/ci/transport/api/evp_proxy.rb
+++ b/lib/datadog/ci/transport/api/evp_proxy.rb
@@ -43,7 +43,14 @@ module Datadog
 
             headers[Ext::Transport::HEADER_EVP_SUBDOMAIN] = Ext::Transport::TEST_COVERAGE_INTAKE_HOST_PREFIX
 
-            perform_request(@agent_intake_http, path: path, payload: @citestcov_payload, headers: headers, verb: verb)
+            perform_request(
+              @agent_intake_http,
+              path: path,
+              payload: @citestcov_payload,
+              headers: headers,
+              verb: verb,
+              compression_level: Zlib::BEST_SPEED
+            )
           end
 
           def logs_intake_request(path:, payload:, headers: {}, verb: "post")
@@ -60,13 +67,22 @@ module Datadog
 
           private
 
-          def perform_request(http_client, path:, payload:, headers:, verb:)
-            http_client.request(
+          def perform_request(
+            http_client,
+            path:,
+            payload:,
+            headers:,
+            verb:,
+            compression_level: nil
+          )
+            request_options = {
               path: path_with_prefix(path),
               payload: payload,
               headers: headers_with_default(headers),
               verb: verb
-            )
+            }
+            request_options[:compression_level] = compression_level if compression_level
+            http_client.request(**request_options)
           end
 
           def path_with_prefix(path)

--- a/lib/datadog/ci/transport/gzip.rb
+++ b/lib/datadog/ci/transport/gzip.rb
@@ -9,9 +9,9 @@ module Datadog
       module Gzip
         module_function
 
-        def compress(input)
+        def compress(input, level: Zlib::DEFAULT_COMPRESSION)
           sio = StringIO.new
-          gzip_writer = Zlib::GzipWriter.new(sio, Zlib::DEFAULT_COMPRESSION, Zlib::DEFAULT_STRATEGY)
+          gzip_writer = Zlib::GzipWriter.new(sio, level, Zlib::DEFAULT_STRATEGY)
           gzip_writer << input
           gzip_writer.close
           sio.string

--- a/lib/datadog/ci/transport/http.rb
+++ b/lib/datadog/ci/transport/http.rb
@@ -55,14 +55,15 @@ module Datadog
           verb: "post",
           retries: MAX_RETRIES,
           backoff: INITIAL_BACKOFF,
-          accept_compressed_response: false
+          accept_compressed_response: false,
+          compression_level: Zlib::DEFAULT_COMPRESSION
         )
           response = nil
 
           duration_ms = Core::Utils::Time.measure(:float_millisecond) do
             if compress
               headers[Ext::Transport::HEADER_CONTENT_ENCODING] = Ext::Transport::CONTENT_ENCODING_GZIP
-              payload = Gzip.compress(payload)
+              payload = Gzip.compress(payload, level: compression_level)
             end
 
             if accept_compressed_response

--- a/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
@@ -340,6 +340,71 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         )
       end
     end
+
+    it "matches legacy MessagePack bytes for native and custom paths" do
+      root = Datadog::CI::Git::LocalRepository.root
+      absolute_native = File.join(root, "app/models/user.rb")
+      binary_file = "frontend/binary-\xFF.js".b
+      long_file = "frontend/#{"x" * 300}.js"
+      custom_files = [
+        "frontend/app.js",
+        absolute_native,
+        "frontend/app.js",
+        "frontend/emoji-❤️.js",
+        binary_file,
+        long_file
+      ] + Array.new(20) { |index| "frontend/generated-#{index}.js" }
+      coverage = {absolute_native => true}
+      files = Datadog::CI::TestImpactAnalysis::Coverage::Files.new(coverage, custom_files)
+      event = described_class.new(
+        test_id: test_id,
+        test_suite_id: test_suite_id,
+        test_session_id: test_session_id,
+        files: files
+      )
+      ddcov = Datadog::CI::TestImpactAnalysis::Coverage::DDCov
+
+      expect(ddcov.pack_coverage_files(coverage, custom_files, root)).to be_a(String)
+
+      encode = lambda do
+        packer = MessagePack::Packer.new
+        event.to_msgpack(packer)
+        packer.to_s
+      end
+      native_bytes = encode.call
+      allow(ddcov).to receive(:pack_coverage_files).and_return(nil)
+
+      expect(native_bytes).to eq(encode.call)
+    end
+
+    it "matches legacy MessagePack bytes for all-absolute paths" do
+      root = Datadog::CI::Git::LocalRepository.root
+      absolute_files = Array.new(20) do |index|
+        File.join(root, "app/generated/model-#{index}.rb")
+      end
+      coverage = absolute_files.first(10).to_h { |file| [file, true] }
+      custom_files = absolute_files.drop(5) + [absolute_files.fetch(5)]
+      files = Datadog::CI::TestImpactAnalysis::Coverage::Files.new(coverage, custom_files)
+      event = described_class.new(
+        test_id: test_id,
+        test_suite_id: test_suite_id,
+        test_session_id: test_session_id,
+        files: files
+      )
+      ddcov = Datadog::CI::TestImpactAnalysis::Coverage::DDCov
+
+      expect(ddcov.pack_coverage_files(coverage, custom_files, root)).to be_a(String)
+
+      encode = lambda do
+        packer = MessagePack::Packer.new
+        event.to_msgpack(packer)
+        packer.to_s
+      end
+      native_bytes = encode.call
+      allow(ddcov).to receive(:pack_coverage_files).and_return(nil)
+
+      expect(native_bytes).to eq(encode.call)
+    end
   end
 
   describe "#pretty_inspect" do

--- a/spec/datadog/ci/transport/api/agentless_spec.rb
+++ b/spec/datadog/ci/transport/api/agentless_spec.rb
@@ -286,6 +286,7 @@ RSpec.describe Datadog::CI::Transport::Api::Agentless do
           expect(args[:headers]).to eq(expected_headers)
           expect(args[:payload]).to eq(expected_payload)
           expect(args[:accept_compressed_response]).to eq(false)
+          expect(args[:compression_level]).to eq(Zlib::BEST_SPEED)
         end
       end
     end

--- a/spec/datadog/ci/transport/api/evp_proxy_spec.rb
+++ b/spec/datadog/ci/transport/api/evp_proxy_spec.rb
@@ -188,7 +188,8 @@ RSpec.describe Datadog::CI::Transport::Api::EvpProxy do
           path: "/evp_proxy/v2/path",
           payload: expected_payload,
           verb: "post",
-          headers: citestcov_headers
+          headers: citestcov_headers,
+          compression_level: Zlib::BEST_SPEED
         )
 
         subject.citestcov_request(path: "/path", payload: "payload")

--- a/spec/datadog/ci/transport/gzip_spec.rb
+++ b/spec/datadog/ci/transport/gzip_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Datadog::CI::Transport::Gzip do
         expect(gzip.read).to eq(input)
       end
     end
+
+    it "supports an explicit compression level" do
+      compressed = described_class.compress(input, level: Zlib::BEST_SPEED)
+
+      expect(described_class.decompress(compressed)).to eq(input)
+    end
   end
 
   describe ".decompress" do

--- a/spec/ddcov/ddcov_spec.rb
+++ b/spec/ddcov/ddcov_spec.rb
@@ -268,47 +268,42 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::DDCov do
           let(:threading_mode) { :single }
           let(:use_allocation_tracing) { false }
 
-          it "collects coverage for each thread separately" do
-            t1_queue = Thread::Queue.new
-            t2_queue = Thread::Queue.new
+          it "rejects overlap and preserves sequential per-thread coverage" do
+            first_collector = described_class.new(
+              root: root,
+              threading_mode: threading_mode,
+              use_allocation_tracing: use_allocation_tracing
+            )
+            second_collector = described_class.new(
+              root: root,
+              threading_mode: threading_mode,
+              use_allocation_tracing: use_allocation_tracing
+            )
 
-            t1 = Thread.new do
-              cov = thread_local_cov
-              cov.start
+            first_collector.start
+            overlap_error = Thread.new do
+              second_collector.start
+            rescue => e
+              e
+            end.value
 
-              t1_queue << :ready
-              expect(t2_queue.pop).to be(:ready)
+            expect(overlap_error).to be_a(RuntimeError)
+            expect(overlap_error.message).to eq("only one DDCov collector can be active at a time")
+            expect(calculator.add(1, 2)).to eq(3)
+            expect(calculator.multiply(1, 2)).to eq(2)
+            first_coverage = first_collector.stop
 
-              expect(calculator.add(1, 2)).to eq(3)
-              expect(calculator.multiply(1, 2)).to eq(2)
-
-              t1_queue << :done
-              expect(t2_queue.pop).to be :done
-
-              coverage = cov.stop
-              expect(coverage.size).to eq(2)
-              expect(coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
-              expect(coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
-            end
-
-            t2 = Thread.new do
-              cov = thread_local_cov
-              cov.start
-
-              t2_queue << :ready
-              expect(t1_queue.pop).to be(:ready)
-
+            second_coverage = Thread.new do
+              second_collector.start
               expect(calculator.subtract(1, 2)).to eq(-1)
+              second_collector.stop
+            end.value
 
-              t2_queue << :done
-              expect(t1_queue.pop).to be :done
-
-              coverage = cov.stop
-              expect(coverage.size).to eq(1)
-              expect(coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
-            end
-
-            [t1, t2].each(&:join)
+            expect(first_coverage.size).to eq(2)
+            expect(first_coverage.keys).to include(absolute_path("calculator/operations/add.rb"))
+            expect(first_coverage.keys).to include(absolute_path("calculator/operations/multiply.rb"))
+            expect(second_coverage.size).to eq(1)
+            expect(second_coverage.keys).to include(absolute_path("calculator/operations/subtract.rb"))
           end
 
           context "when allocation tracing is enabled" do


### PR DESCRIPTION
## Summary

- bypass the Ruby TracePoint wrapper for NEWOBJ while preserving the same allocation event and exact class coverage
- normalize, deduplicate, and MessagePack coverage filenames natively using the process-stable repository root, with an exact Ruby fallback for unsupported shapes
- use best-speed gzip for CI test-coverage payloads only
- enforce and document the supported one-active-DDCov-instance/one-collector-per-process contract

Correctness is the primary constraint. The NEWOBJ callback adds no general Ruby API calls; `rb_mod_name` is the explicitly permitted safe lookup. Native serialization is byte-equivalent to the existing Ruby path for native/custom, relative/absolute, UTF-8, binary, duplicate, long, and large-array inputs.

The faster target-bound CALL/B_CALL/LINE design is deliberately excluded. It preserved the Rails stress gate but made the full RuboCop coverage workload exceed ten minutes at approximately 99% CPU. The performance record documents that rejection and the final 51.50% Rails result; this PR does not claim the original 32% target.

## Validation

- full `spec:main`: 2,323 examples, 0 failures, 1 expected Linux-only pending example
- focused DDCov/Event/Gzip/Agentless/EVP specs: 100 examples, 0 failures
- changed Ruby/spec files: StandardRB passed
- native extension: compiled on Ruby 2.7.8, 3.4.7, and 4.0.1
- Rails TIA stress gate: all 19,080 assertions passed

## Benchmarks

| Benchmark | Current main | Candidate | Result |
| --- | ---: | ---: | --- |
| `ruby-rubocop-coverage` | 52.17% overhead | 53.45% overhead | Inconclusive; runtime multiplier +0.02%, 95% CI [-2.65%, +3.40%], no practical regression detected |
| `ruby-quotes-rails` | 7.65% overhead | 8.35% overhead | Inconclusive; runtime multiplier -0.50%, 95% CI [-13.62%, +11.32%], no practical regression detected |
| `ruby-rails-tia-stress-test-level` | — | **51.50% overhead** | 34,700.27 ms uninstrumented median; 52,570.26 ms TIA median; 1 warmup and 4 measured pairs |

The final Rails run had no macOS-sleep gap. Its slower fourth pair had proportionally high user CPU in both variants, and the reported median is determined by the stable middle samples.
