### PR TITLE
[SDTEST-3814] Disable SymDB upload in CI mode

### DIFF
--- a/lib/datadog/ci/configuration/components.rb
+++ b/lib/datadog/ci/configuration/components.rb
@@ -84,6 +84,9 @@ module Datadog
         end
 
         def activate_ci!(settings)
+          # Symbol Database upload is not supported in CI mode. Older datadog versions do not expose this setting.
+          settings.symbol_database.enabled = false if settings.respond_to?(:symbol_database)
+
           unless settings.tracing.enabled
             Datadog.logger.error(
               "Test Optimization requires tracing to be enabled. Disabling Test Optimization. " \

--- a/spec/datadog/ci/configuration/components_spec.rb
+++ b/spec/datadog/ci/configuration/components_spec.rb
@@ -141,6 +141,16 @@ RSpec.describe Datadog::CI::Configuration::Components do
         context "is enabled" do
           let(:enabled) { true }
 
+          context "when DD_SYMBOL_DATABASE_UPLOAD_ENABLED is true" do
+            around do |example|
+              ClimateControl.modify("DD_SYMBOL_DATABASE_UPLOAD_ENABLED" => "true") { example.run }
+            end
+
+            it "disables Symbol Database upload" do
+              expect(settings.symbol_database.enabled).to be(false)
+            end
+          end
+
           it "shuts down Test Optimization components before telemetry" do
             shutdown_order = []
             allow(components.test_impact_analysis).to receive(:shutdown!) { shutdown_order << :test_impact_analysis }
@@ -512,6 +522,16 @@ RSpec.describe Datadog::CI::Configuration::Components do
         context "is disabled" do
           let(:enabled) { false }
           let(:agentless_enabled) { false }
+
+          context "when DD_SYMBOL_DATABASE_UPLOAD_ENABLED is true" do
+            around do |example|
+              ClimateControl.modify("DD_SYMBOL_DATABASE_UPLOAD_ENABLED" => "true") { example.run }
+            end
+
+            it "leaves Symbol Database upload enabled" do
+              expect(settings.symbol_database.enabled).to be(true)
+            end
+          end
 
           it do
             expect(settings.tracing.test_mode)


### PR DESCRIPTION
**What does this PR do?**

Disables Dynamic Instrumentation Symbol Database uploads whenever Test Optimization CI mode is activated, even when `DD_SYMBOL_DATABASE_UPLOAD_ENABLED=true` is inherited from the environment.

The override is guarded so the gem remains compatible with older `datadog` versions that do not expose Symbol Database configuration. CI-disabled applications retain their configured value.

**Motivation**

Test processes should not perform DI symbol extraction or upload work while running in CI mode.

[SDTEST-3814](https://datadoghq.atlassian.net/browse/SDTEST-3814)

Related context: [dd-trace-rb#5818](https://github.com/DataDog/dd-trace-rb/pull/5818)

**Additional Notes**

None.


[SDTEST-3814]: https://datadoghq.atlassian.net/browse/SDTEST-3814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ