### PR TITLE
Remove ruby-guild from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DataDog/ruby-guild @DataDog/ci-app-libraries
+* @DataDog/ci-app-libraries

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Minitest instrumentation" do
 
       expect(span).to have_test_tag(
         :codeowners,
-        "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+        "[\"@DataDog/ci-app-libraries\"]"
       )
     end
 
@@ -522,7 +522,7 @@ RSpec.describe "Minitest instrumentation" do
           expect(first_test_suite_span).to have_test_tag(:source_start, "446")
           expect(first_test_suite_span).to have_test_tag(
             :codeowners,
-            "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+            "[\"@DataDog/ci-app-libraries\"]"
           )
 
           expect(first_test_suite_span).to have_pass_status

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe "RSpec instrumentation" do
 
       expect(first_test_span).to have_test_tag(
         :codeowners,
-        "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+        "[\"@DataDog/ci-app-libraries\"]"
       )
     end
 
@@ -631,7 +631,7 @@ RSpec.describe "RSpec instrumentation" do
       expect(first_test_suite_span).to have_test_tag(:source_start, "52")
       expect(first_test_suite_span).to have_test_tag(
         :codeowners,
-        "[\"@DataDog/ruby-guild\", \"@DataDog/ci-app-libraries\"]"
+        "[\"@DataDog/ci-app-libraries\"]"
       )
 
       expect(first_test_suite_span).to have_pass_status


### PR DESCRIPTION
## Summary

- Remove the Ruby Guild from the repository-level CODEOWNERS rule.
- Keep CI App Libraries as the repository owner.
- Update Minitest and RSpec instrumentation expectations for the new owner list.

## Testing

- Ruby 3.3 / Minitest 5 integration spec: 64 examples, 0 failures.
- Ruby 3.3 / RSpec 3 integration spec: 103 examples, 0 failures.
- StandardRB: 2 files inspected, no offenses.
- git diff --check.