### PR TITLE
[SDTEST-3764] Trace RSpec and Minitest lifecycle steps

### DIFF
--- a/lib/datadog/ci/contrib/minitest/ext.rb
+++ b/lib/datadog/ci/contrib/minitest/ext.rb
@@ -12,6 +12,10 @@ module Datadog
           FRAMEWORK = "minitest"
 
           DEFAULT_SERVICE_NAME = "minitest"
+
+          STEP_SPAN_TYPE = "step"
+          BEFORE_STEP_SPAN_NAME = "before"
+          AFTER_STEP_SPAN_NAME = "after"
         end
       end
     end

--- a/lib/datadog/ci/contrib/minitest/test.rb
+++ b/lib/datadog/ci/contrib/minitest/test.rb
@@ -48,16 +48,55 @@ module Datadog
               super
             end
 
+            def before_setup
+              test_span = _dd_test_tracing_component.active_test
+              return super unless test_span
+
+              @datadog_before_step_failures_count = failures.length
+              @datadog_before_step_span = _dd_test_tracing_component.trace(
+                Ext::BEFORE_STEP_SPAN_NAME,
+                type: Ext::STEP_SPAN_TYPE
+              )
+
+              super
+            end
+
+            def after_setup
+              super
+            ensure
+              finish_datadog_before_step
+            end
+
+            def before_teardown
+              test_span = _dd_test_tracing_component.active_test
+              return super unless test_span
+
+              # Setup failures prevent Minitest from invoking after_setup, so
+              # close a still-active before span before teardown begins.
+              finish_datadog_before_step
+
+              @datadog_after_step_failures_count = failures.length
+              @datadog_after_step_span = _dd_test_tracing_component.trace(
+                Ext::AFTER_STEP_SPAN_NAME,
+                type: Ext::STEP_SPAN_TYPE
+              )
+
+              super
+            end
+
             def after_teardown
               test_span = _dd_test_tracing_component.active_test
               return super unless test_span
 
-              finish_with_result(test_span, result_code)
+              begin
+                super
+              ensure
+                finish_datadog_after_step
+                finish_with_result(test_span, result_code)
 
-              # remove failures if failure can be ignored because of retries
-              self.failures = [] if test_span.should_ignore_failures?
-
-              super
+                # remove failures if failure can be ignored because of retries
+                self.failures = [] if test_span.should_ignore_failures?
+              end
             end
 
             private
@@ -113,6 +152,32 @@ module Datadog
               return unless Helpers.parallel?(self.class)
 
               Helpers.start_test_suite(self.class)
+            end
+
+            def finish_datadog_before_step
+              span = @datadog_before_step_span
+              return unless span
+
+              finish_datadog_step(span, @datadog_before_step_failures_count)
+              @datadog_before_step_span = nil
+            end
+
+            def finish_datadog_after_step
+              span = @datadog_after_step_span
+              return unless span
+
+              finish_datadog_step(span, @datadog_after_step_failures_count)
+              @datadog_after_step_span = nil
+            end
+
+            def finish_datadog_step(span, failures_count)
+              step_failure = failures[failures_count]
+              if step_failure && !step_failure.is_a?(::Minitest::Skip)
+                exception = step_failure.respond_to?(:error) ? step_failure.error : step_failure
+                span.failed!(exception: exception)
+              end
+
+              span.finish
             end
 
             def skip_datadog_test(test_span)

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -26,8 +26,7 @@ module Datadog
             # ============================================
 
             def run(*args)
-              return super unless datadog_configuration[:enabled]
-              return super if ::RSpec.configuration.dry_run? && !datadog_configuration[:dry_run_enabled]
+              return super unless datadog_tracing_enabled?
 
               @datadog_test_tracing_component = test_tracing_component
 
@@ -198,17 +197,37 @@ module Datadog
             # ============================================
 
             def run_before_example
-              test_tracing_component.trace(Ext::BEFORE_STEP_SPAN_NAME, type: Ext::STEP_SPAN_TYPE) { super }
+              return super unless @datadog_test_tracing_component
+
+              skip_exception = nil
+              # @type var skip_exception: ::RSpec::Core::Pending::SkipDeclaredInExample?
+              result = test_tracing_component.trace(Ext::BEFORE_STEP_SPAN_NAME, type: Ext::STEP_SPAN_TYPE) do
+                super
+              rescue ::RSpec::Core::Pending::SkipDeclaredInExample => e
+                skip_exception = e
+              end
+
+              raise skip_exception if skip_exception
+
+              result
             end
 
             def run_after_example
+              return super unless @datadog_test_tracing_component
+
               exception_before_hooks = exception
 
               test_tracing_component.trace(Ext::AFTER_STEP_SPAN_NAME, type: Ext::STEP_SPAN_TYPE) do |span|
                 result = super
-                span.failed!(exception: exception) if exception && exception != exception_before_hooks
+                span&.failed!(exception: exception) if exception && exception != exception_before_hooks
                 result
               end
+            end
+
+            def datadog_tracing_enabled?
+              Datadog.configuration.ci.enabled &&
+                datadog_configuration[:enabled] &&
+                (!::RSpec.configuration.dry_run? || datadog_configuration[:dry_run_enabled])
             end
 
             def build_test_tags

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -29,6 +29,8 @@ module Datadog
               return super unless datadog_configuration[:enabled]
               return super if ::RSpec.configuration.dry_run? && !datadog_configuration[:dry_run_enabled]
 
+              @datadog_test_tracing_component = test_tracing_component
+
               test_suite_span = test_tracing_component.start_test_suite(datadog_test_suite_name) if ci_queue?
 
               # don't report test to RSpec::Core::Reporter until retries are done
@@ -76,6 +78,8 @@ module Datadog
               # after retries are done, we must report the test to RSpec
               @skip_reporting = false
               finish(reporter)
+            ensure
+              @datadog_test_tracing_component = nil
             end
 
             def finish(reporter)
@@ -390,7 +394,7 @@ module Datadog
             end
 
             def test_tracing_component
-              Datadog.send(:components).test_tracing
+              @datadog_test_tracing_component || Datadog.send(:components).test_tracing
             end
 
             def test_retries_component

--- a/lib/datadog/ci/contrib/rspec/example.rb
+++ b/lib/datadog/ci/contrib/rspec/example.rb
@@ -193,6 +193,20 @@ module Datadog
             # Run method helpers
             # ============================================
 
+            def run_before_example
+              test_tracing_component.trace(Ext::BEFORE_STEP_SPAN_NAME, type: Ext::STEP_SPAN_TYPE) { super }
+            end
+
+            def run_after_example
+              exception_before_hooks = exception
+
+              test_tracing_component.trace(Ext::AFTER_STEP_SPAN_NAME, type: Ext::STEP_SPAN_TYPE) do |span|
+                result = super
+                span.failed!(exception: exception) if exception && exception != exception_before_hooks
+                result
+              end
+            end
+
             def build_test_tags
               # @type var tags : Hash[String, String]
               tags = {

--- a/lib/datadog/ci/contrib/rspec/ext.rb
+++ b/lib/datadog/ci/contrib/rspec/ext.rb
@@ -13,6 +13,10 @@ module Datadog
           ENV_ENABLED = "DD_TRACE_RSPEC_ENABLED"
           ENV_DATADOG_FORMATTER_ENABLED = "DD_TRACE_RSPEC_DATADOG_FORMATTER_ENABLED"
 
+          STEP_SPAN_TYPE = "step"
+          BEFORE_STEP_SPAN_NAME = "before"
+          AFTER_STEP_SPAN_NAME = "after"
+
           # Metadata keys
           METADATA_DD_RETRIES = :dd_retries
           METADATA_DD_RETRY_RESULTS = :dd_retry_results

--- a/sig/datadog/ci/contrib/minitest/ext.rbs
+++ b/sig/datadog/ci/contrib/minitest/ext.rbs
@@ -8,6 +8,10 @@ module Datadog
           FRAMEWORK: String
 
           DEFAULT_SERVICE_NAME: String
+
+          STEP_SPAN_TYPE: String
+          BEFORE_STEP_SPAN_NAME: String
+          AFTER_STEP_SPAN_NAME: String
         end
       end
     end

--- a/sig/datadog/ci/contrib/minitest/test.rbs
+++ b/sig/datadog/ci/contrib/minitest/test.rbs
@@ -19,7 +19,18 @@ module Datadog
             include ::Minitest::Test::LifecycleHooks
             extend ClassMethods
 
+            @datadog_before_step_span: Datadog::CI::Span?
+            @datadog_before_step_failures_count: Integer
+            @datadog_after_step_span: Datadog::CI::Span?
+            @datadog_after_step_failures_count: Integer
+
             def run: () -> ::Minitest::Result
+
+            def before_setup: () -> untyped
+
+            def after_setup: () -> untyped
+
+            def before_teardown: () -> untyped
 
             def after_teardown: () -> untyped
 
@@ -32,6 +43,12 @@ module Datadog
             def start_datadog_test_suite_if_parallel: () -> Datadog::CI::TestSuite?
 
             def start_datadog_test: () -> Datadog::CI::Test?
+
+            def finish_datadog_before_step: () -> void
+
+            def finish_datadog_after_step: () -> void
+
+            def finish_datadog_step: (Datadog::CI::Span span, Integer failures_count) -> void
 
             def skip_datadog_suite: (Datadog::CI::TestSuite test_suite) -> ::Minitest::Result
 

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -6,6 +6,7 @@ module Datadog
           def self.included: (untyped base) -> untyped
           module InstanceMethods : ::RSpec::Core::Example
             @skip_reporting: bool
+            @datadog_test_tracing_component: Datadog::CI::TestTracing::Component?
 
             @datadog_test_suite_description: String
 

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -42,6 +42,7 @@ module Datadog
             # Run method helpers
             def run_before_example: () -> untyped
             def run_after_example: () -> untyped
+            def datadog_tracing_enabled?: () -> bool
             def build_test_tags: () -> Hash[String, String]
             def handle_test_result: (Datadog::CI::Test? test_span, Exception? test_failure) -> Exception?
             def update_formatter_metadata: (Datadog::CI::Test? test_span) -> void

--- a/sig/datadog/ci/contrib/rspec/example.rbs
+++ b/sig/datadog/ci/contrib/rspec/example.rbs
@@ -34,10 +34,13 @@ module Datadog
             def datadog_source_file: () -> String?
             def datadog_source_start: () -> Integer?
             def datadog_source_location_from_parent?: () -> bool
+            def exception: () -> Exception?
 
             private
 
             # Run method helpers
+            def run_before_example: () -> untyped
+            def run_after_example: () -> untyped
             def build_test_tags: () -> Hash[String, String]
             def handle_test_result: (Datadog::CI::Test? test_span, Exception? test_failure) -> Exception?
             def update_formatter_metadata: (Datadog::CI::Test? test_span) -> void

--- a/sig/datadog/ci/contrib/rspec/ext.rbs
+++ b/sig/datadog/ci/contrib/rspec/ext.rbs
@@ -9,6 +9,10 @@ module Datadog
           FRAMEWORK: String
           DEFAULT_SERVICE_NAME: String
 
+          STEP_SPAN_TYPE: String
+          BEFORE_STEP_SPAN_NAME: String
+          AFTER_STEP_SPAN_NAME: String
+
           METADATA_DD_RETRIES: Symbol
           METADATA_DD_RETRY_RESULTS: Symbol
           METADATA_DD_RETRY_REASON: Symbol

--- a/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/minitest/instrumentation_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Minitest instrumentation" do
 
       klass.new(:test_foo).run
 
-      expect(span.service).to eq("datadog-ci-rb")
+      expect(first_test_span.service).to eq("datadog-ci-rb")
     end
   end
 
@@ -66,34 +66,34 @@ RSpec.describe "Minitest instrumentation" do
 
       klass.new(:test_foo).run
 
-      expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-      expect(span.name).to eq("test_foo")
-      expect(span.resource).to eq("test_foo")
-      expect(span.service).to eq("ltest")
+      expect(first_test_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+      expect(first_test_span.name).to eq("test_foo")
+      expect(first_test_span.resource).to eq("test_foo")
+      expect(first_test_span.service).to eq("ltest")
 
-      expect(span).to have_test_tag(:name, "test_foo")
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(:name, "test_foo")
+      expect(first_test_span).to have_test_tag(
         :suite,
         "SomeTest at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
-      expect(span).to have_test_tag(:span_kind, "test")
-      expect(span).to have_test_tag(:type, "test")
-      expect(span).to have_test_tag(:framework, "minitest")
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(:span_kind, "test")
+      expect(first_test_span).to have_test_tag(:type, "test")
+      expect(first_test_span).to have_test_tag(:framework, "minitest")
+      expect(first_test_span).to have_test_tag(
         :framework_version,
         integration.version.to_s
       )
 
-      expect(span).to have_pass_status
+      expect(first_test_span).to have_pass_status
 
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(
         :source_file,
         "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
-      expect(span).to have_test_tag(:source_start, "63")
-      expect(span).to have_test_tag(:source_end, "64")
+      expect(first_test_span).to have_test_tag(:source_start, "63")
+      expect(first_test_span).to have_test_tag(:source_end, "64")
 
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(
         :codeowners,
         "[\"@DataDog/ci-app-libraries\"]"
       )
@@ -118,7 +118,7 @@ RSpec.describe "Minitest instrumentation" do
         klass.new("test_#{i}").run
       end
 
-      expect(spans).to have(num_tests).items
+      expect(test_spans).to have(num_tests).items
     end
 
     it "creates span for spec" do
@@ -134,11 +134,11 @@ RSpec.describe "Minitest instrumentation" do
       method_name = klass.runnable_methods.first
       klass.new(method_name).run
 
-      expect(span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
-      expect(span.resource).to eq(method_name)
-      expect(span.service).to eq("ltest")
-      expect(span).to have_test_tag(:name, method_name)
-      expect(span).to have_test_tag(
+      expect(first_test_span.type).to eq(Datadog::CI::Ext::AppTypes::TYPE_TEST)
+      expect(first_test_span.resource).to eq(method_name)
+      expect(first_test_span.service).to eq("ltest")
+      expect(first_test_span).to have_test_tag(:name, method_name)
+      expect(first_test_span).to have_test_tag(
         :suite,
         "SomeSpec at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
@@ -156,12 +156,12 @@ RSpec.describe "Minitest instrumentation" do
       method_name = klass.runnable_methods.first
       klass.new(method_name).run
 
-      expect(span).to have_test_tag(:name, method_name)
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(:name, method_name)
+      expect(first_test_span).to have_test_tag(
         :suite,
         "SimpleModel at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
-      expect(span).to have_test_tag(
+      expect(first_test_span).to have_test_tag(
         :source_file,
         "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )
@@ -185,35 +185,49 @@ RSpec.describe "Minitest instrumentation" do
         klass.new(method_name).run
       end
 
-      expect(spans).to have(num_specs).items
+      expect(test_spans).to have(num_specs).items
     end
 
     it "creates spans for example with instrumentation" do
+      active_span_names = []
+
       klass = Class.new(Minitest::Test) do
         def self.name
           "SomeTest"
         end
 
-        def test_foo
+        define_method(:setup) do
+          active_span_names << Datadog::Tracing.active_span.name
+        end
+
+        define_method(:test_foo) do
+          active_span_names << Datadog::Tracing.active_span.name
           Datadog::Tracing.trace("get_time") do
             Time.now
           end
+        end
+
+        define_method(:teardown) do
+          active_span_names << Datadog::Tracing.active_span.name
         end
       end
 
       klass.new(:test_foo).run
 
-      expect(spans).to have(2).items
+      expect(active_span_names).to eq(%w[before test_foo after])
+      expect(spans).to have(4).items
+      expect(custom_spans.map(&:name)).to contain_exactly("before", "get_time", "after")
+      expect(custom_spans).to all satisfy { |step_span| step_span.parent_id == first_test_span.id }
       expect(spans).to all have_origin(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
     end
 
     context "catches failures" do
       def expect_failure
-        expect(span).to have_fail_status
-        expect(span).to have_error
-        expect(span).to have_error_type
-        expect(span).to have_error_message
-        expect(span).to have_error_stack
+        expect(first_test_span).to have_fail_status
+        expect(first_test_span).to have_error
+        expect(first_test_span).to have_error_type
+        expect(first_test_span).to have_error_message
+        expect(first_test_span).to have_error_stack
       end
 
       it "within test" do
@@ -249,6 +263,7 @@ RSpec.describe "Minitest instrumentation" do
         klass.new(:test_foo).run
 
         expect_failure
+        expect(custom_spans.find { |step_span| step_span.name == "before" }).to have_error
       end
 
       it "within teardown" do
@@ -268,16 +283,17 @@ RSpec.describe "Minitest instrumentation" do
         klass.new(:test_foo).run
 
         expect_failure
+        expect(custom_spans.find { |step_span| step_span.name == "after" }).to have_error
       end
     end
 
     context "catches errors" do
       def expect_failure
-        expect(span).to have_fail_status
-        expect(span).to have_error
-        expect(span).to have_error_type
-        expect(span).to have_error_message
-        expect(span).to have_error_stack
+        expect(first_test_span).to have_fail_status
+        expect(first_test_span).to have_error
+        expect(first_test_span).to have_error_type
+        expect(first_test_span).to have_error_message
+        expect(first_test_span).to have_error_stack
       end
 
       it "within test" do
@@ -337,8 +353,8 @@ RSpec.describe "Minitest instrumentation" do
 
     context "catches skips" do
       def expect_skip
-        expect(span).to have_skip_status
-        expect(span).to_not have_error
+        expect(first_test_span).to have_skip_status
+        expect(first_test_span).to_not have_error
       end
 
       it "with reason" do
@@ -355,7 +371,7 @@ RSpec.describe "Minitest instrumentation" do
         klass.new(:test_foo).run
 
         expect_skip
-        expect(span).to have_test_tag(:skip_reason, "Skip!")
+        expect(first_test_span).to have_test_tag(:skip_reason, "Skip!")
       end
 
       it "without reason" do
@@ -372,7 +388,7 @@ RSpec.describe "Minitest instrumentation" do
         klass.new(:test_foo).run
 
         expect_skip
-        expect(span).to have_test_tag(:skip_reason, "Skipped, no message given")
+        expect(first_test_span).to have_test_tag(:skip_reason, "Skipped, no message given")
       end
 
       it "within test" do
@@ -519,7 +535,7 @@ RSpec.describe "Minitest instrumentation" do
             :source_file,
             "spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
           )
-          expect(first_test_suite_span).to have_test_tag(:source_start, "446")
+          expect(first_test_suite_span).to have_test_tag(:source_start, "462")
           expect(first_test_suite_span).to have_test_tag(
             :codeowners,
             "[\"@DataDog/ci-app-libraries\"]"
@@ -2066,10 +2082,10 @@ RSpec.describe "Minitest instrumentation" do
       expected_test_name = "test_generated OBJECT:Object on DATE with ARRAY"
       expected_suite_name = "GeneratedSuite OBJECT:Object at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
 
-      expect(span.name).to eq(expected_test_name)
-      expect(span.resource).to eq(expected_test_name)
-      expect(span).to have_test_tag(:name, expected_test_name)
-      expect(span).to have_test_tag(:suite, expected_suite_name)
+      expect(first_test_span.name).to eq(expected_test_name)
+      expect(first_test_span.resource).to eq(expected_test_name)
+      expect(first_test_span).to have_test_tag(:name, expected_test_name)
+      expect(first_test_span).to have_test_tag(:suite, expected_suite_name)
     end
 
     it "normalizes unstable Minitest::Spec generated method names" do
@@ -2089,10 +2105,10 @@ RSpec.describe "Minitest instrumentation" do
 
       expected_test_name = "test_0001_sees OBJECT:Object"
 
-      expect(span.name).to eq(expected_test_name)
-      expect(span.resource).to eq(expected_test_name)
-      expect(span).to have_test_tag(:name, expected_test_name)
-      expect(span).to have_test_tag(
+      expect(first_test_span.name).to eq(expected_test_name)
+      expect(first_test_span.resource).to eq(expected_test_name)
+      expect(first_test_span).to have_test_tag(:name, expected_test_name)
+      expect(first_test_span).to have_test_tag(
         :suite,
         "GeneratedSpec at spec/datadog/ci/contrib/minitest/instrumentation_spec.rb"
       )

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -307,6 +307,36 @@ RSpec.describe "RSpec instrumentation" do
       expect(custom_spans.map(&:name)).to contain_exactly("before", "after")
     end
 
+    it "does not trace lifecycle steps when the RSpec integration is disabled" do
+      rspec_configuration = Datadog.configuration.ci[:rspec]
+      allow(rspec_configuration).to receive(:[]).and_call_original
+      allow(rspec_configuration).to receive(:[]).with(:enabled).and_return(false)
+
+      result = with_new_rspec_environment do
+        RSpec.describe "some test" do
+          after { raise "failure" }
+          it("fails in after") {}
+        end.run
+      end
+
+      expect(result).to be(false)
+      expect(spans).to be_empty
+    end
+
+    it "does not trace lifecycle steps when Datadog CI is disabled" do
+      allow(Datadog.configuration.ci).to receive(:enabled).and_return(false)
+
+      result = with_new_rspec_environment do
+        RSpec.describe "some test" do
+          after { raise "failure" }
+          it("fails in after") {}
+        end.run
+      end
+
+      expect(result).to be(false)
+      expect(spans).to be_empty
+    end
+
     context "catches failures" do
       def expect_failure
         expect(first_test_span).to have_fail_status
@@ -462,6 +492,23 @@ RSpec.describe "RSpec instrumentation" do
         expect(first_test_span).to have_skip_status
         expect(first_test_span).to have_test_tag(:skip_reason, "No reason given")
         expect(first_test_span).not_to have_error
+      end
+
+      it "with skip call in before hook" do
+        with_new_rspec_environment do
+          RSpec.describe "some skipped test" do
+            before { skip }
+
+            it "foo" do
+              expect(1 + 1).to eq(5)
+            end
+          end.run
+        end
+
+        expect(first_test_span).to have_skip_status
+        expect(first_test_span).not_to have_error
+        expect(custom_spans.map(&:name)).to include("before")
+        expect(custom_spans.find { |span| span.name == "before" }).not_to have_error
       end
 
       it "with skip call and reason given" do

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -294,6 +294,19 @@ RSpec.describe "RSpec instrumentation" do
       expect(custom_spans).to all have_origin(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
     end
 
+    it "keeps using the test tracing component selected before the example" do
+      with_new_rspec_environment do
+        RSpec.describe "some test" do
+          it "replaces the global test tracing component" do
+            allow(Datadog.send(:components)).to receive(:test_tracing).and_return(Object.new)
+          end
+        end.run
+      end
+
+      expect(first_test_span).to have_pass_status
+      expect(custom_spans.map(&:name)).to contain_exactly("before", "after")
+    end
+
     context "catches failures" do
       def expect_failure
         expect(first_test_span).to have_fail_status

--- a/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
+++ b/spec/datadog/ci/contrib/rspec/instrumentation_spec.rb
@@ -266,9 +266,20 @@ RSpec.describe "RSpec instrumentation" do
     end
 
     it "creates spans for example with instrumentation" do
+      active_span_names = []
+
       with_new_rspec_environment do
         RSpec.describe "some test" do
+          before do
+            active_span_names << Datadog::Tracing.active_span.name
+          end
+
+          after do
+            active_span_names << Datadog::Tracing.active_span.name
+          end
+
           it "foo" do
+            active_span_names << Datadog::Tracing.active_span.name
             Datadog::Tracing.trace("get_time") do
               Time.now
             end
@@ -276,8 +287,10 @@ RSpec.describe "RSpec instrumentation" do
         end.tap(&:run)
       end
 
+      expect(active_span_names).to eq(%w[before foo after])
       expect(test_spans).to have(1).items
-      expect(custom_spans).to have(1).items
+      expect(custom_spans.map(&:name)).to contain_exactly("before", "get_time", "after")
+      expect(custom_spans).to all satisfy { |step_span| step_span.parent_id == first_test_span.id }
       expect(custom_spans).to all have_origin(Datadog::CI::Ext::Test::CONTEXT_ORIGIN)
     end
 
@@ -335,6 +348,7 @@ RSpec.describe "RSpec instrumentation" do
         end
 
         expect_failure
+        expect(custom_spans.find { |step_span| step_span.name == "before" }).to have_error
       end
 
       it "within after" do
@@ -351,6 +365,7 @@ RSpec.describe "RSpec instrumentation" do
         end
 
         expect_failure
+        expect(custom_spans.find { |step_span| step_span.name == "after" }).to have_error
       end
     end
 

--- a/vendor/rbs/rspec/0/rspec.rbs
+++ b/vendor/rbs/rspec/0/rspec.rbs
@@ -6,6 +6,12 @@ end
 module RSpec::Core
 end
 
+module RSpec::Core::Pending
+end
+
+class RSpec::Core::Pending::SkipDeclaredInExample < StandardError
+end
+
 module RSpec::Queue
 end
 


### PR DESCRIPTION
**What does this PR do?**

- Traces RSpec before/after example hooks as child step spans.
- Traces Minitest setup/teardown lifecycle phases as child step spans.
- Records captured hook failures on their corresponding step spans.
- Adds RBS definitions and framework instrumentation coverage.

**Motivation**

[SDTEST-3764](https://datadoghq.atlassian.net/browse/SDTEST-3764)

Cucumber already traces its before/after hooks as steps, so it is unchanged.

**Additional Notes**

Minitest captures lifecycle exceptions in its failures collection. The integration records the collection length at phase start and uses the first newly appended failure for step-span error attribution.


[SDTEST-3764]: https://datadoghq.atlassian.net/browse/SDTEST-3764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ