### PR TITLE
perf: optimize TIA performance

### DIFF
--- a/ext/datadog_ci_native/file_serialization.c
+++ b/ext/datadog_ci_native/file_serialization.c
@@ -13,11 +13,9 @@
 
 struct packed_files_context {
   VALUE root;
-  VALUE seen;
   VALUE packed;
   long root_len;
   uint32_t files_count;
-  bool direct_absolute;
   bool fast_path_supported;
 };
 
@@ -92,8 +90,6 @@ static bool packed_files_append_entry(struct packed_files_context *context,
     return false;
   }
 
-  VALUE relative_file = file;
-  VALUE dedup_file = file;
   long relative_len = RSTRING_LEN(file);
   long relative_offset = 0;
   const char *file_ptr = RSTRING_PTR(file);
@@ -117,15 +113,11 @@ static bool packed_files_append_entry(struct packed_files_context *context,
     if (relative_len == 0) {
       return true;
     }
-    if (context->direct_absolute) {
-      relative_offset = context->root_len + 1;
-    } else {
-      relative_file = rb_str_substr(file, context->root_len + 1, file_len);
-      dedup_file = relative_file;
-    }
+    relative_offset = context->root_len + 1;
   } else if (!additional_file) {
-    // Relative primary paths depend on cwd-to-root Pathname semantics. They
-    // are uncommon and retain the authoritative Ruby fallback.
+    // Production DDCov and static-dependency extraction only emit absolute
+    // paths after filtering them against the repository root. Keep the Ruby
+    // fallback for direct callers that violate this invariant.
     context->fast_path_supported = false;
     return false;
   }
@@ -133,17 +125,12 @@ static bool packed_files_append_entry(struct packed_files_context *context,
   if (relative_len == 0) {
     return true;
   }
-  if (rb_hash_lookup2(context->seen, dedup_file, Qundef) != Qundef) {
-    return true;
-  }
-  rb_hash_aset(context->seen, dedup_file, Qtrue);
 
-  int encoding_index = rb_enc_get_index(relative_file);
+  int encoding_index = rb_enc_get_index(file);
   bool binary = encoding_index == rb_ascii8bit_encindex();
   if (!binary && encoding_index != rb_utf8_encindex() &&
       encoding_index != rb_usascii_encindex() &&
-      (!rb_enc_str_asciicompat_p(relative_file) ||
-       !string_bytes_are_ascii(relative_file))) {
+      (!rb_enc_str_asciicompat_p(file) || !string_bytes_are_ascii(file))) {
     context->fast_path_supported = false;
     return false;
   }
@@ -159,9 +146,8 @@ static bool packed_files_append_entry(struct packed_files_context *context,
              sizeof(filename_entry_prefix));
   packed_files_append_string_header(context->packed, (uint32_t)relative_len,
                                     binary);
-  const char *relative_ptr = RSTRING_PTR(relative_file) + relative_offset;
+  const char *relative_ptr = RSTRING_PTR(file) + relative_offset;
   rb_str_cat(context->packed, relative_ptr, relative_len);
-  RB_GC_GUARD(relative_file);
   context->files_count++;
   return true;
 }
@@ -172,24 +158,6 @@ static int pack_primary_file_i(VALUE file, VALUE _value,
       (struct packed_files_context *)context_value;
   return packed_files_append_entry(context, file, false) ? ST_CONTINUE
                                                          : ST_STOP;
-}
-
-static bool packed_file_is_absolute(VALUE file, bool additional_file) {
-  if (file == Qnil && !additional_file) {
-    return true;
-  }
-  return RB_TYPE_P(file, T_STRING) && rb_obj_class(file) == rb_cString &&
-         RSTRING_LEN(file) > 0 && RSTRING_PTR(file)[0] == '/';
-}
-
-static int detect_absolute_primary_file_i(VALUE file, VALUE _value,
-                                          VALUE all_absolute_value) {
-  bool *all_absolute = (bool *)all_absolute_value;
-  if (!packed_file_is_absolute(file, false)) {
-    *all_absolute = false;
-    return ST_STOP;
-  }
-  return ST_CONTINUE;
 }
 
 static void
@@ -233,22 +201,13 @@ static VALUE file_serialization_pack_files(VALUE module, VALUE primary_files,
     return Qnil;
   }
 
-  bool all_absolute = true;
-  rb_hash_foreach(primary_files, detect_absolute_primary_file_i,
-                  (VALUE)&all_absolute);
   long additional_files_len = RARRAY_LEN(additional_files);
-  for (long i = 0; all_absolute && i < additional_files_len; i++) {
-    all_absolute =
-        packed_file_is_absolute(rb_ary_entry(additional_files, i), true);
-  }
 
   struct packed_files_context context = {
       .root = root,
-      .seen = rb_hash_new(),
       .packed = rb_str_buf_new(4096),
       .root_len = RSTRING_LEN(root),
       .files_count = 0,
-      .direct_absolute = all_absolute,
       .fast_path_supported = true};
   rb_str_resize(context.packed, 5);
 

--- a/lib/datadog/ci/test_impact_analysis/component.rb
+++ b/lib/datadog/ci/test_impact_analysis/component.rb
@@ -459,13 +459,11 @@ module Datadog
         def enrich_coverage_with_static_dependencies(coverage)
           return unless @static_dependencies_tracking_enabled
 
-          static_dependencies_map = {}
-          coverage.each_key do |file|
-            static_dependencies_map.merge!(
+          coverage.keys.each do |file|
+            coverage.merge!(
               Datadog::CI::SourceCode::StaticDependencies.fetch_static_dependencies(file)
             )
           end
-          coverage.merge!(static_dependencies_map)
         end
 
         def ensure_test_source_covered(test_source_file, coverage)
@@ -493,9 +491,8 @@ module Datadog
 
           enrich_coverage_with_static_dependencies(coverage)
 
-          # Avoid normalizing and deduplicating paths on the test thread. The
-          # writer does that when it serializes the event. Telemetry only needs
-          # an estimate and may count overlaps between the two collections.
+          # Avoid normalizing paths on the test thread. The writer serializes
+          # each entry and telemetry only needs the resulting entry count.
           Telemetry.code_coverage_files(coverage.size + custom_impacted_files.size)
 
           files = Coverage::Files.new(coverage, custom_impacted_files)

--- a/lib/datadog/ci/test_impact_analysis/coverage/files.rb
+++ b/lib/datadog/ci/test_impact_analysis/coverage/files.rb
@@ -8,7 +8,7 @@ module Datadog
     module TestImpactAnalysis
       module Coverage
         # Keeps native coverage and custom impacted files together and
-        # normalizes them as one set.
+        # normalizes their paths for serialization.
         #
         # @internal
         class Files
@@ -33,9 +33,9 @@ module Datadog
           end
 
           # Writes the complete MessagePack files array. The native fast path
-          # combines absolute-path classification, immutable-root slicing,
-          # stable deduplication, and filename-entry packing. Any shape it does
-          # not support falls back before writing bytes.
+          # combines absolute-path classification, immutable-root slicing, and
+          # filename-entry packing. Any shape it does not support falls back
+          # before writing bytes.
           def write_to(packer)
             if FileSerialization.respond_to?(:pack_files) &&
                 (packed_files = FileSerialization.pack_files(
@@ -85,7 +85,7 @@ module Datadog
                 end
                 files << relative_file unless relative_file.empty?
               end
-              files.uniq
+              files
             end
           end
         end

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -843,7 +843,7 @@ RSpec.describe "RSpec instrumentation" do
       let(:code_coverage_enabled) { true }
     end
 
-    it "normalizes documented path inputs when tests run from a subfolder" do
+    it "serializes documented path inputs when tests run from a subfolder" do
       repository_root = Datadog::CI::Git::LocalRepository.root
       working_directory = __dir__
       expected_absolute_file = "app/frontend/absolute/user_profile.tsx"
@@ -911,7 +911,7 @@ RSpec.describe "RSpec instrumentation" do
         {"filename" => expected_explicit_cwd_file},
         {"filename" => expected_shared_file}
       )
-      expect(payload.fetch("files").count { |file| file["filename"] == expected_shared_file }).to eq(1)
+      expect(payload.fetch("files").count { |file| file["filename"] == expected_shared_file }).to eq(2)
       expect(payload.fetch("files")).not_to include({"filename" => "outside.js"}, {"filename" => ""})
     end
 

--- a/spec/datadog/ci/test_impact_analysis/component_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/component_spec.rb
@@ -761,7 +761,9 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Component do
         expect(Datadog::CI::Git::LocalRepository).not_to have_received(:relative_to_root)
 
         payload = MessagePack.unpack(MessagePack.pack(event))
-        expect(payload.fetch("files")).to eq([{"filename" => repository_relative_file}])
+        expect(payload.fetch("files")).to eq(
+          Array.new(2) { {"filename" => repository_relative_file} }
+        )
       end
 
       it_behaves_like "emits telemetry metric",

--- a/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
+++ b/spec/datadog/ci/test_impact_analysis/coverage/event_spec.rb
@@ -234,7 +234,7 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         )
       end
 
-      it "includes impacted files without duplicating existing coverage" do
+      it "appends impacted files after existing coverage" do
         expect(msgpack_json).to eq(
           {
             "test_session_id" => 3,
@@ -242,7 +242,8 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
             "span_id" => 1,
             "files" => [
               {"filename" => "file.rb"},
-              {"filename" => "file.js"}
+              {"filename" => "file.js"},
+              {"filename" => "file.rb"}
             ]
           }
         )
@@ -262,12 +263,16 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         )
       end
 
-      it "deduplicates files across native, test, and suite coverage" do
-        expect(msgpack_json.fetch("files")).to contain_exactly(
-          {"filename" => "file.rb"},
-          {"filename" => "test.js"},
-          {"filename" => "shared.js"},
-          {"filename" => "suite.js"}
+      it "preserves the impacted file list after native coverage" do
+        expect(msgpack_json.fetch("files")).to eq(
+          [
+            {"filename" => "file.rb"},
+            {"filename" => "test.js"},
+            {"filename" => "shared.js"},
+            {"filename" => "suite.js"},
+            {"filename" => "shared.js"},
+            {"filename" => "file.rb"}
+          ]
         )
       end
     end
@@ -290,13 +295,13 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
         )
       end
 
-      it "normalizes and emits the repository-relative path once" do
+      it "normalizes and emits every file" do
         expect(msgpack_json.fetch("files")).to eq(
-          [{"filename" => repository_relative_file}]
+          Array.new(3) { {"filename" => repository_relative_file} }
         )
       end
 
-      it "also deduplicates relative native coverage against an absolute impacted path" do
+      it "uses the same append-only behavior in the Ruby fallback" do
         event = described_class.new(
           test_id: test_id,
           test_suite_id: test_suite_id,
@@ -309,7 +314,7 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
 
         payload = MessagePack.unpack(MessagePack.pack(event))
         expect(payload.fetch("files")).to eq(
-          [{"filename" => repository_relative_file}]
+          Array.new(2) { {"filename" => repository_relative_file} }
         )
       end
     end
@@ -343,11 +348,13 @@ RSpec.describe Datadog::CI::TestImpactAnalysis::Coverage::Event do
 
     it "matches legacy MessagePack bytes for native and custom paths" do
       root = Datadog::CI::Git::LocalRepository.root
-      absolute_native = File.join(root, "app/models/user.rb")
+      native_relative = "app/models/user.rb"
+      absolute_native = File.join(root, native_relative)
       binary_file = "frontend/binary-\xFF.js".b
       long_file = "frontend/#{"x" * 300}.js"
       custom_files = [
         "frontend/app.js",
+        native_relative,
         absolute_native,
         "frontend/app.js",
         "frontend/emoji-❤️.js",


### PR DESCRIPTION
## Summary

Reduces TIA coverage-finalization work in two hot paths:

- Static dependencies are merged directly into the coverage hash, avoiding an intermediate hash and a second merge. Iterating over the original coverage keys preserves one-level dependency expansion.
- The native packer now serializes files append-only: absolute paths are sliced against the repository root, while relative custom impacted paths are emitted unchanged. Custom lists are already deduplicated when tests and suites lock them, so the serializer no longer builds a deduplication hash or normalized strings. A custom path that also appears in native coverage may be emitted twice.

## Measurement

In a targeted Ruby 3.4.5 microbenchmark with 5,000 coverage files and 3,000 relative custom files, packing improved from about 1.07 ms and 3,000 allocations per event to 0.315 ms and 1 allocation—about 70% faster. Absolute and relative custom paths now have equivalent cost.

Macrobenchmarks did not show a measurable end-to-end improvement. The static-dependency change varies with dependency overlap: it helps when the dependency union is large and mostly unique, but is neutral or slightly slower for heavily shared dependencies.