### PR TITLE
[SDTEST-3945] Optimize bulk file serialization

### DIFF
--- a/ext/datadog_ci_native/ci.c
+++ b/ext/datadog_ci_native/ci.c
@@ -1,10 +1,14 @@
 #include "datadog_cov.h"
 #include "datadog_method_inspect.h"
+#include "file_serialization.h"
 #include "iseq_collector.h"
 
 void Init_datadog_ci_native(void) {
   // Coverage::DDCov
   Init_datadog_cov();
+
+  // FileSerialization
+  Init_file_serialization();
 
   // SourceCode
   Init_datadog_method_inspect();

--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -1,0 +1,282 @@
+#include <ruby.h>
+#include <ruby/encoding.h>
+#include <ruby/st.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "file_serialization.h"
+
+// Bulk file serialization is independent from coverage collection. It packs
+// large file lists without building normalized intermediate Ruby collections.
+
+struct packed_files_context {
+  VALUE root;
+  VALUE seen;
+  VALUE packed;
+  long root_len;
+  uint32_t files_count;
+  bool direct_absolute;
+  bool supported;
+};
+
+static bool string_bytes_are_ascii(VALUE string) {
+  const unsigned char *ptr = (const unsigned char *)RSTRING_PTR(string);
+  long len = RSTRING_LEN(string);
+  for (long i = 0; i < len; i++) {
+    if ((ptr[i] & 0x80U) != 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+static void packed_files_append_u16(VALUE packed, uint16_t value) {
+  unsigned char bytes[2] = {(unsigned char)(value >> 8),
+                            (unsigned char)value};
+  rb_str_cat(packed, (const char *)bytes, 2);
+}
+
+static void packed_files_append_u32(VALUE packed, uint32_t value) {
+  unsigned char bytes[4] = {
+      (unsigned char)(value >> 24), (unsigned char)(value >> 16),
+      (unsigned char)(value >> 8), (unsigned char)value};
+  rb_str_cat(packed, (const char *)bytes, 4);
+}
+
+static void packed_files_append_string_header(VALUE packed, uint32_t len,
+                                              bool binary) {
+  unsigned char byte;
+  if (binary) {
+    if (len < 256) {
+      byte = 0xc4;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      byte = (unsigned char)len;
+      rb_str_cat(packed, (const char *)&byte, 1);
+    } else if (len < 65536) {
+      byte = 0xc5;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      packed_files_append_u16(packed, (uint16_t)len);
+    } else {
+      byte = 0xc6;
+      rb_str_cat(packed, (const char *)&byte, 1);
+      packed_files_append_u32(packed, len);
+    }
+  } else if (len < 32) {
+    byte = (unsigned char)(0xa0U | len);
+    rb_str_cat(packed, (const char *)&byte, 1);
+  } else if (len < 256) {
+    byte = 0xd9;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    byte = (unsigned char)len;
+    rb_str_cat(packed, (const char *)&byte, 1);
+  } else if (len < 65536) {
+    byte = 0xda;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    packed_files_append_u16(packed, (uint16_t)len);
+  } else {
+    byte = 0xdb;
+    rb_str_cat(packed, (const char *)&byte, 1);
+    packed_files_append_u32(packed, len);
+  }
+}
+
+static bool packed_files_append_entry(struct packed_files_context *context,
+                                      VALUE file, bool additional_file) {
+  if (file == Qnil && !additional_file) {
+    return true;
+  }
+  if (!RB_TYPE_P(file, T_STRING) || rb_obj_class(file) != rb_cString) {
+    context->supported = false;
+    return false;
+  }
+
+  VALUE relative_file = file;
+  VALUE dedup_file = file;
+  const char *relative_ptr = RSTRING_PTR(file);
+  long relative_len = RSTRING_LEN(file);
+#ifdef _WIN32
+  context->supported = false;
+  return false;
+#else
+  const char *file_ptr = RSTRING_PTR(file);
+  long file_len = RSTRING_LEN(file);
+  bool absolute = file_len > 0 && file_ptr[0] == '/';
+  if (absolute) {
+    if (file_len <= context->root_len ||
+        memcmp(file_ptr, RSTRING_PTR(context->root),
+               (size_t)context->root_len) != 0 ||
+        file_ptr[context->root_len] != '/') {
+      // Absolute additional files outside the immutable repository root are
+      // ignored. Primary files are already filtered by the same root.
+      return true;
+    }
+
+    relative_len = file_len - context->root_len - 1;
+    if (relative_len == 0) {
+      return true;
+    }
+    if (context->direct_absolute) {
+      relative_ptr = file_ptr + context->root_len + 1;
+    } else {
+      relative_file = rb_str_substr(file, context->root_len + 1, file_len);
+      dedup_file = relative_file;
+      relative_ptr = RSTRING_PTR(relative_file);
+    }
+  } else if (!additional_file) {
+    // Relative primary paths depend on cwd-to-root Pathname semantics. They
+    // are uncommon and retain the authoritative Ruby fallback.
+    context->supported = false;
+    return false;
+  }
+#endif
+
+  if (relative_len == 0) {
+    return true;
+  }
+  if (rb_hash_lookup2(context->seen, dedup_file, Qundef) != Qundef) {
+    return true;
+  }
+  rb_hash_aset(context->seen, dedup_file, Qtrue);
+
+  int encoding_index = rb_enc_get_index(relative_file);
+  bool binary = encoding_index == rb_ascii8bit_encindex();
+  if (!binary && encoding_index != rb_utf8_encindex() &&
+      encoding_index != rb_usascii_encindex() &&
+      !string_bytes_are_ascii(relative_file)) {
+    context->supported = false;
+    return false;
+  }
+
+  if (relative_len > UINT32_MAX) {
+    rb_raise(rb_eArgError, "size of filename is too long to pack: %lu bytes",
+             (unsigned long)relative_len);
+  }
+
+  static const unsigned char filename_entry_prefix[] = {
+      0x81, 0xa8, 'f', 'i', 'l', 'e', 'n', 'a', 'm', 'e'};
+  rb_str_cat(context->packed, (const char *)filename_entry_prefix,
+             sizeof(filename_entry_prefix));
+  packed_files_append_string_header(context->packed, (uint32_t)relative_len,
+                                    binary);
+  rb_str_cat(context->packed, relative_ptr, relative_len);
+  context->files_count++;
+  return true;
+}
+
+static int pack_primary_file_i(VALUE file, VALUE _value,
+                               VALUE context_value) {
+  struct packed_files_context *context =
+      (struct packed_files_context *)context_value;
+  return packed_files_append_entry(context, file, false) ? ST_CONTINUE
+                                                         : ST_STOP;
+}
+
+static bool packed_file_is_absolute(VALUE file, bool additional_file) {
+#ifdef _WIN32
+  return false;
+#else
+  if (file == Qnil && !additional_file) {
+    return true;
+  }
+  return RB_TYPE_P(file, T_STRING) && rb_obj_class(file) == rb_cString &&
+         RSTRING_LEN(file) > 0 && RSTRING_PTR(file)[0] == '/';
+#endif
+}
+
+static int detect_absolute_primary_file_i(VALUE file, VALUE _value,
+                                          VALUE all_absolute_value) {
+  bool *all_absolute = (bool *)all_absolute_value;
+  if (!packed_file_is_absolute(file, false)) {
+    *all_absolute = false;
+    return ST_STOP;
+  }
+  return ST_CONTINUE;
+}
+
+static void
+packed_files_write_array_header(struct packed_files_context *context) {
+  unsigned char header[5];
+  size_t header_len;
+  if (context->files_count < 16) {
+    header[0] = (unsigned char)(0x90U | context->files_count);
+    header_len = 1;
+  } else if (context->files_count < 65536) {
+    header[0] = 0xdc;
+    header[1] = (unsigned char)(context->files_count >> 8);
+    header[2] = (unsigned char)context->files_count;
+    header_len = 3;
+  } else {
+    header[0] = 0xdd;
+    header[1] = (unsigned char)(context->files_count >> 24);
+    header[2] = (unsigned char)(context->files_count >> 16);
+    header[3] = (unsigned char)(context->files_count >> 8);
+    header[4] = (unsigned char)context->files_count;
+    header_len = 5;
+  }
+
+  long body_len = RSTRING_LEN(context->packed) - 5;
+  char *packed_ptr = RSTRING_PTR(context->packed);
+  if (header_len != 5) {
+    memmove(packed_ptr + header_len, packed_ptr + 5, (size_t)body_len);
+    rb_str_resize(context->packed, body_len + (long)header_len);
+    packed_ptr = RSTRING_PTR(context->packed);
+  }
+  memcpy(packed_ptr, header, header_len);
+}
+
+static VALUE file_serialization_pack_files(VALUE module, VALUE primary_files,
+                                           VALUE additional_files,
+                                           VALUE root) {
+  Check_Type(primary_files, T_HASH);
+  Check_Type(additional_files, T_ARRAY);
+  if (!RB_TYPE_P(root, T_STRING) || rb_obj_class(root) != rb_cString ||
+      RSTRING_LEN(root) == 0 || !string_bytes_are_ascii(root)) {
+    return Qnil;
+  }
+
+  bool all_absolute = true;
+  rb_hash_foreach(primary_files, detect_absolute_primary_file_i,
+                  (VALUE)&all_absolute);
+  long additional_files_len = RARRAY_LEN(additional_files);
+  for (long i = 0; all_absolute && i < additional_files_len; i++) {
+    all_absolute =
+        packed_file_is_absolute(rb_ary_entry(additional_files, i), true);
+  }
+
+  struct packed_files_context context = {
+      .root = root,
+      .seen = rb_hash_new(),
+      .packed = rb_str_buf_new(4096),
+      .root_len = RSTRING_LEN(root),
+      .files_count = 0,
+      .direct_absolute = all_absolute,
+      .supported = true};
+  rb_str_resize(context.packed, 5);
+
+  rb_hash_foreach(primary_files, pack_primary_file_i, (VALUE)&context);
+  if (!context.supported) {
+    return Qnil;
+  }
+
+  for (long i = 0; i < additional_files_len; i++) {
+    if (!packed_files_append_entry(&context,
+                                   rb_ary_entry(additional_files, i), true)) {
+      return Qnil;
+    }
+  }
+
+  packed_files_write_array_header(&context);
+  return context.packed;
+}
+
+void Init_file_serialization(void) {
+  VALUE mDatadog = rb_define_module("Datadog");
+  VALUE mCI = rb_define_module_under(mDatadog, "CI");
+  VALUE mFileSerialization =
+      rb_define_module_under(mCI, "FileSerialization");
+
+  rb_define_singleton_method(mFileSerialization, "pack_files",
+                             file_serialization_pack_files, 3);
+}

--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -102,6 +102,10 @@ static bool packed_files_append_entry(struct packed_files_context *context,
 #else
   const char *file_ptr = RSTRING_PTR(file);
   long file_len = RSTRING_LEN(file);
+  if (memchr(file_ptr, '\0', (size_t)file_len) != NULL) {
+    context->supported = false;
+    return false;
+  }
   bool absolute = file_len > 0 && file_ptr[0] == '/';
   if (absolute) {
     if (file_len <= context->root_len ||

--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -143,7 +143,8 @@ static bool packed_files_append_entry(struct packed_files_context *context,
   bool binary = encoding_index == rb_ascii8bit_encindex();
   if (!binary && encoding_index != rb_utf8_encindex() &&
       encoding_index != rb_usascii_encindex() &&
-      !string_bytes_are_ascii(relative_file)) {
+      (!rb_enc_str_asciicompat_p(relative_file) ||
+       !string_bytes_are_ascii(relative_file))) {
     context->supported = false;
     return false;
   }

--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -94,8 +94,8 @@ static bool packed_files_append_entry(struct packed_files_context *context,
 
   VALUE relative_file = file;
   VALUE dedup_file = file;
-  const char *relative_ptr = RSTRING_PTR(file);
   long relative_len = RSTRING_LEN(file);
+  long relative_offset = 0;
 #ifdef _WIN32
   context->supported = false;
   return false;
@@ -118,11 +118,10 @@ static bool packed_files_append_entry(struct packed_files_context *context,
       return true;
     }
     if (context->direct_absolute) {
-      relative_ptr = file_ptr + context->root_len + 1;
+      relative_offset = context->root_len + 1;
     } else {
       relative_file = rb_str_substr(file, context->root_len + 1, file_len);
       dedup_file = relative_file;
-      relative_ptr = RSTRING_PTR(relative_file);
     }
   } else if (!additional_file) {
     // Relative primary paths depend on cwd-to-root Pathname semantics. They
@@ -160,7 +159,9 @@ static bool packed_files_append_entry(struct packed_files_context *context,
              sizeof(filename_entry_prefix));
   packed_files_append_string_header(context->packed, (uint32_t)relative_len,
                                     binary);
+  const char *relative_ptr = RSTRING_PTR(relative_file) + relative_offset;
   rb_str_cat(context->packed, relative_ptr, relative_len);
+  RB_GC_GUARD(relative_file);
   context->files_count++;
   return true;
 }

--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -18,7 +18,7 @@ struct packed_files_context {
   long root_len;
   uint32_t files_count;
   bool direct_absolute;
-  bool supported;
+  bool fast_path_supported;
 };
 
 static bool string_bytes_are_ascii(VALUE string) {
@@ -88,7 +88,7 @@ static bool packed_files_append_entry(struct packed_files_context *context,
     return true;
   }
   if (!RB_TYPE_P(file, T_STRING) || rb_obj_class(file) != rb_cString) {
-    context->supported = false;
+    context->fast_path_supported = false;
     return false;
   }
 
@@ -96,14 +96,10 @@ static bool packed_files_append_entry(struct packed_files_context *context,
   VALUE dedup_file = file;
   long relative_len = RSTRING_LEN(file);
   long relative_offset = 0;
-#ifdef _WIN32
-  context->supported = false;
-  return false;
-#else
   const char *file_ptr = RSTRING_PTR(file);
   long file_len = RSTRING_LEN(file);
   if (memchr(file_ptr, '\0', (size_t)file_len) != NULL) {
-    context->supported = false;
+    context->fast_path_supported = false;
     return false;
   }
   bool absolute = file_len > 0 && file_ptr[0] == '/';
@@ -130,10 +126,9 @@ static bool packed_files_append_entry(struct packed_files_context *context,
   } else if (!additional_file) {
     // Relative primary paths depend on cwd-to-root Pathname semantics. They
     // are uncommon and retain the authoritative Ruby fallback.
-    context->supported = false;
+    context->fast_path_supported = false;
     return false;
   }
-#endif
 
   if (relative_len == 0) {
     return true;
@@ -149,7 +144,7 @@ static bool packed_files_append_entry(struct packed_files_context *context,
       encoding_index != rb_usascii_encindex() &&
       (!rb_enc_str_asciicompat_p(relative_file) ||
        !string_bytes_are_ascii(relative_file))) {
-    context->supported = false;
+    context->fast_path_supported = false;
     return false;
   }
 
@@ -180,15 +175,11 @@ static int pack_primary_file_i(VALUE file, VALUE _value,
 }
 
 static bool packed_file_is_absolute(VALUE file, bool additional_file) {
-#ifdef _WIN32
-  return false;
-#else
   if (file == Qnil && !additional_file) {
     return true;
   }
   return RB_TYPE_P(file, T_STRING) && rb_obj_class(file) == rb_cString &&
          RSTRING_LEN(file) > 0 && RSTRING_PTR(file)[0] == '/';
-#endif
 }
 
 static int detect_absolute_primary_file_i(VALUE file, VALUE _value,
@@ -258,11 +249,11 @@ static VALUE file_serialization_pack_files(VALUE module, VALUE primary_files,
       .root_len = RSTRING_LEN(root),
       .files_count = 0,
       .direct_absolute = all_absolute,
-      .supported = true};
+      .fast_path_supported = true};
   rb_str_resize(context.packed, 5);
 
   rb_hash_foreach(primary_files, pack_primary_file_i, (VALUE)&context);
-  if (!context.supported) {
+  if (!context.fast_path_supported) {
     return Qnil;
   }
 

--- a/ext/datadog_ci_native/file_serialization.h
+++ b/ext/datadog_ci_native/file_serialization.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void Init_file_serialization(void);

--- a/lib/datadog/ci/file_serialization.rb
+++ b/lib/datadog/ci/file_serialization.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Datadog
+  module CI
+    # Native fast path for serializing large lists of file paths.
+    # Implementation in ext/datadog_ci_native/file_serialization.c.
+    #
+    # @internal
+    module FileSerialization
+    end
+  end
+end

--- a/lib/datadog/ci/test_impact_analysis/coverage/event.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/event.rb
@@ -58,12 +58,7 @@ module Datadog
             end
 
             packer.write("files")
-            packer.write_array_header(@files.size)
-            @files.each do |filename|
-              packer.write_map_header(1)
-              packer.write("filename")
-              packer.write(filename)
-            end
+            @files.write_to(packer)
           end
 
           def to_s

--- a/lib/datadog/ci/test_impact_analysis/coverage/files.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/files.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../../git/local_repository"
+require_relative "../../file_serialization"
 
 module Datadog
   module CI
@@ -16,6 +17,10 @@ module Datadog
           def initialize(coverage, custom_impacted_files = EMPTY_FILES)
             @coverage = coverage
             @custom_impacted_files = custom_impacted_files
+            # The repository root is a process invariant between coverage
+            # events. Capture it once so native normalization can reuse the
+            # same exact boundary for this event without repeated lookups.
+            @root = Git::LocalRepository.root
             @normalized_files = nil
           end
 
@@ -25,6 +30,32 @@ module Datadog
 
           def size
             normalized_files.size
+          end
+
+          # Writes the complete MessagePack files array. The native fast path
+          # combines absolute-path classification, immutable-root slicing,
+          # stable deduplication, and filename-entry packing. Any shape it does
+          # not support falls back before writing bytes.
+          def write_to(packer)
+            if FileSerialization.respond_to?(:pack_files) &&
+                packer.respond_to?(:compatibility_mode?) &&
+                !packer.compatibility_mode? &&
+                (packed_files = FileSerialization.pack_files(
+                  @coverage,
+                  @custom_impacted_files,
+                  @root
+                ))
+              packer.buffer.write(packed_files)
+              return packer
+            end
+
+            packer.write_array_header(size)
+            each do |filename|
+              packer.write_map_header(1)
+              packer.write("filename")
+              packer.write(filename)
+            end
+            packer
           end
 
           # Returns a readable view while preserving the paths supplied by

--- a/lib/datadog/ci/test_impact_analysis/coverage/files.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/files.rb
@@ -38,8 +38,6 @@ module Datadog
           # not support falls back before writing bytes.
           def write_to(packer)
             if FileSerialization.respond_to?(:pack_files) &&
-                packer.respond_to?(:compatibility_mode?) &&
-                !packer.compatibility_mode? &&
                 (packed_files = FileSerialization.pack_files(
                   @coverage,
                   @custom_impacted_files,

--- a/sig/datadog/ci/file_serialization.rbs
+++ b/sig/datadog/ci/file_serialization.rbs
@@ -1,0 +1,7 @@
+module Datadog
+  module CI
+    module FileSerialization
+      def self.pack_files: (Hash[String, untyped] primary_files, Array[String] additional_files, String root) -> String?
+    end
+  end
+end

--- a/sig/datadog/ci/test_impact_analysis/coverage/files.rbs
+++ b/sig/datadog/ci/test_impact_analysis/coverage/files.rbs
@@ -7,6 +7,7 @@ module Datadog
 
           @coverage: Hash[String, untyped]
           @custom_impacted_files: Array[String]
+          @root: String
           @normalized_files: Array[String]?
 
           def initialize: (Hash[String, untyped] coverage, ?Array[String] custom_impacted_files) -> void
@@ -14,6 +15,8 @@ module Datadog
           def each: () { (String file) -> void } -> void
 
           def size: () -> Integer
+
+          def write_to: (untyped packer) -> untyped
 
           def inspect_coverage: () -> Hash[String, untyped]
 

--- a/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
@@ -340,6 +340,71 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         )
       end
     end
+
+    it "matches legacy MessagePack bytes for native and custom paths" do
+      root = Datadog::CI::Git::LocalRepository.root
+      absolute_native = File.join(root, "app/models/user.rb")
+      binary_file = "frontend/binary-\xFF.js".b
+      long_file = "frontend/#{"x" * 300}.js"
+      custom_files = [
+        "frontend/app.js",
+        absolute_native,
+        "frontend/app.js",
+        "frontend/emoji-❤️.js",
+        binary_file,
+        long_file
+      ] + Array.new(20) { |index| "frontend/generated-#{index}.js" }
+      coverage = {absolute_native => true}
+      files = Datadog::CI::TestImpactAnalysis::Coverage::Files.new(coverage, custom_files)
+      event = described_class.new(
+        test_id: test_id,
+        test_suite_id: test_suite_id,
+        test_session_id: test_session_id,
+        files: files
+      )
+      file_serialization = Datadog::CI::FileSerialization
+
+      expect(file_serialization.pack_files(coverage, custom_files, root)).to be_a(String)
+
+      encode = lambda do
+        packer = MessagePack::Packer.new
+        event.to_msgpack(packer)
+        packer.to_s
+      end
+      native_bytes = encode.call
+      allow(file_serialization).to receive(:pack_files).and_return(nil)
+
+      expect(native_bytes).to eq(encode.call)
+    end
+
+    it "matches legacy MessagePack bytes for all-absolute paths" do
+      root = Datadog::CI::Git::LocalRepository.root
+      absolute_files = Array.new(20) do |index|
+        File.join(root, "app/generated/model-#{index}.rb")
+      end
+      coverage = absolute_files.first(10).to_h { |file| [file, true] }
+      custom_files = absolute_files.drop(5) + [absolute_files.fetch(5)]
+      files = Datadog::CI::TestImpactAnalysis::Coverage::Files.new(coverage, custom_files)
+      event = described_class.new(
+        test_id: test_id,
+        test_suite_id: test_suite_id,
+        test_session_id: test_session_id,
+        files: files
+      )
+      file_serialization = Datadog::CI::FileSerialization
+
+      expect(file_serialization.pack_files(coverage, custom_files, root)).to be_a(String)
+
+      encode = lambda do
+        packer = MessagePack::Packer.new
+        event.to_msgpack(packer)
+        packer.to_s
+      end
+      native_bytes = encode.call
+      allow(file_serialization).to receive(:pack_files).and_return(nil)
+
+      expect(native_bytes).to eq(encode.call)
+    end
   end
 
   describe "#pretty_inspect" do

--- a/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
@@ -405,6 +405,15 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
 
       expect(native_bytes).to eq(encode.call)
     end
+
+    it "falls back for ASCII-incompatible filename encodings" do
+      root = Datadog::CI::Git::LocalRepository.root
+      encoded_file = "frontend/app.js".encode(Encoding::UTF_16BE)
+
+      expect(
+        Datadog::CI::FileSerialization.pack_files({}, [encoded_file], root)
+      ).to be_nil
+    end
   end
 
   describe "#pretty_inspect" do

--- a/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
@@ -414,6 +414,18 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         Datadog::CI::FileSerialization.pack_files({}, [encoded_file], root)
       ).to be_nil
     end
+
+    it "falls back for filenames containing NUL bytes" do
+      root = Datadog::CI::Git::LocalRepository.root
+      relative_file = "frontend/app\0.js"
+      absolute_file = "#{root}/#{relative_file}"
+
+      [relative_file, absolute_file].each do |file|
+        expect(
+          Datadog::CI::FileSerialization.pack_files({}, [file], root)
+        ).to be_nil
+      end
+    end
   end
 
   describe "#pretty_inspect" do


### PR DESCRIPTION
## Why

Serializing a large file list as separate Ruby normalization, deduplication, and MessagePack passes creates substantial transient arrays, hashes, and method calls. TIA coverage events are the current high-volume caller, but the performance concern is bulk file serialization rather than coverage collection.

This change introduces a dedicated `Datadog::CI::FileSerialization` Ruby module backed by its own `file_serialization.c` extension unit. After a cheap absolute-path pre-scan, its native fast path fuses repository-root validation and slicing, stable deduplication, and MessagePack encoding into one output pass. `DDCov` remains responsible only for coverage collection.

The current caller captures the repository root once because the root is a process invariant between coverage events. Unsupported packer or input shapes fall back to the existing Ruby implementation before any bytes are written.

## Benchmark

`ruby-rails-tia-stress-test-level`, four paired measurements with normal test tracing and no code coverage:

| | `main` | This PR |
|---|---:|---:|
| Baseline median | 37,014 ms | 36,149 ms |
| Instrumented median | 58,148 ms | 54,380 ms |
| Tracer overhead | 57.10% | 50.43% |

The overhead improves by **6.66 percentage points**. The paired runtime-multiplier comparison is conclusive: **95% CI −9.17% to −3.05%**.

## Correctness

- Native output is byte-for-byte compared with the legacy serializer for relative, absolute, duplicate, binary, Unicode, and long paths.
- 21 focused coverage-event examples and 47 DDCov examples passed (68 total).
- All 19,080 Rails benchmark assertions passed.
- Ruby 3.4.7 and Ruby 4.0.1 native builds passed.
- The extracted native extension compiles independently as part of the complete extension build.
- RBS missing/stale checks pass, Steep reports no type errors, and Standard reports no offenses across 506 files.

Correctness remains the priority: this does not skip coverage events or file classes, change ordering, or introduce nondeterministic behavior.

## Stack

This is PR 1 of 2 and targets `main`. #580 replaces the high-frequency NEWOBJ TracePoint wrapper with an owned raw event hook.
