### PR TITLE
Fix: Test Optimization telemetry shutdown order

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -72,8 +72,6 @@ module Datadog
         end
 
         def shutdown!(replacement = nil)
-          super
-
           @test_optimization_cache&.shutdown!
           @test_tracing&.shutdown!
           @test_impact_analysis&.shutdown!
@@ -81,6 +79,8 @@ module Datadog
           @test_discovery&.shutdown!
           @code_coverage&.shutdown!
           @git_tree_upload_worker&.stop
+
+          super
         end
 
         def activate_ci!(settings)

--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -79,7 +79,7 @@ module Datadog
           @test_discovery&.shutdown!
           @code_coverage&.shutdown!
           @git_tree_upload_worker&.stop
-
+        ensure
           super
         end
 

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -151,6 +151,18 @@ RSpec.describe Datadog::CI::Configuration::Components do
             expect(shutdown_order).to eq([:test_impact_analysis, :telemetry])
           end
 
+          it "shuts down telemetry when a Test Optimization component fails to shut down" do
+            shutdown_attempts = 0
+            allow(components.test_impact_analysis).to receive(:shutdown!) do
+              shutdown_attempts += 1
+              raise "Test Optimization shutdown failed" if shutdown_attempts == 1
+            end
+            allow(components.telemetry).to receive(:shutdown!)
+
+            expect { components.shutdown! }.to raise_error("Test Optimization shutdown failed")
+            expect(components.telemetry).to have_received(:shutdown!).once
+          end
+
           context "when tracing is disabled" do
             let(:tracing_enabled) { false }
 

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -141,6 +141,16 @@ RSpec.describe Datadog::CI::Configuration::Components do
         context "is enabled" do
           let(:enabled) { true }
 
+          it "shuts down Test Optimization components before telemetry" do
+            shutdown_order = []
+            allow(components.test_impact_analysis).to receive(:shutdown!) { shutdown_order << :test_impact_analysis }
+            allow(components.telemetry).to receive(:shutdown!) { shutdown_order << :telemetry }
+
+            components.shutdown!
+
+            expect(shutdown_order).to eq([:test_impact_analysis, :telemetry])
+          end
+
           context "when tracing is disabled" do
             let(:tracing_enabled) { false }
 


### PR DESCRIPTION
**What does this PR do?**

Shuts down Test Optimization components before delegating to the base tracer shutdown, which stops telemetry. It also adds a regression spec that fixes the required ordering between Test Impact Analysis and telemetry shutdown.

**Motivation**

The scheduled Shepherd Ruby run [failed its RuboCop custom impacted-files suite assertion](https://github.com/DataDog/shepherd/actions/runs/32316358168): the coverage request reached Mockdog successfully, but `telemetry.code_coverage_payloads` was `0`.

Artifact and debug-log comparison with adjacent passing runs showed that the failed process omitted the `endpoint_payload` request, byte, and duration metrics for the code-coverage endpoint from its final telemetry batches. `Datadog::CI::Configuration::Components#shutdown!` called `super` first, so core telemetry could stop before the Test Impact Analysis coverage writer finished and recorded those metrics. The result depended on thread timing.

Moving `super` to the end preserves the base shutdown sequence while ensuring telemetry is the final component stopped.

**Additional Notes**

No matching issue or open PR was found for this shutdown-order race. The scheduled assertion has passed in later runs, consistent with the timing-dependent root cause.

**How to test the change?**

- Regression spec demonstrated the old ordering (`telemetry` before `test_impact_analysis`) and passes with the fix.
- `bundle exec rspec spec/datadog/ci/configuration/components_spec.rb` — 33 examples, 0 failures.
- `bundle exec rake test:main` — 2,325 examples, 0 failures, 1 expected pending example.
- `bundle exec standardrb` — 506 files, no offenses.
- `bundle exec rake steep:check` — no type errors.
- Shepherd: `bin/crook run rubocop --assert rubocop-custom-impacted-files-suite --dep datadog-ci-rb=path:<checkout> --debug` — all 70 assertions passed, including one code-coverage payload and two telemetry payloads.
